### PR TITLE
fix: replace unsound serde_yml with serde_norway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,14 @@ jobs:
 
           # Rust changes: lint + test
           if echo "${CHANGED}" | grep -qE '\.rs$|^Cargo\.(toml|lock)$|^clippy\.toml$|^rustfmt\.toml$'; then
-            MATRIX+=',{"name":"Lint","check":"lint","runner":"ubuntu-slim"}'
-            MATRIX+=',{"name":"Test (Linux)","check":"test","runner":"ubuntu-slim"}'
+            MATRIX+=',{"name":"Lint","check":"lint","runner":"ubuntu-latest"}'
+            MATRIX+=',{"name":"Test (Linux)","check":"test","runner":"ubuntu-latest"}'
             MATRIX+=',{"name":"Test (macOS)","check":"test","runner":"macos-26"}'
           fi
 
           # Audited-actions changes: verify all entries
           if echo "${CHANGED}" | grep -qE '^audited-actions/'; then
-            MATRIX+=',{"name":"Verify Audited Actions","check":"verify-audited","runner":"ubuntu-slim"}'
+            MATRIX+=',{"name":"Verify Audited Actions","check":"verify-audited","runner":"ubuntu-latest"}'
           fi
 
           # Site or audited-actions changes: format check + build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ pinprick is a CLI tool for GitHub Actions supply chain security. It pins action 
 - **Platform:** macOS, Linux
 - **Architecture:** Single binary CLI with four subcommands (`audit`, `completions`, `pin`, `update`)
 - **License:** AGPL-3.0-only
-- **Dependencies:** clap (CLI), tokio (async), reqwest (HTTP), serde/serde_yml (parsing), regex (pattern matching)
+- **Dependencies:** clap (CLI), tokio (async), reqwest (HTTP), serde/serde_norway (parsing), regex (pattern matching)
 
 ## Repository structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,16 +739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +853,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -1272,27 +1262,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -1635,6 +1623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,12 +1657,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_norway = "0.9"
 regex = "1"
 anyhow = "1"
 thiserror = "2"

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use serde_yml::Value;
+use serde_norway::Value;
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::ExitCode;
@@ -149,7 +149,7 @@ fn extract_run_blocks(path: &Path) -> Result<Vec<(usize, String)>> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let yaml: Value =
-        serde_yml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+        serde_norway::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
 
     let mut blocks = Vec::new();
 
@@ -459,7 +459,7 @@ async fn scan_action_source(
         let source_label = format!("{} ({path})", action.full_name());
 
         if is_action_yml {
-            if let Ok(yaml) = serde_yml::from_str::<Value>(&content) {
+            if let Ok(yaml) = serde_norway::from_str::<Value>(&content) {
                 scan_action_yml_runs(&yaml, &source_label, &action_name, findings);
             }
         } else if is_js {


### PR DESCRIPTION
## Summary

- Replace `serde_yml` (archived, unsound) with `serde_norway` (maintained fork)
- Removes `libyml` transitive dependency (also archived, unsound)
- Same API, no code changes beyond import paths