### PR TITLE
ci: dogfood pinprick audit via SARIF upload to code scanning

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -1,0 +1,64 @@
+name: pinprick audit
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/**"
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: "pinprick-audit-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload SARIF results
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cache cargo (debug)
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-debug-
+
+      - name: Build pinprick
+        run: cargo build
+
+      - name: Run pinprick audit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          ./target/debug/pinprick audit --sarif . > pinprick.sarif
+          EXIT=$?
+          # 0 = clean, 1 = findings (still upload), 2+ = real error
+          if [[ "${EXIT}" -gt 1 ]]; then
+            echo "::error::pinprick audit errored with exit code ${EXIT}"
+            exit "${EXIT}"
+          fi
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: pinprick.sarif
+          category: pinprick


### PR DESCRIPTION
Adds `.github/workflows/pinprick-audit.yml`, which builds pinprick, runs `pinprick audit --sarif .` against this repo, and uploads the result via `github/codeql-action/upload-sarif`.

- Triggers on PR (Rust / Cargo / workflow changes) and push to main. PR runs surface findings as Files-changed annotations; push-to-main runs keep the Security tab baseline current — this also closes the gap where nothing was running on push to main after a Rust-only merge.
- Exit 0/1 (clean or findings) both upload; exit ≥2 fails the job.
- Reuses the existing `cargo-debug-*` cache via `restore-keys`, so warm runs skip recompiling deps.
- All three actions referenced (`actions/checkout`, `actions/cache`, `github/codeql-action/upload-sarif`) are already in `audited-actions/`.