### PR TITLE
feat(audit): exempt data-format URLs from unversioned fetch rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ Pipe-to-shell pre-empts the other shell/Docker patterns so each line emits a sin
 
 URL "versioned" heuristic: a URL is considered versioned if any path segment matches `v?\d+(\.\d+)+`.
 
+Data-format exemption: unversioned-URL rules (shell, JS, Python) do **not** fire when the URL's path ends in a data-format extension (`.json`/`.jsonl`/`.ndjson`, `.yaml`/`.yml`/`.toml`, `.csv`/`.tsv`/`.xml`, `.txt`/`.md`/`.rst`). Matches are recorded as allowed (visible under `--verbose`) with reason `data format URL`. Applies only to the unversioned-URL rules — `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension. `.html` and `.svg` are intentionally excluded because both can carry embedded scripts.
+
 Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
 
 ### Exit codes

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Without a GitHub token, audit scans local `run:` blocks only. With a token (via 
 
 Pipe-to-shell is flagged even when the URL is versioned — a piped payload is never written to disk, so it cannot be checksum-verified and the versioned path pins the URL but not the content.
 
+Unversioned-URL rules don't fire when the URL's path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.) — the payload is consumed as data, not executed. These matches are only visible under `--verbose`.
+
 Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are downgraded one severity level. Pipe-to-shell findings are exempt.
 
 ## Exit codes

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -17,6 +17,7 @@ pinprick scans line by line. Each rule is an anchored regex, compiled once at st
 
 - **Pipe-to-shell pre-empts other shell rules.** If a line matches a pipe-to-shell rule, no other shell or Docker rule fires on that line. So `curl ... | sh` produces a single high-severity finding instead of one medium (unversioned URL) plus one high (pipe-to-shell).
 - **Versioned-URL downgrade.** Non-pipe shell, JavaScript, and Python fetch rules only fire if the URL is _unversioned_. A URL is versioned if any path segment matches `v?\d+(\.\d+)+` — e.g. `/v1.2.3/`, `/0.55.8/`. See [Versioned URL heuristic](#versioned-url-heuristic).
+- **Data-format exemption.** If a fetch targets a URL whose path ends in a known data-format extension (`.json`, `.yaml`, `.toml`, etc.), it is treated as a data fetch, not a code fetch, and downgraded to an allowed match instead of a finding. See [Data-format exemption](#data-format-exemption).
 - **Checksum downgrade.** A non-pipe finding followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` is downgraded one severity level (high → medium → low). The fetch is still reported.
 - **Pipe-to-shell is never downgraded.** A piped payload is never written to disk, so no checksum command can verify it.
 
@@ -120,7 +121,10 @@ curl -L https://example.com/install.sh -o install.sh
 wget https://example.com/bin/tool
 ```
 
-Not flagged: any URL whose path contains a segment matching `v?\d+(\.\d+)+`, e.g. `https://example.com/releases/download/v1.2.3/tool`.
+Not flagged:
+
+- Any URL whose path contains a segment matching `v?\d+(\.\d+)+`, e.g. `https://example.com/releases/download/v1.2.3/tool`.
+- Any URL whose path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.). See [Data-format exemption](#data-format-exemption).
 
 ### gh release download without a pinned tag
 
@@ -257,9 +261,8 @@ const r = await axios.get('https://example.com/api/data');
 
 Not flagged:
 
-```javascript
-const r = await fetch('https://example.com/api/1.2.3/data');
-```
+- Versioned URL: `fetch('https://example.com/api/1.2.3/data')`
+- Data-format URL: `fetch('https://example.com/config.json')` — see [Data-format exemption](#data-format-exemption).
 
 ## Python fetches
 
@@ -294,9 +297,8 @@ urllib.request.urlopen("https://example.com/file")
 
 Not flagged:
 
-```python
-requests.get("https://example.com/releases/download/v1.2.3/tool")
-```
+- Versioned URL: `requests.get("https://example.com/releases/download/v1.2.3/tool")`
+- Data-format URL: `requests.get("https://example.com/data.json")` — see [Data-format exemption](#data-format-exemption).
 
 ## Dockerfile patterns
 
@@ -367,6 +369,25 @@ A URL is considered _versioned_ if it contains a path segment matching `v?\d+(\.
 | `https://example.com/v4/resource`                          | no (single numeric component only) |
 
 This is intentionally strict — `v4` alone is a sliding major-version alias, not a pinned release.
+
+## Data-format exemption
+
+Unversioned URL rules (`curl`/`wget` to an unversioned URL, `fetch()`/`axios` to an unversioned URL, `urllib`/`requests` to an unversioned URL) are **not** emitted as findings when the URL's path ends in a known data-format extension. Instead, the match is recorded as an _allowed_ match with reason `data format URL` and is only visible under `--verbose`.
+
+Rationale: a workflow fetching JSON for `jq` or YAML for parsing is a different risk class from fetching an install script. The payload is consumed as data, never executed. Homebrew/core's `curl -s https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json` is a real example — the JSON is assigned to a shell variable and parsed, never run.
+
+**Extensions considered data formats:**
+
+| Category | Extensions                   |
+| -------- | ---------------------------- |
+| JSON     | `.json`, `.jsonl`, `.ndjson` |
+| Config   | `.yaml`, `.yml`, `.toml`     |
+| Tabular  | `.csv`, `.tsv`, `.xml`       |
+| Text     | `.txt`, `.md`, `.rst`        |
+
+Matching is case-insensitive. Query strings (`?foo=bar`) and fragments (`#section`) are stripped before the extension check. `.html` and `.svg` are intentionally excluded — both can carry embedded scripts.
+
+The exemption applies only to the _unversioned-URL_ rules. `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension, because the risk there is about the _path_ being mutable, not about what the bytes decode to.
 
 ## Suppressing findings
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -7,7 +7,7 @@ use std::process::ExitCode;
 use crate::audit_patterns::{
     self, DOCKER_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS, PY_URL_PATTERNS, Pattern,
     SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, category_str,
-    extract_url, gh_release_has_tag, has_checksum_verify, url_has_version,
+    extract_url, gh_release_has_tag, has_checksum_verify, url_has_version, url_is_data_format,
 };
 use crate::audited_actions::AuditedActions;
 use crate::auth;
@@ -485,6 +485,16 @@ fn check_url_patterns(
                 pattern_matched: line.trim().to_string(),
                 reason: "versioned URL".to_string(),
             });
+        } else if url_is_data_format(url) {
+            collector.push_allowed(AuditMatch {
+                severity: output::severity_str(&pattern.severity).to_string(),
+                category: category_str(&pattern.category).to_string(),
+                action: action_name.to_string(),
+                source_file: source_file.to_string(),
+                line: Some(line_num),
+                pattern_matched: line.trim().to_string(),
+                reason: "data format URL".to_string(),
+            });
         } else {
             collector.push_finding(AuditFinding {
                 severity: output::severity_str(&pattern.severity).to_string(),
@@ -804,5 +814,76 @@ mod tests {
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
         assert!(c.findings[0].description.contains("piped to shell"));
+    }
+
+    #[test]
+    fn shell_scan_data_format_url_is_allowed_not_finding() {
+        // Real Homebrew/core workflow line — regression anchor.
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            r#"DATA_30="$(curl -s https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json)""#,
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "data format URL");
+    }
+
+    #[test]
+    fn shell_scan_data_format_url_dropped_without_verbose() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -s https://example.com/config.yaml -o config.yaml",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert!(c.allowed.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_non_data_url_still_flagged() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/install.sh -o install.sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn js_scan_data_format_url_is_allowed() {
+        let mut c = AuditCollector::new(true);
+        scan_js_content(
+            r#"const r = await fetch("https://example.com/config.json");"#,
+            "test.js",
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "data format URL");
+    }
+
+    #[test]
+    fn py_scan_data_format_url_is_allowed() {
+        let mut c = AuditCollector::new(true);
+        scan_py_content(
+            r#"r = requests.get("https://example.com/data.json")"#,
+            "test.py",
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "data format URL");
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -366,6 +366,25 @@ pub fn url_has_version(s: &str) -> bool {
     VERSION_SEGMENT.is_match(s)
 }
 
+/// File extensions whose contents are parsed as data rather than executed.
+/// Fetches to these are downgraded to allowed matches.
+const DATA_FORMAT_EXTENSIONS: &[&str] = &[
+    "json", "jsonl", "ndjson", "yaml", "yml", "toml", "xml", "csv", "tsv", "txt", "md", "rst",
+];
+
+/// Check if a URL's path ends with a known data-format extension.
+pub fn url_is_data_format(url: &str) -> bool {
+    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let last = path.rsplit('/').next().unwrap_or("");
+    let Some(dot) = last.rfind('.') else {
+        return false;
+    };
+    let ext = &last[dot + 1..];
+    DATA_FORMAT_EXTENSIONS
+        .iter()
+        .any(|e| ext.eq_ignore_ascii_case(e))
+}
+
 /// Extract the first URL from a line.
 pub fn extract_url(line: &str) -> Option<&str> {
     static URL_RE: LazyLock<Regex> =
@@ -427,6 +446,97 @@ mod tests {
     fn single_number_not_version() {
         // A single number segment like /v4/ is not multi-component, so not matched
         assert!(!url_has_version("https://example.com/v4/resource"));
+    }
+
+    // ── url_is_data_format ──────────────────────────────────────────────
+
+    #[test]
+    fn data_format_json() {
+        assert!(url_is_data_format(
+            "https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json"
+        ));
+    }
+
+    #[test]
+    fn data_format_yaml() {
+        assert!(url_is_data_format("https://example.com/config.yaml"));
+        assert!(url_is_data_format("https://example.com/config.yml"));
+    }
+
+    #[test]
+    fn data_format_toml() {
+        assert!(url_is_data_format("https://example.com/settings.toml"));
+    }
+
+    #[test]
+    fn data_format_csv_tsv_xml() {
+        assert!(url_is_data_format("https://example.com/data.csv"));
+        assert!(url_is_data_format("https://example.com/data.tsv"));
+        assert!(url_is_data_format("https://example.com/data.xml"));
+    }
+
+    #[test]
+    fn data_format_markdown() {
+        assert!(url_is_data_format(
+            "https://raw.githubusercontent.com/owner/repo/main/README.md"
+        ));
+    }
+
+    #[test]
+    fn data_format_case_insensitive() {
+        assert!(url_is_data_format("https://example.com/DATA.JSON"));
+    }
+
+    #[test]
+    fn data_format_with_query_string() {
+        assert!(url_is_data_format(
+            "https://example.com/data.json?cache=false"
+        ));
+    }
+
+    #[test]
+    fn data_format_with_fragment() {
+        assert!(url_is_data_format("https://example.com/doc.md#section"));
+    }
+
+    #[test]
+    fn data_format_jsonl_ndjson() {
+        assert!(url_is_data_format("https://example.com/events.jsonl"));
+        assert!(url_is_data_format("https://example.com/events.ndjson"));
+    }
+
+    #[test]
+    fn not_data_format_shell_script() {
+        assert!(!url_is_data_format("https://example.com/install.sh"));
+    }
+
+    #[test]
+    fn not_data_format_archive() {
+        assert!(!url_is_data_format("https://example.com/tool.tar.gz"));
+        assert!(!url_is_data_format("https://example.com/bundle.zip"));
+    }
+
+    #[test]
+    fn not_data_format_executable() {
+        assert!(!url_is_data_format("https://example.com/tool.exe"));
+        assert!(!url_is_data_format("https://example.com/tool"));
+    }
+
+    #[test]
+    fn not_data_format_html() {
+        assert!(!url_is_data_format("https://example.com/page.html"));
+    }
+
+    #[test]
+    fn not_data_format_no_extension() {
+        assert!(!url_is_data_format("https://api.github.com/user"));
+    }
+
+    #[test]
+    fn not_data_format_path_ends_with_dot_in_earlier_segment() {
+        assert!(!url_is_data_format(
+            "https://example.com/v1.2.3/config/settings"
+        ));
     }
 
     // ── extract_url ─────────────────────────────────────────────────────


### PR DESCRIPTION
Unversioned-URL rules (shell, JavaScript, Python) no longer fire when the fetch targets a known data-format extension (`.json`, `.yaml`/`.yml`, `.toml`, `.xml`, `.csv`/`.tsv`, `.txt`, `.md`, `.rst`, `.jsonl`/`.ndjson`). The match is recorded as allowed with reason `data format URL` — visible under `--verbose`, like versioned URLs.

Pipe-to-shell, `/latest/` URLs, and `gh release download` without a tag are unaffected.