### PR TITLE
fix(audit-actions): detect newly created audited-actions files

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
+          # -N stages untracked files as intent-to-add so `git diff` sees them
+          # as full-content additions; required for the dispatch-add path that
+          # creates brand-new audited-actions/OWNER/REPO.json files.
+          git add -N audited-actions/
           if git diff --quiet audited-actions/; then
             echo "changed=false" >> "${GITHUB_OUTPUT}"
           else


### PR DESCRIPTION
`git diff` ignores untracked files, so the dispatch-add path for a brand-new `OWNER/REPO.json` was silently reported as no changes and the PR was never opened. Stage untracked files with `git add -N` before the diff so they appear as full-content additions.