### PR TITLE
docs: install from crates.io instead of git

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`
 - **ci.yml** — Dynamic matrix PR checks: conventional commits, clippy + rustfmt + typos, cargo test, site format + build, audited-actions verification, zizmor
 - **codeql.yml** — CodeQL security analysis on push to main
 - **deploy-site.yml** — Build and deploy Astro site to Cloudflare Workers
-- **release.yml** — Manual dispatch: build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations
+- **release.yml** — Manual dispatch: build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io
 - **zizmor.yml** — GitHub Actions security audit on push to main
 
 ## Commit conventions

--- a/README.md
+++ b/README.md
@@ -21,15 +21,23 @@ pinprick picks up where static analysis leaves off. SHA-pinning actions is table
 brew install p-linnane/tap/pinprick
 ```
 
-### From source
+### crates.io
 
 ```bash
-cargo install --git https://github.com/p-linnane/pinprick
+cargo install pinprick
 ```
 
 ### From releases
 
 Download a prebuilt binary from [GitHub Releases](https://github.com/p-linnane/pinprick/releases).
+
+### From git (unreleased HEAD)
+
+To try unreleased changes from `main`:
+
+```bash
+cargo install --git https://github.com/p-linnane/pinprick
+```
 
 ## Usage
 


### PR DESCRIPTION
README now leads with `cargo install pinprick`. The former `--git` form is preserved as an "unreleased HEAD" option for trying out unshipped changes.