### PR TITLE
feat(release): use trusted publishing for crates.io authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,7 @@ jobs:
       deployment: false
     permissions:
       contents: read
+      id-token: write # required to mint the OIDC token exchanged with crates.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -216,7 +217,11 @@ jobs:
       - name: Verify packageable
         run: cargo publish --dry-run
 
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
       - name: Publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,0 @@
-rules:
-  use-trusted-publishing:
-    # Tracked for a follow-up PR. The initial crates.io publish requires a
-    # stored token because trusted publishers must be configured against an
-    # existing crate. After the first release with the stored token, we will
-    # swap in OIDC-based publishing and delete the stored token.
-    ignore:
-      - release.yml


### PR DESCRIPTION
Replaces the stored `CARGO_REGISTRY_TOKEN` with OIDC via `rust-lang/crates-io-auth-action`.