### PR TITLE
refactor(ci): cache cargo on main only, scope key by arch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,9 @@ jobs:
 
       # --- Cargo cache ---
 
-      - name: Cache cargo (debug)
+      - name: Restore cargo cache (debug)
         if: matrix.check == 'lint' || matrix.check == 'test'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin/
@@ -99,21 +99,8 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-debug-
-
-      - name: Cache cargo (release)
-        if: matrix.check == 'verify-audited'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-release-
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       # --- Conventional Commits ---
 

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache cargo (debug)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Restore cargo cache (debug)
+        id: cargo-cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cargo/bin/
@@ -38,11 +39,23 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-debug-
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Build pinprick
         run: cargo build
+
+      - name: Save cargo cache (debug)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run pinprick audit
         env:


### PR DESCRIPTION
Changes the cargo cache to a split restore/save pattern:

- **PRs**: restore only (via `actions/cache/restore@<sha>`). Reads from main's cache through `restore-keys`, never writes — stops per-PR cache churn.
- **Push to main (pinprick-audit workflow)**: saves via `actions/cache/save@<sha>`, gated on `github.ref == 'refs/heads/main'` and `cache-hit != 'true'` so we only write when something actually changed.

Cache key is now scoped by `runner.arch` in addition to `runner.os`, so Linux x86_64 and ARM64 no longer share a namespace and clobber each other's `~/.cargo/bin/` binaries — that was the "Exec format error" we just hit on #16.

The release-profile cache block is removed from ci.yml entirely: nothing warms it on main, so restore-only would always miss.