### PR TITLE
fix(ci): use ubuntu-latest for all Rust jobs

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   scan:
     name: Scan
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-slim
+            runner: ubuntu-latest
             artifact: pinprick-linux-amd64
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-slim
+            runner: ubuntu-latest
             artifact: pinprick-linux-arm64
             cross: true
           - target: aarch64-apple-darwin


### PR DESCRIPTION
## Summary

- Switch audit-actions scan job and release Linux build jobs from ubuntu-slim to ubuntu-latest
- ubuntu-slim does not include Rust