### PR TITLE
feat(audit): detect Dockerfile ADD with an http(s):// URL source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Six categories of runtime fetch detection:
 - **PowerShell:** `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` with unversioned URLs
 - **JavaScript:** `fetch()`/`axios`/`got`/`http.get` with unversioned URLs, `exec()`/`child_process` shelling out to curl
 - **Python:** `urllib.request.urlopen`/`requests.get` with unversioned URLs, `subprocess` shelling out to curl/wget
-- **Docker:** `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell)
+- **Docker:** `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell), `ADD` with an `http(s)://` URL source (subject to versioning + data-format exemption via the URL-check path)
 
 Pipe-to-shell pre-empts the other shell/Docker patterns so each line emits a single finding. It also reuses the existing `ShellFetch` SARIF category/rule id to keep downstream configs stable.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Without a GitHub token, audit scans local `run:` blocks only. With a token (via 
 | Docker | `FROM :latest` or untagged | High |
 | Docker | `RUN curl`/`wget` piped to a shell | High |
 | Docker | `curl`/`wget` in `RUN` instructions | Medium |
+| Docker | `ADD` with an `http(s)://` URL source | Medium |
 
 Pipe-to-shell is flagged even when the URL is versioned — a piped payload is never written to disk, so it cannot be checksum-verified and the versioned path pins the URL but not the content.
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -356,6 +356,23 @@ RUN wget https://example.com/tool
 
 Not flagged: a `curl` line followed within 3 lines by a checksum command, which is downgraded to low.
 
+### ADD with a URL source
+
+**Severity:** Medium
+
+Dockerfile's `ADD` instruction accepts an `http://` or `https://` URL as its source, which is downloaded at build time. Unlike `COPY`, it can reach the network.
+
+```dockerfile
+ADD https://example.com/install.tar.gz /tmp/
+ADD --chown=user:group https://example.com/tool.tgz /opt/
+```
+
+Not flagged:
+
+- Versioned URL: `ADD https://example.com/releases/download/v1.2.3/install.tar.gz /tmp/`
+- Data-format URL: `ADD https://example.com/config.json /etc/` — see [Data-format exemption](#data-format-exemption).
+- Local source: `ADD ./local.tar.gz /tmp/`
+
 ## Versioned URL heuristic
 
 A URL is considered _versioned_ if it contains a path segment matching `v?\d+(\.\d+)+` between `/` or `=` boundaries:

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -5,9 +5,10 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use crate::audit_patterns::{
-    self, DOCKER_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS, PY_URL_PATTERNS, Pattern,
-    SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, category_str,
-    extract_url, gh_release_has_tag, has_checksum_verify, url_has_version, url_is_data_format,
+    self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS,
+    PY_URL_PATTERNS, Pattern, SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS,
+    SHELL_URL_PATTERNS, category_str, extract_url, gh_release_has_tag, has_checksum_verify,
+    url_has_version, url_is_data_format,
 };
 use crate::audited_actions::AuditedActions;
 use crate::auth;
@@ -457,6 +458,15 @@ fn scan_dockerfile_content(
             action_name,
             collector,
         );
+
+        check_url_patterns(
+            &DOCKER_URL_PATTERNS,
+            line,
+            source_file,
+            line_num,
+            action_name,
+            collector,
+        );
     }
 }
 
@@ -814,6 +824,60 @@ mod tests {
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
         assert!(c.findings[0].description.contains("piped to shell"));
+    }
+
+    #[test]
+    fn dockerfile_scan_add_unversioned_url_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu:22.04\nADD https://example.com/install.tar.gz /tmp/\n",
+            "Dockerfile",
+            "",
+            &mut c,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("ADD with URL source"));
+    }
+
+    #[test]
+    fn dockerfile_scan_add_versioned_url_is_allowed() {
+        let mut c = AuditCollector::new(true);
+        scan_dockerfile_content(
+            "FROM ubuntu:22.04\nADD https://example.com/releases/download/v1.2.3/install.tar.gz /tmp/\n",
+            "Dockerfile",
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "versioned URL");
+    }
+
+    #[test]
+    fn dockerfile_scan_add_data_format_url_is_allowed() {
+        let mut c = AuditCollector::new(true);
+        scan_dockerfile_content(
+            "FROM ubuntu:22.04\nADD https://example.com/config.json /etc/\n",
+            "Dockerfile",
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "data format URL");
+    }
+
+    #[test]
+    fn dockerfile_scan_add_local_src_not_flagged() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu:22.04\nADD ./local.tar.gz /tmp/\n",
+            "Dockerfile",
+            "",
+            &mut c,
+        );
+        assert!(c.findings.is_empty());
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -247,6 +247,7 @@ re!(
 re!(DOCKER_FROM_DIGEST, r"(?i)^FROM\s+\S+@sha256:");
 re!(DOCKER_RUN_CURL, r"(?i)^RUN\b.*\bcurl\b");
 re!(DOCKER_RUN_WGET, r"(?i)^RUN\b.*\bwget\b");
+re!(DOCKER_ADD_URL, r"(?i)^ADD\b[^#]*\bhttps?://\S+");
 
 pub static DOCKER_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![
@@ -275,6 +276,15 @@ pub static DOCKER_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             description: "wget in Dockerfile RUN — check URL is versioned",
         },
     ]
+});
+
+pub static DOCKER_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
+    vec![Pattern {
+        regex: &DOCKER_ADD_URL,
+        severity: Severity::Medium,
+        category: Category::DockerUnpinned,
+        description: "Dockerfile ADD with URL source — build-time fetch bypasses pinning",
+    }]
 });
 
 // ── Python patterns ─────────────────────────────────────────────────────────
@@ -704,6 +714,30 @@ mod tests {
     #[test]
     fn docker_run_curl_detected() {
         assert!(DOCKER_RUN_CURL.is_match("RUN curl -L https://example.com/install.sh | bash"));
+    }
+
+    #[test]
+    fn docker_add_url_detected() {
+        assert!(DOCKER_ADD_URL.is_match("ADD https://example.com/install.tar.gz /tmp/"));
+        assert!(DOCKER_ADD_URL.is_match("ADD http://example.com/foo.zip /opt/"));
+    }
+
+    #[test]
+    fn docker_add_url_with_chown_detected() {
+        assert!(
+            DOCKER_ADD_URL.is_match("ADD --chown=user:group https://example.com/tool.tgz /opt/")
+        );
+    }
+
+    #[test]
+    fn docker_add_local_not_matched() {
+        assert!(!DOCKER_ADD_URL.is_match("ADD ./local.tar.gz /opt/"));
+        assert!(!DOCKER_ADD_URL.is_match("ADD context/* /app/"));
+    }
+
+    #[test]
+    fn docker_add_case_insensitive() {
+        assert!(DOCKER_ADD_URL.is_match("add https://example.com/tool.tgz /opt/"));
     }
 
     // ── PowerShell patterns ────────────────────────────────────────────


### PR DESCRIPTION
`ADD` is the only Dockerfile instruction besides `RUN curl`/`wget` that can fetch from the network at build time — it accepts an `http://` or `https://` URL as its source and downloads it into the image.

Routed through the existing URL-check path so it inherits the versioned-URL and data-format exemptions: `ADD https://example.com/releases/download/v1.2.3/tool.tar.gz /opt/` is allowed, `ADD https://example.com/config.json /etc/` is allowed, `ADD https://example.com/install.tar.gz /tmp/` is a medium finding, and `ADD ./local.tar.gz /tmp/` is untouched.