### PR TITLE
feat(config): allow extra file extensions in data-format exemption

### DIFF
--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -19,6 +19,11 @@ fetch-remote = true
 # Minimum severity to report: "low", "medium", or "high" (default: "low")
 severity = "medium"
 
+# Additional file extensions to treat as data formats, beyond the built-in set
+# (see the Detections reference for the full built-in list). Case-insensitive;
+# leading dots are optional.
+extra-data-formats = ["proto", "graphql"]
+
 # Suppress specific findings
 [ignore]
 # Skip audit for these actions entirely
@@ -39,6 +44,16 @@ When enabled, pinprick fetches the community audited-actions list from `pinprick
 ### `severity`
 
 Filter findings by minimum severity. Set to `"medium"` to hide low-severity findings like unpinned `pip install`, or `"high"` to only see the most critical patterns.
+
+### `extra-data-formats`
+
+A list of file extensions to append to pinprick's built-in [data-format exemption](/reference/detections#data-format-exemption) set. Useful if you regularly fetch protocol schemas (`.proto`, `.graphql`), infrastructure definitions (`.tf`, `.hcl`), or any other non-executable asset format that's not in the default list.
+
+```toml
+extra-data-formats = ["proto", "graphql", "tf", "hcl"]
+```
+
+Matching is case-insensitive. Leading dots are stripped (`".proto"` and `"proto"` behave identically). The configured extensions are _added_ to the built-in set, not replacing it.
 
 ### `ignore.actions`
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -406,6 +406,8 @@ Matching is case-insensitive. Query strings (`?foo=bar`) and fragments (`#sectio
 
 The exemption applies only to the _unversioned-URL_ rules. `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension, because the risk there is about the _path_ being mutable, not about what the bytes decode to.
 
+The list can be extended via `extra-data-formats` in [`.pinprick.toml`](/configuration/config-file#extra-data-formats) to add project-specific extensions (e.g., `.proto`, `.graphql`).
+
 ## Suppressing findings
 
 Use `.pinprick.toml` to suppress by action or by description substring. See [Config File](/configuration/config-file).

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -8,7 +8,7 @@ use crate::audit_patterns::{
     self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS,
     PY_URL_PATTERNS, Pattern, SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS,
     SHELL_URL_PATTERNS, category_str, extract_url, gh_release_has_tag, has_checksum_verify,
-    url_has_version, url_is_data_format,
+    url_has_version,
 };
 use crate::audited_actions::AuditedActions;
 use crate::auth;
@@ -74,7 +74,14 @@ pub async fn run(
 
         let run_blocks = extract_run_blocks(file)?;
         for (line_offset, content) in &run_blocks {
-            scan_shell_content(content, &display_name, *line_offset, "", &mut collector);
+            scan_shell_content(
+                content,
+                &display_name,
+                *line_offset,
+                "",
+                &mut collector,
+                config,
+            );
         }
 
         if !quiet {
@@ -123,7 +130,7 @@ pub async fn run(
                 }
 
                 let findings_before = collector.findings.len();
-                match scan_action_source(client, action, &mut collector).await {
+                match scan_action_source(client, action, &mut collector, config).await {
                     Ok(()) => {
                         if !quiet {
                             eprintln!(" done");
@@ -243,6 +250,7 @@ fn scan_shell_content(
     base_line: usize,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     let lines: Vec<&str> = content.lines().collect();
 
@@ -295,6 +303,7 @@ fn scan_shell_content(
                 line_num,
                 action_name,
                 collector,
+                config,
             );
         }
 
@@ -345,6 +354,7 @@ fn scan_js_content(
     source_file: &str,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     for (i, line) in content.lines().enumerate() {
         let line_num = i + 1;
@@ -370,6 +380,7 @@ fn scan_js_content(
                     line_num,
                     action_name,
                     collector,
+                    config,
                 );
             }
         } else {
@@ -388,6 +399,7 @@ fn scan_js_content(
                 line_num,
                 action_name,
                 collector,
+                config,
             );
         }
     }
@@ -398,6 +410,7 @@ fn scan_py_content(
     source_file: &str,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     for (i, line) in content.lines().enumerate() {
         let line_num = i + 1;
@@ -417,6 +430,7 @@ fn scan_py_content(
             line_num,
             action_name,
             collector,
+            config,
         );
     }
 }
@@ -426,6 +440,7 @@ fn scan_dockerfile_content(
     source_file: &str,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     let lines: Vec<&str> = content.lines().collect();
 
@@ -473,6 +488,7 @@ fn scan_dockerfile_content(
             line_num,
             action_name,
             collector,
+            config,
         );
     }
 }
@@ -484,6 +500,7 @@ fn check_url_patterns(
     line_num: usize,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     for pattern in patterns {
         if !pattern.regex.is_match(line) {
@@ -502,7 +519,7 @@ fn check_url_patterns(
                 pattern_matched: line.trim().to_string(),
                 reason: "versioned URL".to_string(),
             });
-        } else if url_is_data_format(url) {
+        } else if config.is_data_format_exempt(url) {
             collector.push_allowed(AuditMatch {
                 severity: output::severity_str(&pattern.severity).to_string(),
                 category: category_str(&pattern.category).to_string(),
@@ -557,6 +574,7 @@ async fn scan_action_source(
     client: &GitHubClient,
     action: &ActionRef,
     collector: &mut AuditCollector,
+    config: &Config,
 ) -> Result<()> {
     let action_name = format!("{}@{}", action.full_name(), short_sha(&action.ref_string));
     let tree = client
@@ -605,14 +623,14 @@ async fn scan_action_source(
 
         if is_action_yml {
             if let Ok(yaml) = serde_norway::from_str::<Value>(&content) {
-                scan_action_yml_runs(&yaml, &source_label, &action_name, collector);
+                scan_action_yml_runs(&yaml, &source_label, &action_name, collector, config);
             }
         } else if is_js {
-            scan_js_content(&content, &source_label, &action_name, collector);
+            scan_js_content(&content, &source_label, &action_name, collector, config);
         } else if is_py {
-            scan_py_content(&content, &source_label, &action_name, collector);
+            scan_py_content(&content, &source_label, &action_name, collector, config);
         } else if is_dockerfile {
-            scan_dockerfile_content(&content, &source_label, &action_name, collector);
+            scan_dockerfile_content(&content, &source_label, &action_name, collector, config);
         }
     }
 
@@ -624,6 +642,7 @@ fn scan_action_yml_runs(
     source_file: &str,
     action_name: &str,
     collector: &mut AuditCollector,
+    config: &Config,
 ) {
     // runs.steps[].run (composite actions)
     if let Some(steps) = yaml
@@ -633,7 +652,7 @@ fn scan_action_yml_runs(
     {
         for step in steps {
             if let Some(run) = step.get("run").and_then(|r| r.as_str()) {
-                scan_shell_content(run, source_file, 0, action_name, collector);
+                scan_shell_content(run, source_file, 0, action_name, collector, config);
             }
         }
     }
@@ -644,7 +663,7 @@ fn scan_action_yml_runs(
         .and_then(|r| r.get("args"))
         .and_then(|a| a.as_str())
     {
-        scan_shell_content(args, source_file, 0, action_name, collector);
+        scan_shell_content(args, source_file, 0, action_name, collector, config);
     }
 }
 
@@ -655,6 +674,9 @@ fn short_sha(sha: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::LazyLock;
+
+    static DEFAULT_CONFIG: LazyLock<Config> = LazyLock::new(Config::default);
 
     #[test]
     fn collector_drops_allowed_when_not_verbose() {
@@ -695,6 +717,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert!(c.allowed.is_empty());
@@ -709,6 +732,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -724,6 +748,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -738,6 +763,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -752,6 +778,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -767,6 +794,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert!(c.allowed.is_empty());
@@ -780,6 +808,7 @@ mod tests {
             "test.js",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -793,6 +822,7 @@ mod tests {
             "test.js",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert!(c.allowed.is_empty());
@@ -807,6 +837,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1, "expected exactly one finding");
         assert_eq!(c.findings[0].severity, "high");
@@ -823,6 +854,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -841,6 +873,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -856,6 +889,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -870,6 +904,7 @@ mod tests {
             "Dockerfile",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
@@ -884,6 +919,7 @@ mod tests {
             "Dockerfile",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "medium");
@@ -898,6 +934,7 @@ mod tests {
             "Dockerfile",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -912,6 +949,7 @@ mod tests {
             "Dockerfile",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -926,6 +964,7 @@ mod tests {
             "Dockerfile",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
     }
@@ -940,6 +979,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -955,6 +995,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert!(c.allowed.is_empty());
@@ -969,6 +1010,7 @@ mod tests {
             1,
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
     }
@@ -981,6 +1023,7 @@ mod tests {
             "test.js",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
@@ -995,9 +1038,48 @@ mod tests {
             "test.py",
             "",
             &mut c,
+            &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "data format URL");
+    }
+
+    #[test]
+    fn shell_scan_honors_extra_data_formats() {
+        let config = Config {
+            extra_data_formats: vec!["proto".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            "curl -sSL https://example.com/api.proto -o schema.proto",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "data format URL");
+    }
+
+    #[test]
+    fn shell_scan_non_configured_extension_still_flagged() {
+        let config = Config {
+            extra_data_formats: vec!["proto".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/install.sh -o install.sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert_eq!(c.findings.len(), 1);
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -382,14 +382,20 @@ const DATA_FORMAT_EXTENSIONS: &[&str] = &[
     "json", "jsonl", "ndjson", "yaml", "yml", "toml", "xml", "csv", "tsv", "txt", "md", "rst",
 ];
 
-/// Check if a URL's path ends with a known data-format extension.
-pub fn url_is_data_format(url: &str) -> bool {
+/// Extract the filename extension from a URL's path. Query strings and
+/// fragments are stripped. Returns `None` if the final path segment has no dot.
+pub fn url_extension(url: &str) -> Option<&str> {
     let path = url.split(['?', '#']).next().unwrap_or(url);
     let last = path.rsplit('/').next().unwrap_or("");
-    let Some(dot) = last.rfind('.') else {
+    let dot = last.rfind('.')?;
+    Some(&last[dot + 1..])
+}
+
+/// Check if a URL's path ends with a known data-format extension.
+pub fn url_is_data_format(url: &str) -> bool {
+    let Some(ext) = url_extension(url) else {
         return false;
     };
-    let ext = &last[dot + 1..];
     DATA_FORMAT_EXTENSIONS
         .iter()
         .any(|e| ext.eq_ignore_ascii_case(e))
@@ -456,6 +462,42 @@ mod tests {
     fn single_number_not_version() {
         // A single number segment like /v4/ is not multi-component, so not matched
         assert!(!url_has_version("https://example.com/v4/resource"));
+    }
+
+    // ── url_extension ───────────────────────────────────────────────────
+
+    #[test]
+    fn url_extension_simple() {
+        assert_eq!(url_extension("https://example.com/data.json"), Some("json"));
+    }
+
+    #[test]
+    fn url_extension_strips_query_string() {
+        assert_eq!(
+            url_extension("https://example.com/data.json?cache=false"),
+            Some("json")
+        );
+    }
+
+    #[test]
+    fn url_extension_strips_fragment() {
+        assert_eq!(
+            url_extension("https://example.com/doc.md#section"),
+            Some("md")
+        );
+    }
+
+    #[test]
+    fn url_extension_no_extension() {
+        assert_eq!(url_extension("https://api.github.com/user"), None);
+    }
+
+    #[test]
+    fn url_extension_dot_only_in_earlier_segment() {
+        assert_eq!(
+            url_extension("https://example.com/v1.2.3/config/settings"),
+            None
+        );
     }
 
     // ── url_is_data_format ──────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::audit_patterns;
 use serde::Deserialize;
 use std::path::Path;
 
@@ -15,6 +16,12 @@ pub struct Config {
     /// Finding suppression rules
     #[serde(default)]
     pub ignore: IgnoreConfig,
+
+    /// Additional file extensions (beyond the built-in set) to treat as
+    /// data formats when evaluating unversioned-URL fetches. Case-insensitive;
+    /// leading dots are stripped.
+    #[serde(default)]
+    pub extra_data_formats: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -81,6 +88,21 @@ impl Config {
             .iter()
             .any(|p| description.contains(p.as_str()))
     }
+
+    /// Check if a URL is exempt from unversioned-fetch rules because its
+    /// path ends in a known data-format extension. Consults both the
+    /// built-in set and the user-configured `extra_data_formats` list.
+    pub fn is_data_format_exempt(&self, url: &str) -> bool {
+        if audit_patterns::url_is_data_format(url) {
+            return true;
+        }
+        let Some(ext) = audit_patterns::url_extension(url) else {
+            return false;
+        };
+        self.extra_data_formats
+            .iter()
+            .any(|e| e.trim_start_matches('.').eq_ignore_ascii_case(ext))
+    }
 }
 
 fn load_global() -> Option<Config> {
@@ -99,4 +121,77 @@ fn load_local(repo_root: &Path) -> Option<Config> {
 fn load_file(path: &Path) -> Option<Config> {
     let content = std::fs::read_to_string(path).ok()?;
     toml::from_str(&content).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_data_format_exempt_built_in() {
+        let cfg = Config::default();
+        assert!(cfg.is_data_format_exempt("https://example.com/data.json"));
+        assert!(cfg.is_data_format_exempt("https://example.com/config.yaml"));
+    }
+
+    #[test]
+    fn is_data_format_exempt_rejects_non_data_default() {
+        let cfg = Config::default();
+        assert!(!cfg.is_data_format_exempt("https://example.com/tool.tar.gz"));
+        assert!(!cfg.is_data_format_exempt("https://example.com/install.sh"));
+    }
+
+    #[test]
+    fn is_data_format_exempt_with_extra_format() {
+        let cfg = Config {
+            extra_data_formats: vec!["proto".to_string(), "graphql".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_data_format_exempt("https://example.com/api.proto"));
+        assert!(cfg.is_data_format_exempt("https://example.com/schema.graphql"));
+        assert!(!cfg.is_data_format_exempt("https://example.com/install.sh"));
+    }
+
+    #[test]
+    fn is_data_format_exempt_extra_format_case_insensitive() {
+        let cfg = Config {
+            extra_data_formats: vec!["proto".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_data_format_exempt("https://example.com/API.PROTO"));
+    }
+
+    #[test]
+    fn is_data_format_exempt_strips_leading_dot_in_config() {
+        let cfg = Config {
+            extra_data_formats: vec![".proto".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_data_format_exempt("https://example.com/api.proto"));
+    }
+
+    #[test]
+    fn is_data_format_exempt_does_not_match_similar_extension() {
+        let cfg = Config {
+            extra_data_formats: vec!["proto".to_string()],
+            ..Config::default()
+        };
+        assert!(!cfg.is_data_format_exempt("https://example.com/api.protobuf"));
+    }
+
+    #[test]
+    fn deserializes_extra_data_formats_from_toml() {
+        let toml_content = r#"
+extra-data-formats = ["proto", "graphql"]
+"#;
+        let cfg: Config = toml::from_str(toml_content).unwrap();
+        assert_eq!(cfg.extra_data_formats, vec!["proto", "graphql"]);
+    }
+
+    #[test]
+    fn missing_extra_data_formats_defaults_to_empty() {
+        let toml_content = "";
+        let cfg: Config = toml::from_str(toml_content).unwrap();
+        assert!(cfg.extra_data_formats.is_empty());
+    }
 }


### PR DESCRIPTION
New `extra-data-formats` config key appends user-defined extensions to the built-in data-format exemption list. Useful for project-specific formats like `.proto` or `.graphql`.