### PR TITLE
feat(audit): flag pipe-to-shell as high regardless of URL versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,16 +66,19 @@ pinprick/
 
 ### Audit patterns
 
-Five categories of runtime fetch detection:
+Six categories of runtime fetch detection:
+- **Pipe-to-shell:** `curl`/`wget` piped into `sh`/`bash`/`python`, `bash <(curl …)` process substitution, `bash -c "$(curl …)"` / `eval "$(…)"` command substitution, PowerShell `iex (iwr …)` / `Invoke-Expression (… DownloadString …)`. Flagged high severity regardless of URL versioning.
 - **Shell:** `curl`/`wget`/`gh release download` with unversioned URLs, `go install @latest`, unpinned `pip`/`npm` installs
 - **PowerShell:** `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` with unversioned URLs
 - **JavaScript:** `fetch()`/`axios`/`got`/`http.get` with unversioned URLs, `exec()`/`child_process` shelling out to curl
 - **Python:** `urllib.request.urlopen`/`requests.get` with unversioned URLs, `subprocess` shelling out to curl/wget
-- **Docker:** `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions
+- **Docker:** `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell)
+
+Pipe-to-shell pre-empts the other shell/Docker patterns so each line emits a single finding. It also reuses the existing `ShellFetch` SARIF category/rule id to keep downstream configs stable.
 
 URL "versioned" heuristic: a URL is considered versioned if any path segment matches `v?\d+(\.\d+)+`.
 
-Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level.
+Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Without a GitHub token, audit scans local `run:` blocks only. With a token (via 
 
 | Category | Examples | Severity |
 |----------|----------|----------|
+| Pipe-to-shell | `curl`/`wget` piped to `sh`/`bash`/`python` (any URL) | High |
+| Pipe-to-shell | `bash <(curl ...)`, `bash -c "$(curl ...)"`, `eval "$(curl ...)"` | High |
+| Pipe-to-shell | PowerShell `iex (iwr ...)` / `Invoke-Expression (... DownloadString ...)` | High |
 | Shell | `curl`/`wget` to `/latest/` URLs | High |
 | Shell | `curl`/`wget` to unversioned URLs | Medium |
 | Shell | `go install @latest`, unpinned `pip`/`npm` | Low–Medium |
@@ -115,9 +118,12 @@ Without a GitHub token, audit scans local `run:` blocks only. With a token (via 
 | Python | `requests.get`/`urllib` to `/latest/` URLs | High |
 | Python | `subprocess` shelling out to `curl`/`wget` | High |
 | Docker | `FROM :latest` or untagged | High |
+| Docker | `RUN curl`/`wget` piped to a shell | High |
 | Docker | `curl`/`wget` in `RUN` instructions | Medium |
 
-Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are downgraded one severity level.
+Pipe-to-shell is flagged even when the URL is versioned — a piped payload is never written to disk, so it cannot be checksum-verified and the versioned path pins the URL but not the content.
+
+Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are downgraded one severity level. Pipe-to-shell findings are exempt.
 
 ## Exit codes
 

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -14,19 +14,23 @@ pinprick audit /path/to/repo
 
 ### Shell (in `run:` blocks and `action.yml`)
 
-| Pattern                                    | Severity |
-| ------------------------------------------ | -------- |
-| `curl`/`wget` to `/latest/` URLs           | High     |
-| `curl`/`wget` to unversioned URLs          | Medium   |
-| `gh release download` without a pinned tag | Medium   |
-| `go install @latest`                       | Medium   |
-| `pip install` without version pin          | Low      |
-| `npm install` without version pin          | Low      |
+| Pattern                                               | Severity |
+| ----------------------------------------------------- | -------- |
+| `curl`/`wget` piped to `sh`/`bash`/`python` (any URL) | High     |
+| `bash <(curl ...)` process substitution               | High     |
+| `bash -c "$(curl ...)"` / `eval "$(curl ...)"`        | High     |
+| `curl`/`wget` to `/latest/` URLs                      | High     |
+| `curl`/`wget` to unversioned URLs                     | Medium   |
+| `gh release download` without a pinned tag            | Medium   |
+| `go install @latest`                                  | Medium   |
+| `pip install` without version pin                     | Low      |
+| `npm install` without version pin                     | Low      |
 
 ### PowerShell (in `run:` blocks)
 
 | Pattern                                                                 | Severity |
 | ----------------------------------------------------------------------- | -------- |
+| `iex`/`Invoke-Expression` on fetched content (`iex (iwr ...)`)          | High     |
 | `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` to `/latest/` URLs  | High     |
 | `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` to unversioned URLs | Medium   |
 
@@ -53,12 +57,15 @@ Minified bundles (`dist/index.js`) are split on `;` and scanned statement-by-sta
 | Pattern                                | Severity                 |
 | -------------------------------------- | ------------------------ |
 | `FROM image:latest` or untagged `FROM` | High                     |
+| `RUN curl`/`wget` piped to a shell     | High                     |
 | `curl`/`wget` in `RUN` instructions    | Medium                   |
 | `FROM image@sha256:...`                | Skipped (already pinned) |
 
 ### Checksum verification
 
 Findings followed within 3 lines by a checksum verification command (`sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, `Get-FileHash`) are downgraded one severity level. The fetch is still flagged, but verified downloads are less risky.
+
+Pipe-to-shell findings are **not** downgraded by a following checksum command — the piped payload is never written to disk, so a checksum line nearby cannot cover it.
 
 ## Audited actions list
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -6,8 +6,8 @@ use std::process::ExitCode;
 
 use crate::audit_patterns::{
     self, DOCKER_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS, PY_URL_PATTERNS, Pattern,
-    SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_URL_PATTERNS, category_str, extract_url,
-    gh_release_has_tag, has_checksum_verify, url_has_version,
+    SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, category_str,
+    extract_url, gh_release_has_tag, has_checksum_verify, url_has_version,
 };
 use crate::audited_actions::AuditedActions;
 use crate::auth;
@@ -244,10 +244,33 @@ fn scan_shell_content(
     collector: &mut AuditCollector,
 ) {
     let lines: Vec<&str> = content.lines().collect();
+
+    // Pipe-to-shell pass runs first so its findings land before `findings_before`
+    // and escape the checksum downgrade loop below.
+    let mut pipe_shell_lines: HashSet<usize> = HashSet::new();
+    for (i, line) in lines.iter().enumerate() {
+        let line_num = base_line + i;
+        let before = collector.findings.len();
+        check_patterns(
+            &SHELL_PIPE_PATTERNS,
+            line,
+            source_file,
+            line_num,
+            action_name,
+            collector,
+        );
+        if collector.findings.len() > before {
+            pipe_shell_lines.insert(line_num);
+        }
+    }
+
     let findings_before = collector.findings.len();
 
     for (i, line) in lines.iter().enumerate() {
         let line_num = base_line + i;
+        if pipe_shell_lines.contains(&line_num) {
+            continue;
+        }
 
         check_patterns(
             &SHELL_PATTERNS,
@@ -282,7 +305,8 @@ fn scan_shell_content(
         }
     }
 
-    // Downgrade severity for findings followed by checksum verification
+    // Downgrade severity for findings followed by checksum verification.
+    // Pipe-shell findings sit below `findings_before`, so they are exempt.
     for finding in collector.findings.iter_mut().skip(findings_before) {
         if let Some(finding_line) = finding.line {
             let rel = finding_line.saturating_sub(base_line);
@@ -395,10 +419,33 @@ fn scan_dockerfile_content(
     action_name: &str,
     collector: &mut AuditCollector,
 ) {
-    for (i, line) in content.lines().enumerate() {
+    let lines: Vec<&str> = content.lines().collect();
+
+    // Escalate `RUN curl ... | sh` from medium (DOCKER_RUN_CURL) to high.
+    let mut pipe_shell_lines: HashSet<usize> = HashSet::new();
+    for (i, line) in lines.iter().enumerate() {
+        let line_num = i + 1;
+        let before = collector.findings.len();
+        check_patterns(
+            &SHELL_PIPE_PATTERNS,
+            line,
+            source_file,
+            line_num,
+            action_name,
+            collector,
+        );
+        if collector.findings.len() > before {
+            pipe_shell_lines.insert(line_num);
+        }
+    }
+
+    for (i, line) in lines.iter().enumerate() {
         let line_num = i + 1;
 
         if audit_patterns::DOCKER_FROM_DIGEST.is_match(line) {
+            continue;
+        }
+        if pipe_shell_lines.contains(&line_num) {
             continue;
         }
 
@@ -679,5 +726,83 @@ mod tests {
         );
         assert_eq!(c.findings.len(), 1);
         assert!(c.allowed.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_pipe_to_sh_versioned_still_high() {
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            "curl -sSL https://example.com/releases/download/v1.2.3/install.sh | sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1, "expected exactly one finding");
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("piped to shell"));
+        assert!(c.allowed.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_pipe_to_sh_not_downgraded_by_checksum() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -sSL https://example.com/install.sh | sh\nsha256sum -c checksums.txt",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(
+            !c.findings[0].description.contains("checksum verified"),
+            "pipe-shell must not be downgraded by a nearby checksum"
+        );
+    }
+
+    #[test]
+    fn shell_scan_pipe_to_sh_deduplicates_with_latest_pattern() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/releases/latest/install.sh | sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("piped to shell"));
+    }
+
+    #[test]
+    fn shell_scan_proc_sub_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "bash <(curl -L https://example.com/install.sh)",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("process substitution"));
+    }
+
+    #[test]
+    fn dockerfile_scan_pipe_shell_escalates_to_high() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu:22.04\nRUN curl -sSL https://example.com/install.sh | sh\n",
+            "Dockerfile",
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("piped to shell"));
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -51,6 +51,23 @@ re!(
     r#"(?i)(Invoke-WebRequest|iwr|Invoke-RestMethod|irm)\b.*https?://[^\s"']+"#
 );
 
+re!(
+    SH_PIPE_SHELL,
+    r"(?i)\b(curl|wget)\b[^|]*\|\s*(?:sudo\s+)?(bash|sh|zsh|dash|ash|ksh|fish|python3?)\b"
+);
+re!(
+    SH_PROC_SUB_FETCH,
+    r"(?i)\b(bash|sh|zsh|dash|ash|ksh|fish|python3?)\s+<\(\s*(curl|wget)\b"
+);
+re!(
+    SH_CMD_SUB_FETCH,
+    r#"(?i)\b(bash|sh|zsh|eval)\b[^"']*["']?\$\(\s*(curl|wget)\b"#
+);
+re!(
+    SH_IEX_FETCH,
+    r"(?i)\b(iex|Invoke-Expression)\b.*\b(iwr|Invoke-WebRequest|Invoke-RestMethod|irm|DownloadString)\b"
+);
+
 pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![
         Pattern {
@@ -112,6 +129,38 @@ pub static SHELL_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "PowerShell fetching URL without version pinning",
+        },
+    ]
+});
+
+// Scanned before (and pre-empt) the regular shell patterns so `curl ... | sh`
+// produces a single high-severity finding. Not subject to checksum downgrade —
+// a piped payload is never written to disk and cannot be verified.
+pub static SHELL_PIPE_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
+    vec![
+        Pattern {
+            regex: &SH_PIPE_SHELL,
+            severity: Severity::High,
+            category: Category::ShellFetch,
+            description: "fetch piped to shell — payload not written to disk, cannot be checksummed",
+        },
+        Pattern {
+            regex: &SH_PROC_SUB_FETCH,
+            severity: Severity::High,
+            category: Category::ShellFetch,
+            description: "shell reading fetched content via process substitution — bypasses pinning",
+        },
+        Pattern {
+            regex: &SH_CMD_SUB_FETCH,
+            severity: Severity::High,
+            category: Category::ShellFetch,
+            description: "shell executing fetched content via command substitution — bypasses pinning",
+        },
+        Pattern {
+            regex: &SH_IEX_FETCH,
+            severity: Severity::High,
+            category: Category::ShellFetch,
+            description: "PowerShell Invoke-Expression on fetched content — bypasses pinning",
         },
     ]
 });
@@ -559,6 +608,104 @@ mod tests {
             !PY_REQUESTS_LATEST
                 .is_match(r#"requests.get("https://example.com/releases/download/v1.2.3/tool")"#)
         );
+    }
+
+    // ── Pipe-to-shell patterns ─────────────────────────────────────────
+
+    #[test]
+    fn pipe_shell_curl_to_sh() {
+        assert!(SH_PIPE_SHELL.is_match("curl -sSL https://example.com/install.sh | sh"));
+    }
+
+    #[test]
+    fn pipe_shell_curl_to_sudo_bash() {
+        assert!(SH_PIPE_SHELL.is_match("curl -fsSL https://example.com/install.sh | sudo bash"));
+    }
+
+    #[test]
+    fn pipe_shell_wget_to_sh_with_args() {
+        assert!(
+            SH_PIPE_SHELL.is_match("wget -qO- https://example.com/install.sh | sh -s -- --yes")
+        );
+    }
+
+    #[test]
+    fn pipe_shell_curl_to_python3() {
+        assert!(SH_PIPE_SHELL.is_match("curl https://example.com/get.py | python3"));
+    }
+
+    #[test]
+    fn pipe_shell_versioned_url_still_matches() {
+        assert!(
+            SH_PIPE_SHELL
+                .is_match("curl -sSL https://example.com/releases/download/v1.2.3/install.sh | sh")
+        );
+    }
+
+    #[test]
+    fn pipe_shell_tee_not_matched() {
+        assert!(!SH_PIPE_SHELL.is_match("curl https://example.com/file.sh | tee out.sh"));
+    }
+
+    #[test]
+    fn pipe_shell_jq_not_matched() {
+        assert!(!SH_PIPE_SHELL.is_match("curl https://api.example.com/data | jq ."));
+    }
+
+    #[test]
+    fn proc_sub_bash_curl_matched() {
+        assert!(SH_PROC_SUB_FETCH.is_match("bash <(curl https://example.com/install.sh)"));
+    }
+
+    #[test]
+    fn proc_sub_sh_wget_matched() {
+        assert!(SH_PROC_SUB_FETCH.is_match("sh <(wget -qO- https://example.com/install.sh)"));
+    }
+
+    #[test]
+    fn proc_sub_not_fetch_not_matched() {
+        assert!(!SH_PROC_SUB_FETCH.is_match("bash <(cat local.sh)"));
+    }
+
+    #[test]
+    fn cmd_sub_bash_c_curl_matched() {
+        assert!(
+            SH_CMD_SUB_FETCH.is_match(r#"bash -c "$(curl -fsSL https://example.com/install.sh)""#)
+        );
+    }
+
+    #[test]
+    fn cmd_sub_eval_wget_matched() {
+        assert!(SH_CMD_SUB_FETCH.is_match(r#"eval "$(wget -qO- https://example.com/install.sh)""#));
+    }
+
+    #[test]
+    fn cmd_sub_local_not_matched() {
+        assert!(!SH_CMD_SUB_FETCH.is_match(r#"bash -c "$(pwd)""#));
+    }
+
+    #[test]
+    fn iex_iwr_matched() {
+        assert!(SH_IEX_FETCH.is_match("iex (iwr https://example.com/install.ps1)"));
+    }
+
+    #[test]
+    fn iex_downloadstring_matched() {
+        assert!(SH_IEX_FETCH.is_match(
+            r#"Invoke-Expression ((New-Object Net.WebClient).DownloadString("https://example.com/install.ps1"))"#
+        ));
+    }
+
+    #[test]
+    fn iex_invoke_restmethod_matched() {
+        assert!(
+            SH_IEX_FETCH.is_match("iex (Invoke-RestMethod -Uri https://example.com/install.ps1)")
+        );
+    }
+
+    #[test]
+    fn iex_without_fetch_not_matched() {
+        assert!(!SH_IEX_FETCH.is_match("iex $scriptBlock"));
     }
 
     // ── Checksum verification ──────────────────────────────────────────


### PR DESCRIPTION
Adds detection for fetch-and-execute patterns that today slip through `pinprick audit` because the URL happens to be versioned:

- `curl`/`wget` piped into `sh`/`bash`/`zsh`/`dash`/`ash`/`ksh`/`fish`/`python(3)`, with optional `sudo`
- `bash <(curl ...)` / `sh <(wget ...)` process substitution
- `bash -c "$(curl ...)"` / `eval "$(wget ...)"` command substitution
- PowerShell `iex (iwr ...)` / `Invoke-Expression (... DownloadString ...)` / `Invoke-RestMethod`

All four are emitted as high severity under the existing `ShellFetch` category and SARIF rule id `pinprick/shell_fetch`, so downstream configs stay stable. `scan_shell_content` and `scan_dockerfile_content` now run a pipe-to-shell pre-pass; the regular pattern passes skip lines already claimed by that pre-pass so each line emits one finding, and the checksum-downgrade loop runs only over findings from the second pass — a piped payload is never written to disk, so a nearby `sha256sum` line cannot cover it. In Docker, `RUN curl ... | sh` is escalated from medium (the generic `DOCKER_RUN_CURL`) to high.

22 new tests: 16 regex unit tests in `audit_patterns.rs` (positive and negative cases, versioned URL still matches, `| tee`/`| jq` do not match) and 6 integration tests in `audit.rs` covering severity, checksum-exemption, deduplication, process substitution, and Dockerfile escalation.

Dogfooded: `pinprick audit` on this repo is still clean. Smoke-tested against a throwaway workflow combining a versioned `curl ... | sh` followed by `sha256sum -c`, `bash <(curl ...)`, and `iex (iwr ...)` — all three fire as high with `--sarif` level `error`.