### PR TITLE
feat(pin): add --dry-run to preview without writing

### DIFF
--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -6,7 +6,8 @@ description: Resolve action tag references to full SHAs.
 Scan `.github/workflows/*.yml` files and resolve action tag references to full SHA-pinned references.
 
 ```bash
-pinprick pin
+pinprick pin                # write changes in place
+pinprick pin --dry-run      # preview without writing
 pinprick pin /path/to/repo
 ```
 
@@ -18,6 +19,7 @@ pinprick pin /path/to/repo
 - Branch refs (e.g., `@main`) are flagged — pin to a SHA manually
 - Annotated tags are followed to their underlying commit SHA
 - Files are rewritten in-place with `@sha # tag` format, preserving all comments and formatting
+- `--dry-run` prints the same preview without touching any files and exits 1 when there are unpinned actions — useful for CI gating
 
 ## Example
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,11 @@ enum Command {
         /// Repository root
         #[arg(default_value = ".")]
         path: PathBuf,
+
+        /// Preview changes without writing files. Exits 1 when there are
+        /// unpinned actions — useful for CI gating.
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Check for updates to pinned actions
     Update {
@@ -115,7 +120,7 @@ async fn main() -> ExitCode {
             );
             return ExitCode::SUCCESS;
         }
-        Command::Pin { path } => pin::run(path, cli.json).await,
+        Command::Pin { path, dry_run } => pin::run(path, cli.json, *dry_run).await,
         Command::Update { path, apply, only } => {
             update::run(path, *apply, cli.json, only.as_deref()).await
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -27,6 +27,7 @@ pub struct PinSkip {
 pub struct PinReport {
     pub pinned: Vec<PinResult>,
     pub skipped: Vec<PinSkip>,
+    pub applied: bool,
 }
 
 impl PinReport {
@@ -71,8 +72,9 @@ impl PinReport {
 
         let total_files: std::collections::HashSet<&str> =
             self.pinned.iter().map(|p| p.file.as_str()).collect();
+        let verb = if self.applied { "Pinned" } else { "Would pin" };
         println!(
-            "Pinned {} action{} across {} file{}{}",
+            "{verb} {} action{} across {} file{}{}",
             self.pinned.len(),
             if self.pinned.len() == 1 { "" } else { "s" },
             total_files.len(),
@@ -83,6 +85,9 @@ impl PinReport {
                 format!(" ({} skipped)", self.skipped.len())
             }
         );
+        if !self.applied && !self.pinned.is_empty() {
+            println!("Run without {} to write changes.", "--dry-run".bold());
+        }
     }
 
     pub fn print_json(&self) {

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -7,7 +7,7 @@ use crate::github::GitHubClient;
 use crate::output::{PinReport, PinResult, PinSkip};
 use crate::workflow::{self, RefType};
 
-pub async fn run(repo_root: &Path, json: bool) -> Result<ExitCode> {
+pub async fn run(repo_root: &Path, json: bool, dry_run: bool) -> Result<ExitCode> {
     let token = auth::require_token().await?;
     let client = GitHubClient::new(token);
 
@@ -15,6 +15,7 @@ pub async fn run(repo_root: &Path, json: bool) -> Result<ExitCode> {
     let mut report = PinReport {
         pinned: Vec::new(),
         skipped: Vec::new(),
+        applied: !dry_run,
     };
 
     for file in &files {
@@ -99,7 +100,7 @@ pub async fn run(repo_root: &Path, json: bool) -> Result<ExitCode> {
             }
         }
 
-        if !replacements.is_empty() {
+        if !dry_run && !replacements.is_empty() {
             workflow::rewrite_actions(file, &replacements)?;
         }
     }
@@ -110,5 +111,9 @@ pub async fn run(repo_root: &Path, json: bool) -> Result<ExitCode> {
         report.print_human();
     }
 
-    Ok(ExitCode::SUCCESS)
+    if dry_run && !report.pinned.is_empty() {
+        Ok(ExitCode::from(1))
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
 }


### PR DESCRIPTION
Mirrors the existing dry-run-by-default behavior of `update`, but inverted for `pin` (which writes by default). `pin --dry-run` runs the full resolution flow, prints the same preview, and exits 1 when there are unpinned actions — useful for CI gates that want to fail if a PR introduces an unpinned ref.

The human summary switches between "Pinned N …" and "Would pin N …" based on whether writes happened. The JSON report gains an `applied` boolean, matching the shape of `UpdateReport`.