### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "GitHub Actions supply chain security tool"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Prepares the next release. Highlights since 0.1.1: `--sarif` audit output (#14), `--verbose` flag for audit (#10), run-block scalar skip fix (#9).