### PR TITLE
feat(update): --only filter and release page links

### DIFF
--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -6,8 +6,10 @@ description: Check pinned actions for newer releases.
 Check SHA-pinned actions for newer releases and optionally update them.
 
 ```bash
-pinprick update            # dry-run (show available updates)
-pinprick update --apply    # write updates to files
+pinprick update                       # dry-run (show available updates)
+pinprick update --apply               # write updates to files
+pinprick update --only actions/       # only check actions in the `actions/` org
+pinprick update --only actions/checkout
 pinprick update /path/to/repo
 ```
 
@@ -18,6 +20,18 @@ pinprick update /path/to/repo
 - Compares version numbers numerically — suggests the latest release regardless of major version
 - Dry-run by default — shows what would change without writing files
 - Exit code 1 when updates are available (useful in CI)
+
+## Filtering with `--only`
+
+`--only <pattern>` restricts the scan to actions whose `owner/repo` _contains_ the pattern as a substring. Useful in CI pipelines that bump one action at a time, or to scope an update to a single org:
+
+```bash
+pinprick update --only actions/checkout    # exactly this action
+pinprick update --only actions/            # all actions/* repos
+pinprick update --only aws                 # any repo with "aws" in owner/repo
+```
+
+Matching is case-sensitive. Matching is against `owner/repo` only — subpaths are not considered.
 
 ## Example
 

--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -19,6 +19,7 @@ pinprick update /path/to/repo
 - Queries the GitHub Releases API for the latest non-draft, non-prerelease release
 - Compares version numbers numerically — suggests the latest release regardless of major version
 - Dry-run by default — shows what would change without writing files
+- Each update is printed with a link to the release page for easy changelog review
 - Exit code 1 when updates are available (useful in CI)
 
 ## Filtering with `--only`
@@ -38,8 +39,10 @@ Matching is case-sensitive. Matching is against `owner/repo` only — subpaths a
 ```
 $ pinprick update
 .github/workflows/ci.yml
-  actions/checkout  v4.1.0 -> v6.0.2
-  actions/setup-node  v4.0.0 -> v6.3.0
+  actions/checkout v4.1.0 -> v6.0.2
+    https://github.com/actions/checkout/releases/tag/v6.0.2
+  actions/setup-node v4.0.0 -> v6.3.0
+    https://github.com/actions/setup-node/releases/tag/v6.3.0
 
 2 updates available. Run with --apply to apply.
 ```

--- a/src/github.rs
+++ b/src/github.rs
@@ -41,6 +41,7 @@ pub struct Release {
     pub tag_name: String,
     pub draft: bool,
     pub prerelease: bool,
+    pub html_url: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,11 @@ enum Command {
         /// Apply updates (default is dry-run)
         #[arg(long)]
         apply: bool,
+
+        /// Only check actions whose owner/repo contains this substring
+        /// (e.g., `actions/checkout`, `actions/` for the whole org)
+        #[arg(long, value_name = "PATTERN")]
+        only: Option<String>,
     },
 }
 
@@ -111,7 +116,9 @@ async fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         Command::Pin { path } => pin::run(path, cli.json).await,
-        Command::Update { path, apply } => update::run(path, *apply, cli.json).await,
+        Command::Update { path, apply, only } => {
+            update::run(path, *apply, cli.json, only.as_deref()).await
+        }
     };
 
     match result {

--- a/src/output.rs
+++ b/src/output.rs
@@ -101,6 +101,8 @@ pub struct UpdateResult {
     pub latest_tag: String,
     pub latest_sha: String,
     pub line: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_url: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -133,6 +135,9 @@ impl UpdateReport {
                 "->".dimmed(),
                 u.latest_tag.green()
             );
+            if let Some(url) = &u.release_url {
+                println!("    {}", url.dimmed());
+            }
         }
 
         println!();

--- a/src/update.rs
+++ b/src/update.rs
@@ -101,6 +101,7 @@ pub async fn run(
                 latest_tag: latest.tag_name.clone(),
                 latest_sha: new_sha.clone(),
                 line: action.line_number,
+                release_url: latest.html_url.clone(),
             });
 
             if apply

--- a/src/update.rs
+++ b/src/update.rs
@@ -7,7 +7,12 @@ use crate::github::GitHubClient;
 use crate::output::{UpdateReport, UpdateResult};
 use crate::workflow::{self, RefType};
 
-pub async fn run(repo_root: &Path, apply: bool, json: bool) -> Result<ExitCode> {
+pub async fn run(
+    repo_root: &Path,
+    apply: bool,
+    json: bool,
+    only: Option<&str>,
+) -> Result<ExitCode> {
     let token = auth::require_token().await?;
     let client = GitHubClient::new(token);
 
@@ -29,6 +34,11 @@ pub async fn run(repo_root: &Path, apply: bool, json: bool) -> Result<ExitCode> 
 
         for action in &actions {
             if action.ref_type != RefType::Sha {
+                continue;
+            }
+            if let Some(pat) = only
+                && !action.owner_repo().contains(pat)
+            {
                 continue;
             }
             let current_tag = match &action.tag_comment {


### PR DESCRIPTION
Two small improvements to the `update` command.

`--only <pattern>` restricts the scan to actions whose `owner/repo` contains the pattern as a substring. Useful for CI pipelines that bump one action at a time or for scoping an update to a single org (`--only actions/`).

Each pending update in dry-run output is now printed with a dimmed link to the release page so changelogs are one click away. Also surfaced as `release_url` in `--json` output.