### PR TITLE
feat(audit-actions): dispatch add via starhaven-bot

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -5,6 +5,11 @@ on:
     - cron: "23 7 * * 1"
   workflow_dispatch:
     inputs:
+      action:
+        description: "Add a new action (OWNER/REPO). Leave empty for a full scan."
+        required: false
+        default: ""
+        type: string
       dry-run:
         description: "Log what would be added without committing"
         required: true
@@ -39,10 +44,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry-run || 'false' }}
+          INPUT_ACTION: ${{ inputs.action }}
         run: |
           UPDATED=0
-          for JSON_FILE in audited-actions/*/*.json; do
-            [[ "${JSON_FILE}" == *.json ]] || continue
+          if [[ -n "${INPUT_ACTION}" ]]; then
+            if [[ "${INPUT_ACTION}" != */* ]]; then
+              echo "error: expected OWNER/REPO, got '${INPUT_ACTION}'" >&2
+              exit 1
+            fi
+            STUB="audited-actions/${INPUT_ACTION}.json"
+            mkdir -p "$(dirname "${STUB}")"
+            [[ -f "${STUB}" ]] || echo "[]" > "${STUB}"
+            SCAN_FILES=("${STUB}")
+          else
+            SCAN_FILES=(audited-actions/*/*.json)
+          fi
+          for JSON_FILE in "${SCAN_FILES[@]}"; do
             OWNER=$(basename "$(dirname "${JSON_FILE}")")
             REPO=$(basename "${JSON_FILE}" .json)
             echo "--- ${OWNER}/${REPO} ---"

--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -147,12 +147,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up authenticated remote
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-        run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
-
       - name: Download results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -168,31 +162,65 @@ jobs:
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Create PR
+      - name: Create signed commit and open PR
         if: steps.diff.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           INPUT_ACTION: ${{ inputs.action }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           BOT_USER="${APP_SLUG}[bot]"
           BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
-          git config user.name "${BOT_USER}"
-          git config user.email "${BOT_ID}+${BOT_USER}@users.noreply.github.com"
+          BASE_SHA=$(git rev-parse HEAD)
 
           if [[ -n "${INPUT_ACTION}" ]]; then
             SLUG="${INPUT_ACTION//\//-}"
             BRANCH="chore/audited-actions-add-${SLUG}"
             TITLE="chore(audited-actions): add ${INPUT_ACTION}"
-            BODY="Added \`${INPUT_ACTION}\` after a clean audit."
+            PR_BODY="Added \`${INPUT_ACTION}\` after a clean audit."
           else
-            BRANCH="chore/audited-actions-update-$(date +%Y%m%d)"
+            BRANCH="chore/audited-actions-update-$(date -u +%Y%m%d)"
             TITLE="chore(audited-actions): update scanned actions"
-            BODY="Automated scan found new clean releases for tracked actions."
+            PR_BODY="Automated scan found new clean releases for tracked actions."
           fi
 
-          git checkout -b "${BRANCH}"
-          git add audited-actions/
-          git commit -s -m "${TITLE}"
-          git push -u origin "${BRANCH}"
-          gh pr create --title "${TITLE}" --body "${BODY}"
+          COMMIT_BODY="Signed-off-by: ${BOT_USER} <${BOT_ID}+${BOT_USER}@users.noreply.github.com>"
+
+          ADDITIONS=$(
+            git diff --name-only HEAD -- audited-actions/ |
+            while IFS= read -r file; do
+              CONTENT=$(base64 < "$file" | tr -d '\n')
+              jq -n --arg path "$file" --arg contents "$CONTENT" \
+                '{path: $path, contents: $contents}'
+            done | jq -s .
+          )
+
+          gh api "repos/${REPOSITORY}/git/refs" -X POST \
+            -f "ref=refs/heads/${BRANCH}" \
+            -f "sha=${BASE_SHA}"
+
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg branch "${BRANCH}" \
+            --arg title "${TITLE}" \
+            --arg body "${COMMIT_BODY}" \
+            --arg head "${BASE_SHA}" \
+            --argjson additions "${ADDITIONS}" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: $title, body: $body },
+                  fileChanges: { additions: $additions },
+                  expectedHeadOid: $head
+                }
+              }
+            }' | gh api graphql --input -
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "${TITLE}" \
+            --body "${PR_BODY}"

--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -131,17 +131,25 @@ jobs:
     needs: scan
     if: needs.scan.result == 'success' && !inputs.dry-run
     runs-on: ubuntu-slim
+    environment: starhaven
     permissions:
-      contents: write # required to push branch
-      pull-requests: write # required to create PR
+      contents: read
+      actions: read # required by download-artifact
     steps:
+      - name: Mint bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up authenticated remote
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
         run: git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPOSITORY}.git"
 
@@ -163,15 +171,28 @@ jobs:
       - name: Create PR
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          INPUT_ACTION: ${{ inputs.action }}
         run: |
-          BRANCH="chore/audited-actions-update-$(date +%Y%m%d)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          BOT_USER="${APP_SLUG}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
+          git config user.name "${BOT_USER}"
+          git config user.email "${BOT_ID}+${BOT_USER}@users.noreply.github.com"
+
+          if [[ -n "${INPUT_ACTION}" ]]; then
+            SLUG="${INPUT_ACTION//\//-}"
+            BRANCH="chore/audited-actions-add-${SLUG}"
+            TITLE="chore(audited-actions): add ${INPUT_ACTION}"
+            BODY="Added \`${INPUT_ACTION}\` after a clean audit."
+          else
+            BRANCH="chore/audited-actions-update-$(date +%Y%m%d)"
+            TITLE="chore(audited-actions): update scanned actions"
+            BODY="Automated scan found new clean releases for tracked actions."
+          fi
+
           git checkout -b "${BRANCH}"
           git add audited-actions/
-          git commit -m "chore(audited-actions): update scanned actions"
+          git commit -s -m "${TITLE}"
           git push -u origin "${BRANCH}"
-          gh pr create \
-            --title "chore(audited-actions): update scanned actions" \
-            --body "Automated scan found new clean releases for tracked actions."
+          gh pr create --title "${TITLE}" --body "${BODY}"


### PR DESCRIPTION
Adds a `workflow_dispatch` `action: OWNER/REPO` input for adding new audited
actions on demand. With the input set, the scan loop validates the format,
stubs the target `audited-actions/OWNER/REPO.json` file if missing, and
restricts the scan to that single entry. With it empty, the weekly full scan
runs unchanged.

Switches automated PR creation to the `starhaven-bot` GitHub App. The bot's
identity is resolved at runtime so commits are authored as
`starhaven-bot[bot]`. Branch names, commit messages, and PR titles and bodies
differ between the weekly scan and the dispatch-add paths.