### PR TITLE
feat(release): publish to crates.io on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,3 +198,25 @@ jobs:
           gh release edit "${TAG}" \
             --repo "${REPOSITORY}" \
             --notes-file "${RUNNER_TEMP}/formatted_notes.md"
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify packageable
+        run: cargo publish --dry-run
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  use-trusted-publishing:
+    # Tracked for a follow-up PR. The initial crates.io publish requires a
+    # stored token because trusted publishers must be configured against an
+    # existing crate. After the first release with the stored token, we will
+    # swap in OIDC-based publishing and delete the stored token.
+    ignore:
+      - release.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,18 @@
 name = "pinprick"
 version = "0.3.0"
 edition = "2024"
+rust-version = "1.88"
 description = "GitHub Actions supply chain security tool"
 license = "AGPL-3.0-only"
+repository = "https://github.com/p-linnane/pinprick"
+homepage = "https://pinprick.rs"
+keywords = ["github-actions", "security", "supply-chain", "sha", "cli"]
+categories = ["command-line-utilities", "development-tools"]
+exclude = [
+    "/.github/",
+    "/site/",
+    "/scripts/",
+]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "color"] }


### PR DESCRIPTION
Adds the missing `[package]` metadata (`repository`, `homepage`, `keywords`, `categories`, `rust-version = "1.88"`, `exclude` list for `/.github/`, `/site/`, `/scripts/`) and a new `publish-crate` job in `release.yml` that runs after the GitHub release succeeds, using `CARGO_REGISTRY_TOKEN` from the existing `release` environment.

The new `.github/zizmor.yml` suppresses `use-trusted-publishing` on `release.yml` only. A follow-up PR will swap the stored token for OIDC-based trusted publishing once the crate exists on crates.io.