### PR TITLE
feat(audit): add --sarif output for GitHub code scanning

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -46,7 +46,16 @@ impl AuditCollector {
     }
 }
 
-pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -> Result<ExitCode> {
+pub async fn run(
+    repo_root: &Path,
+    json: bool,
+    sarif: bool,
+    verbose: bool,
+    config: &Config,
+) -> Result<ExitCode> {
+    // Machine-readable formats must keep stdout clean.
+    let quiet = json || sarif;
+
     let token = auth::resolve_token().await;
     let client = token.as_ref().map(|t| GitHubClient::new(t.clone()));
     let had_token = client.is_some();
@@ -58,7 +67,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
 
     for file in &files {
         let display_name = workflow::display_path(file, repo_root);
-        if !json {
+        if !quiet {
             eprint!("Scanning {display_name}...");
         }
 
@@ -67,7 +76,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
             scan_shell_content(content, &display_name, *line_offset, "", &mut collector);
         }
 
-        if !json {
+        if !quiet {
             eprintln!(" done");
         }
 
@@ -80,7 +89,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
                 }
 
                 if config.is_action_ignored(&action.owner_repo()) {
-                    if !json {
+                    if !quiet {
                         eprintln!(
                             "  {}@{} ignored",
                             action.full_name(),
@@ -94,7 +103,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
                     .check(&action.owner, &action.repo, &action.ref_string)
                     .await
                 {
-                    if !json {
+                    if !quiet {
                         eprintln!(
                             "  {}@{} audited",
                             action.full_name(),
@@ -104,7 +113,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
                     continue;
                 }
 
-                if !json {
+                if !quiet {
                     eprint!(
                         "  Fetching {}@{}...",
                         action.full_name(),
@@ -115,8 +124,16 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
                 let findings_before = collector.findings.len();
                 match scan_action_source(client, action, &mut collector).await {
                     Ok(()) => {
-                        if !json {
+                        if !quiet {
                             eprintln!(" done");
+                        }
+                        // Tag every finding produced by this remote scan with the
+                        // workflow file and `uses:` line that loaded the action, so
+                        // downstream consumers (e.g. SARIF) can anchor the result
+                        // inside the scanning repo.
+                        for finding in collector.findings.iter_mut().skip(findings_before) {
+                            finding.workflow_file = Some(display_name.clone());
+                            finding.workflow_line = Some(action.line_number);
                         }
                         if collector.findings.len() == findings_before
                             && action.ref_type == workflow::RefType::Sha
@@ -131,7 +148,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
                         }
                     }
                     Err(e) => {
-                        if !json {
+                        if !quiet {
                             eprintln!(" failed");
                         }
                         eprintln!("warning: could not scan {}: {e}", action.full_name());
@@ -141,7 +158,7 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
         }
     }
 
-    if !json && !files.is_empty() {
+    if !quiet && !files.is_empty() {
         eprintln!();
     }
 
@@ -165,7 +182,9 @@ pub async fn run(repo_root: &Path, json: bool, verbose: bool, config: &Config) -
         had_token,
     };
 
-    if json {
+    if sarif {
+        report.print_sarif();
+    } else if json {
         report.print_json();
     } else {
         report.print_human(verbose);
@@ -257,6 +276,8 @@ fn scan_shell_content(
                 line: Some(line_num),
                 pattern_matched: line.trim().to_string(),
                 description: "gh release download without pinned version".to_string(),
+                workflow_file: None,
+                workflow_line: None,
             });
         }
     }
@@ -426,6 +447,8 @@ fn check_url_patterns(
                 line: Some(line_num),
                 pattern_matched: line.trim().to_string(),
                 description: pattern.description.to_string(),
+                workflow_file: None,
+                workflow_line: None,
             });
         }
     }
@@ -449,6 +472,8 @@ fn check_patterns(
                 line: Some(line_num),
                 pattern_matched: line.trim().to_string(),
                 description: pattern.description.to_string(),
+                workflow_file: None,
+                workflow_line: None,
             });
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,10 @@ enum Command {
         /// passed the version check (useful for CI audit logs)
         #[arg(short, long)]
         verbose: bool,
+
+        /// Output findings as SARIF 2.1.0 (for github/codeql-action/upload-sarif)
+        #[arg(long, conflicts_with = "json")]
+        sarif: bool,
     },
     /// Generate shell completions
     Completions {
@@ -89,9 +93,13 @@ async fn main() -> ExitCode {
     }
 
     let result = match &cli.command {
-        Command::Audit { path, verbose } => {
+        Command::Audit {
+            path,
+            verbose,
+            sarif,
+        } => {
             let config = config::Config::load(path);
-            audit::run(path, cli.json, *verbose, &config).await
+            audit::run(path, cli.json, *sarif, *verbose, &config).await
         }
         Command::Completions { shell } => {
             clap_complete::generate(

--- a/src/output.rs
+++ b/src/output.rs
@@ -168,6 +168,13 @@ pub struct AuditFinding {
     pub line: Option<usize>,
     pub pattern_matched: String,
     pub description: String,
+    /// When this finding came from scanning a remote action's source,
+    /// the workflow file in the scanning repo that loaded the action.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_file: Option<String>,
+    /// 1-based line number of the `uses:` line in `workflow_file`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_line: Option<usize>,
 }
 
 #[derive(Serialize)]
@@ -273,6 +280,90 @@ impl AuditReport {
     pub fn print_json(&self) {
         println!("{}", serde_json::to_string_pretty(self).unwrap());
     }
+
+    /// Emit findings as a SARIF 2.1.0 document suitable for
+    /// `github/codeql-action/upload-sarif`.
+    ///
+    /// Local findings (from workflow `run:` blocks) anchor to their
+    /// workflow file + line. Remote findings (from scanning an action's
+    /// own source code) anchor to the `uses:` line in the workflow that
+    /// loaded the action, with the original remote path surfaced in the
+    /// result message — the remote file doesn't exist in the scanning
+    /// repo, so it cannot be a physical location itself.
+    pub fn print_sarif(&self) {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&self.build_sarif()).unwrap()
+        );
+    }
+
+    fn build_sarif(&self) -> SarifDocument {
+        let results = self
+            .findings
+            .iter()
+            .map(|f| {
+                let (uri, start_line) =
+                    if let (Some(wf), Some(wl)) = (f.workflow_file.as_ref(), f.workflow_line) {
+                        (wf.clone(), wl)
+                    } else {
+                        (f.source_file.clone(), f.line.unwrap_or(1))
+                    };
+
+                let mut text = f.description.clone();
+                if f.workflow_file.is_some() {
+                    text.push_str(&format!(" (in {})", f.source_file));
+                }
+
+                SarifResult {
+                    rule_id: format!("pinprick/{}", f.category),
+                    level: sarif_level(&f.severity).to_string(),
+                    message: SarifText { text },
+                    locations: vec![SarifLocation {
+                        physical_location: SarifPhysicalLocation {
+                            artifact_location: SarifArtifactLocation { uri },
+                            region: SarifRegion {
+                                start_line: start_line.max(1),
+                            },
+                        },
+                    }],
+                }
+            })
+            .collect();
+
+        let rules = SARIF_RULES
+            .iter()
+            .map(|r| SarifRule {
+                id: r.id.to_string(),
+                name: r.name.to_string(),
+                short_description: SarifText {
+                    text: r.short.to_string(),
+                },
+                full_description: SarifText {
+                    text: r.full.to_string(),
+                },
+                help_uri: TOOL_URI.to_string(),
+                default_configuration: SarifConfig {
+                    level: "warning".to_string(),
+                },
+            })
+            .collect();
+
+        SarifDocument {
+            schema: SARIF_SCHEMA.to_string(),
+            version: SARIF_VERSION.to_string(),
+            runs: vec![SarifRun {
+                tool: SarifTool {
+                    driver: SarifDriver {
+                        name: TOOL_NAME.to_string(),
+                        version: env!("CARGO_PKG_VERSION").to_string(),
+                        information_uri: TOOL_URI.to_string(),
+                        rules,
+                    },
+                },
+                results,
+            }],
+        }
+    }
 }
 
 pub fn severity_str(s: &Severity) -> &'static str {
@@ -280,5 +371,287 @@ pub fn severity_str(s: &Severity) -> &'static str {
         Severity::High => "high",
         Severity::Medium => "medium",
         Severity::Low => "low",
+    }
+}
+
+// ── SARIF 2.1.0 ─────────────────────────────────────────────────────────────
+
+const SARIF_SCHEMA: &str = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+const SARIF_VERSION: &str = "2.1.0";
+const TOOL_NAME: &str = "pinprick";
+const TOOL_URI: &str = "https://pinprick.rs";
+
+struct RuleDef {
+    id: &'static str,
+    name: &'static str,
+    short: &'static str,
+    full: &'static str,
+}
+
+/// One rule per audit-pattern category. Rule IDs are stable and derived from
+/// `audit_patterns::category_str`, so a new category requires a new entry here.
+const SARIF_RULES: &[RuleDef] = &[
+    RuleDef {
+        id: "pinprick/shell_fetch",
+        name: "ShellFetch",
+        short: "Shell runtime fetch without pinning",
+        full: "Shell commands (curl, wget, gh release download, go install, pip, npm, PowerShell Invoke-WebRequest) that download content at runtime without pinning to a specific version. These bypass action SHA pinning.",
+    },
+    RuleDef {
+        id: "pinprick/javascript_fetch",
+        name: "JavaScriptFetch",
+        short: "JavaScript runtime fetch without pinning",
+        full: "JavaScript or TypeScript code (fetch, axios, got, http.get, or child_process shelling out to curl/wget) that downloads content at runtime without pinning to a specific version.",
+    },
+    RuleDef {
+        id: "pinprick/python_fetch",
+        name: "PythonFetch",
+        short: "Python runtime fetch without pinning",
+        full: "Python code (urllib, requests, or subprocess shelling out to curl/wget) that downloads content at runtime without pinning to a specific version.",
+    },
+    RuleDef {
+        id: "pinprick/docker_unpinned",
+        name: "DockerUnpinned",
+        short: "Docker image or RUN instruction without pinning",
+        full: "Dockerfile FROM lines using `:latest` or no tag, or RUN instructions that download content without pinning. Prefer digest-pinned images and versioned downloads.",
+    },
+];
+
+fn sarif_level(severity: &str) -> &'static str {
+    match severity {
+        "high" => "error",
+        "medium" => "warning",
+        _ => "note",
+    }
+}
+
+#[derive(Serialize)]
+struct SarifDocument {
+    #[serde(rename = "$schema")]
+    schema: String,
+    version: String,
+    runs: Vec<SarifRun>,
+}
+
+#[derive(Serialize)]
+struct SarifRun {
+    tool: SarifTool,
+    results: Vec<SarifResult>,
+}
+
+#[derive(Serialize)]
+struct SarifTool {
+    driver: SarifDriver,
+}
+
+#[derive(Serialize)]
+struct SarifDriver {
+    name: String,
+    version: String,
+    #[serde(rename = "informationUri")]
+    information_uri: String,
+    rules: Vec<SarifRule>,
+}
+
+#[derive(Serialize)]
+struct SarifRule {
+    id: String,
+    name: String,
+    #[serde(rename = "shortDescription")]
+    short_description: SarifText,
+    #[serde(rename = "fullDescription")]
+    full_description: SarifText,
+    #[serde(rename = "helpUri")]
+    help_uri: String,
+    #[serde(rename = "defaultConfiguration")]
+    default_configuration: SarifConfig,
+}
+
+#[derive(Serialize)]
+struct SarifConfig {
+    level: String,
+}
+
+#[derive(Serialize)]
+struct SarifResult {
+    #[serde(rename = "ruleId")]
+    rule_id: String,
+    level: String,
+    message: SarifText,
+    locations: Vec<SarifLocation>,
+}
+
+#[derive(Serialize)]
+struct SarifText {
+    text: String,
+}
+
+#[derive(Serialize)]
+struct SarifLocation {
+    #[serde(rename = "physicalLocation")]
+    physical_location: SarifPhysicalLocation,
+}
+
+#[derive(Serialize)]
+struct SarifPhysicalLocation {
+    #[serde(rename = "artifactLocation")]
+    artifact_location: SarifArtifactLocation,
+    region: SarifRegion,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: String,
+}
+
+#[derive(Serialize)]
+struct SarifRegion {
+    #[serde(rename = "startLine")]
+    start_line: usize,
+}
+
+#[cfg(test)]
+mod sarif_tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn finding(severity: &str, category: &str) -> AuditFinding {
+        AuditFinding {
+            severity: severity.into(),
+            category: category.into(),
+            action: String::new(),
+            source_file: ".github/workflows/ci.yml".into(),
+            line: Some(42),
+            pattern_matched: "curl -L https://example.com/latest/foo".into(),
+            description: "unversioned curl".into(),
+            workflow_file: None,
+            workflow_line: None,
+        }
+    }
+
+    fn report(findings: Vec<AuditFinding>) -> AuditReport {
+        AuditReport {
+            findings,
+            allowed: vec![],
+            actions_scanned: 0,
+            had_token: false,
+        }
+    }
+
+    fn sarif(findings: Vec<AuditFinding>) -> Value {
+        let doc = report(findings).build_sarif();
+        let json = serde_json::to_string(&doc).unwrap();
+        serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn document_has_schema_version_and_tool_metadata() {
+        let v = sarif(vec![]);
+        assert_eq!(v["version"], "2.1.0");
+        assert!(
+            v["$schema"]
+                .as_str()
+                .unwrap()
+                .contains("sarif-schema-2.1.0.json")
+        );
+        let driver = &v["runs"][0]["tool"]["driver"];
+        assert_eq!(driver["name"], "pinprick");
+        assert_eq!(driver["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(driver["informationUri"], "https://pinprick.rs");
+    }
+
+    #[test]
+    fn all_four_rules_enumerated() {
+        let v = sarif(vec![]);
+        let rules = v["runs"][0]["tool"]["driver"]["rules"].as_array().unwrap();
+        assert_eq!(rules.len(), 4);
+        let ids: Vec<&str> = rules.iter().map(|r| r["id"].as_str().unwrap()).collect();
+        assert!(ids.contains(&"pinprick/shell_fetch"));
+        assert!(ids.contains(&"pinprick/javascript_fetch"));
+        assert!(ids.contains(&"pinprick/python_fetch"));
+        assert!(ids.contains(&"pinprick/docker_unpinned"));
+        // Each rule has the required fields
+        for rule in rules {
+            assert!(rule["name"].is_string());
+            assert!(rule["shortDescription"]["text"].is_string());
+            assert!(rule["fullDescription"]["text"].is_string());
+            assert!(rule["helpUri"].is_string());
+            assert_eq!(rule["defaultConfiguration"]["level"], "warning");
+        }
+    }
+
+    #[test]
+    fn severity_maps_to_sarif_level() {
+        let v = sarif(vec![
+            finding("high", "shell_fetch"),
+            finding("medium", "shell_fetch"),
+            finding("low", "shell_fetch"),
+        ]);
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results[0]["level"], "error");
+        assert_eq!(results[1]["level"], "warning");
+        assert_eq!(results[2]["level"], "note");
+    }
+
+    #[test]
+    fn rule_id_derived_from_category() {
+        let v = sarif(vec![
+            finding("high", "javascript_fetch"),
+            finding("medium", "docker_unpinned"),
+        ]);
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results[0]["ruleId"], "pinprick/javascript_fetch");
+        assert_eq!(results[1]["ruleId"], "pinprick/docker_unpinned");
+    }
+
+    #[test]
+    fn local_finding_anchors_to_source_file_and_line() {
+        let f = finding("high", "shell_fetch");
+        let v = sarif(vec![f]);
+        let loc = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"];
+        assert_eq!(loc["artifactLocation"]["uri"], ".github/workflows/ci.yml");
+        assert_eq!(loc["region"]["startLine"], 42);
+        // Message text is just the description — no " (in ...)" suffix
+        assert_eq!(
+            v["runs"][0]["results"][0]["message"]["text"],
+            "unversioned curl"
+        );
+    }
+
+    #[test]
+    fn remote_finding_anchors_to_workflow_and_surfaces_remote_path() {
+        let mut f = finding("medium", "javascript_fetch");
+        f.source_file = "actions/checkout (dist/index.js)".into();
+        f.line = Some(10_000);
+        f.workflow_file = Some(".github/workflows/ci.yml".into());
+        f.workflow_line = Some(7);
+
+        let v = sarif(vec![f]);
+        let loc = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"];
+        // Anchored to the workflow file, not the remote path
+        assert_eq!(loc["artifactLocation"]["uri"], ".github/workflows/ci.yml");
+        assert_eq!(loc["region"]["startLine"], 7);
+        // Remote path surfaced in the message instead
+        let text = v["runs"][0]["results"][0]["message"]["text"]
+            .as_str()
+            .unwrap();
+        assert!(text.contains("unversioned curl"));
+        assert!(text.contains("actions/checkout (dist/index.js)"));
+    }
+
+    #[test]
+    fn missing_line_defaults_to_one() {
+        let mut f = finding("low", "shell_fetch");
+        f.line = None;
+        let v = sarif(vec![f]);
+        let loc = &v["runs"][0]["results"][0]["locations"][0]["physicalLocation"];
+        assert_eq!(loc["region"]["startLine"], 1);
+    }
+
+    #[test]
+    fn empty_findings_produce_zero_results() {
+        let v = sarif(vec![]);
+        let results = v["runs"][0]["results"].as_array().unwrap();
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
Adds a `--sarif` flag to `pinprick audit` that emits findings as a SARIF 2.1.0 document consumable by `github/codeql-action/upload-sarif`, unlocking GitHub Security tab integration and PR annotations.

- One rule per pattern category (`shell_fetch`, `javascript_fetch`, `python_fetch`, `docker_unpinned`); severity maps high→error, medium→warning, low→note.
- Local findings (from workflow `run:` blocks) anchor to their workflow file and line. Remote findings (from scanning an action's source) anchor to the `uses:` line that loaded the action, with the remote path surfaced in the result message — the remote file doesn't exist in the scanning repo and can't be a SARIF physical location itself.
- `--sarif` conflicts with `--json`. Both suppress scan progress so stdout stays a clean document.