### PR TITLE
ci: cache cargo builds across jobs

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -37,6 +37,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Cache cargo (release)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-
+
       - name: Build pinprick
         run: cargo build --release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,34 @@ jobs:
           fetch-depth: ${{ matrix.fetch_depth || 1 }}
           persist-credentials: false
 
+      # --- Cargo cache ---
+
+      - name: Cache cargo (debug)
+        if: matrix.check == 'lint' || matrix.check == 'test'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-debug-
+
+      - name: Cache cargo (release)
+        if: matrix.check == 'verify-audited'
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-
+
       # --- Conventional Commits ---
 
       - name: Check PR title


### PR DESCRIPTION
Add `actions/cache` to ci.yml (lint, test, verify-audited) and audit-actions.yml (scan). Debug mode is a shared key across lint + test; release mode is a separate key shared across verify-audited and the audit-actions scan job. Keys include OS and a hash of `Cargo.lock` so dependency changes invalidate correctly.