### PR TITLE
feat(config): add trusted-hosts allowlist for unversioned fetches

### DIFF
--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -24,6 +24,11 @@ severity = "medium"
 # leading dots are optional.
 extra-data-formats = ["proto", "graphql"]
 
+# Hostnames to treat as trusted sources for unversioned fetches. A fetch whose
+# URL host exactly matches an entry is downgraded from a finding to an allowed
+# match. Case-insensitive.
+trusted-hosts = ["artifacts.example.com"]
+
 # Suppress specific findings
 [ignore]
 # Skip audit for these actions entirely
@@ -54,6 +59,28 @@ extra-data-formats = ["proto", "graphql", "tf", "hcl"]
 ```
 
 Matching is case-insensitive. Leading dots are stripped (`".proto"` and `"proto"` behave identically). The configured extensions are _added_ to the built-in set, not replacing it.
+
+### `trusted-hosts`
+
+A list of hostnames that are trusted sources for unversioned fetches. Any fetch whose URL host exactly matches an entry is recorded as an allowed match (visible under `--verbose`) with reason `trusted host` instead of being emitted as a finding.
+
+```toml
+trusted-hosts = [
+  "artifacts.example.com",
+  "releases.internal.example.org",
+]
+```
+
+**Matching is exact and case-insensitive.** `example.com` does _not_ trust `api.example.com` — each subdomain must be listed separately. This is deliberate: suffix-matching `example.com` would implicitly trust any subdomain including ones that don't exist yet, which is an easy way to accidentally widen the trust boundary.
+
+**Scope.** `trusted-hosts` exempts the same rules as the [data-format exemption](/reference/detections#data-format-exemption): unversioned-URL rules only. It does **not** suppress:
+
+- `/latest/` URL findings — the risk is about the path being mutable, regardless of who's serving it
+- Pipe-to-shell findings — the risk is that the payload is never written to disk, regardless of trust
+- `gh release download` without a pinned tag
+- Package manager installs (`pip install foo`, `npm install foo`) — those are package registries, not HTTP hosts
+
+To suppress a specific pattern that `trusted-hosts` doesn't cover, use [`ignore.patterns`](#ignorepatterns) instead.
 
 ### `ignore.actions`
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -17,6 +17,7 @@ pinprick scans line by line. Each rule is an anchored regex, compiled once at st
 
 - **Pipe-to-shell pre-empts other shell rules.** If a line matches a pipe-to-shell rule, no other shell or Docker rule fires on that line. So `curl ... | sh` produces a single high-severity finding instead of one medium (unversioned URL) plus one high (pipe-to-shell).
 - **Versioned-URL downgrade.** Non-pipe shell, JavaScript, and Python fetch rules only fire if the URL is _unversioned_. A URL is versioned if any path segment matches `v?\d+(\.\d+)+` — e.g. `/v1.2.3/`, `/0.55.8/`. See [Versioned URL heuristic](#versioned-url-heuristic).
+- **Trusted hosts exemption.** Unversioned-URL rules are downgraded to allowed matches when the URL host matches an entry in the user's [`trusted-hosts`](#trusted-hosts-exemption) list.
 - **Data-format exemption.** If a fetch targets a URL whose path ends in a known data-format extension (`.json`, `.yaml`, `.toml`, etc.), it is treated as a data fetch, not a code fetch, and downgraded to an allowed match instead of a finding. See [Data-format exemption](#data-format-exemption).
 - **Checksum downgrade.** A non-pipe finding followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` is downgraded one severity level (high → medium → low). The fetch is still reported.
 - **Pipe-to-shell is never downgraded.** A piped payload is never written to disk, so no checksum command can verify it.
@@ -124,6 +125,7 @@ wget https://example.com/bin/tool
 Not flagged:
 
 - Any URL whose path contains a segment matching `v?\d+(\.\d+)+`, e.g. `https://example.com/releases/download/v1.2.3/tool`.
+- Any URL whose host matches [`trusted-hosts`](#trusted-hosts-exemption) in `.pinprick.toml`.
 - Any URL whose path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.). See [Data-format exemption](#data-format-exemption).
 
 ### gh release download without a pinned tag
@@ -262,6 +264,7 @@ const r = await axios.get('https://example.com/api/data');
 Not flagged:
 
 - Versioned URL: `fetch('https://example.com/api/1.2.3/data')`
+- Trusted host via [`trusted-hosts`](#trusted-hosts-exemption)
 - Data-format URL: `fetch('https://example.com/config.json')` — see [Data-format exemption](#data-format-exemption).
 
 ## Python fetches
@@ -298,6 +301,7 @@ urllib.request.urlopen("https://example.com/file")
 Not flagged:
 
 - Versioned URL: `requests.get("https://example.com/releases/download/v1.2.3/tool")`
+- Trusted host via [`trusted-hosts`](#trusted-hosts-exemption)
 - Data-format URL: `requests.get("https://example.com/data.json")` — see [Data-format exemption](#data-format-exemption).
 
 ## Dockerfile patterns
@@ -370,6 +374,7 @@ ADD --chown=user:group https://example.com/tool.tgz /opt/
 Not flagged:
 
 - Versioned URL: `ADD https://example.com/releases/download/v1.2.3/install.tar.gz /tmp/`
+- Trusted host via [`trusted-hosts`](#trusted-hosts-exemption)
 - Data-format URL: `ADD https://example.com/config.json /etc/` — see [Data-format exemption](#data-format-exemption).
 - Local source: `ADD ./local.tar.gz /tmp/`
 
@@ -407,6 +412,23 @@ Matching is case-insensitive. Query strings (`?foo=bar`) and fragments (`#sectio
 The exemption applies only to the _unversioned-URL_ rules. `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension, because the risk there is about the _path_ being mutable, not about what the bytes decode to.
 
 The list can be extended via `extra-data-formats` in [`.pinprick.toml`](/configuration/config-file#extra-data-formats) to add project-specific extensions (e.g., `.proto`, `.graphql`).
+
+## Trusted hosts exemption
+
+Unversioned-URL rules are downgraded to allowed matches when the URL host matches an entry in the user's [`trusted-hosts`](/configuration/config-file#trusted-hosts) list. Configured via `.pinprick.toml`:
+
+```toml
+trusted-hosts = ["artifacts.example.com"]
+```
+
+Matching is exact hostname, case-insensitive. `example.com` does _not_ trust `api.example.com` — each subdomain must be listed separately. Port numbers and paths are stripped before comparison.
+
+The exemption applies only to the _unversioned-URL_ rules — the same scope as the data-format exemption. It does **not** cover:
+
+- `/latest/` URLs — the risk is the path being mutable, regardless of who's serving it.
+- Pipe-to-shell — the piped payload is never written to disk, so host trust doesn't change the safety profile.
+- `gh release download` without a pinned tag.
+- Package manager installs (`pip install foo`, `npm install foo`) — those go through package registries, not the HTTP host.
 
 ## Suppressing findings
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -519,6 +519,16 @@ fn check_url_patterns(
                 pattern_matched: line.trim().to_string(),
                 reason: "versioned URL".to_string(),
             });
+        } else if config.is_host_trusted(url) {
+            collector.push_allowed(AuditMatch {
+                severity: output::severity_str(&pattern.severity).to_string(),
+                category: category_str(&pattern.category).to_string(),
+                action: action_name.to_string(),
+                source_file: source_file.to_string(),
+                line: Some(line_num),
+                pattern_matched: line.trim().to_string(),
+                reason: "trusted host".to_string(),
+            });
         } else if config.is_data_format_exempt(url) {
             collector.push_allowed(AuditMatch {
                 severity: output::severity_str(&pattern.severity).to_string(),
@@ -1081,5 +1091,106 @@ mod tests {
             &config,
         );
         assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn shell_scan_trusted_host_is_allowed() {
+        let config = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            "curl -L https://artifacts.example.com/install.sh -o install.sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "trusted host");
+    }
+
+    #[test]
+    fn shell_scan_untrusted_host_still_flagged() {
+        let config = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://other.example.com/install.sh -o install.sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn shell_scan_trusted_host_does_not_exempt_latest() {
+        // `/latest/` still fires on a trusted host — the risk is about the
+        // mutable path, not about who's serving it.
+        let config = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://artifacts.example.com/releases/latest/install.sh -o foo",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("'latest' URL"));
+    }
+
+    #[test]
+    fn shell_scan_trusted_host_does_not_exempt_pipe_to_shell() {
+        // Pipe-to-shell still fires on a trusted host — payload isn't
+        // written to disk regardless of who's serving it.
+        let config = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -sSL https://artifacts.example.com/install.sh | sh",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &config,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("piped to shell"));
+    }
+
+    #[test]
+    fn js_scan_trusted_host_is_allowed() {
+        let config = Config {
+            trusted_hosts: vec!["api.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(true);
+        scan_js_content(
+            r#"const r = await fetch("https://api.example.com/data");"#,
+            "test.js",
+            "",
+            &mut c,
+            &config,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "trusted host");
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -391,6 +391,20 @@ pub fn url_extension(url: &str) -> Option<&str> {
     Some(&last[dot + 1..])
 }
 
+/// Extract the hostname from an `http(s)://` URL. Strips the protocol,
+/// optional `user@` prefix, and trailing port/path/query/fragment. Returns
+/// `None` if the URL does not start with `http://` or `https://`.
+pub fn url_host(url: &str) -> Option<&str> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let after_userinfo = rest.split_once('@').map(|(_, r)| r).unwrap_or(rest);
+    let end = after_userinfo
+        .find(['/', ':', '?', '#'])
+        .unwrap_or(after_userinfo.len());
+    Some(&after_userinfo[..end])
+}
+
 /// Check if a URL's path ends with a known data-format extension.
 pub fn url_is_data_format(url: &str) -> bool {
     let Some(ext) = url_extension(url) else {
@@ -498,6 +512,66 @@ mod tests {
             url_extension("https://example.com/v1.2.3/config/settings"),
             None
         );
+    }
+
+    // ── url_host ────────────────────────────────────────────────────────
+
+    #[test]
+    fn url_host_simple_https() {
+        assert_eq!(
+            url_host("https://example.com/path/to/file"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn url_host_simple_http() {
+        assert_eq!(url_host("http://example.com/"), Some("example.com"));
+    }
+
+    #[test]
+    fn url_host_with_port_strips_port() {
+        assert_eq!(
+            url_host("https://example.com:8080/api"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn url_host_with_query() {
+        assert_eq!(url_host("https://example.com?foo=bar"), Some("example.com"));
+    }
+
+    #[test]
+    fn url_host_with_fragment() {
+        assert_eq!(url_host("https://example.com#section"), Some("example.com"));
+    }
+
+    #[test]
+    fn url_host_bare() {
+        assert_eq!(url_host("https://example.com"), Some("example.com"));
+    }
+
+    #[test]
+    fn url_host_strips_userinfo() {
+        assert_eq!(
+            url_host("https://user@example.com/path"),
+            Some("example.com")
+        );
+    }
+
+    #[test]
+    fn url_host_subdomain() {
+        assert_eq!(
+            url_host("https://api.example.com/data"),
+            Some("api.example.com")
+        );
+    }
+
+    #[test]
+    fn url_host_not_a_url() {
+        assert_eq!(url_host("example.com"), None);
+        assert_eq!(url_host("ftp://example.com"), None);
     }
 
     // ── url_is_data_format ──────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,14 @@ pub struct Config {
     /// leading dots are stripped.
     #[serde(default)]
     pub extra_data_formats: Vec<String>,
+
+    /// Hostnames that are trusted sources for unversioned fetches. A fetch
+    /// whose URL host exactly matches an entry is downgraded from a finding
+    /// to an allowed match. Case-insensitive. Only applies to the
+    /// unversioned-URL rules — `/latest/` URLs and pipe-to-shell still fire
+    /// regardless.
+    #[serde(default)]
+    pub trusted_hosts: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -102,6 +110,18 @@ impl Config {
         self.extra_data_formats
             .iter()
             .any(|e| e.trim_start_matches('.').eq_ignore_ascii_case(ext))
+    }
+
+    /// Check if a URL's host is in the configured `trusted_hosts` list.
+    /// Case-insensitive exact match. Returns false if the URL cannot be
+    /// parsed or has no host.
+    pub fn is_host_trusted(&self, url: &str) -> bool {
+        let Some(host) = audit_patterns::url_host(url) else {
+            return false;
+        };
+        self.trusted_hosts
+            .iter()
+            .any(|h| h.eq_ignore_ascii_case(host))
     }
 }
 
@@ -193,5 +213,76 @@ extra-data-formats = ["proto", "graphql"]
         let toml_content = "";
         let cfg: Config = toml::from_str(toml_content).unwrap();
         assert!(cfg.extra_data_formats.is_empty());
+    }
+
+    #[test]
+    fn is_host_trusted_exact_match() {
+        let cfg = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_host_trusted("https://artifacts.example.com/foo/bar"));
+    }
+
+    #[test]
+    fn is_host_trusted_case_insensitive() {
+        let cfg = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_host_trusted("https://ARTIFACTS.EXAMPLE.COM/foo"));
+    }
+
+    #[test]
+    fn is_host_trusted_strips_port() {
+        let cfg = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        assert!(cfg.is_host_trusted("https://artifacts.example.com:8443/foo"));
+    }
+
+    #[test]
+    fn is_host_trusted_no_subdomain_match() {
+        let cfg = Config {
+            trusted_hosts: vec!["example.com".to_string()],
+            ..Config::default()
+        };
+        // Exact match only — `api.example.com` is not trusted.
+        assert!(!cfg.is_host_trusted("https://api.example.com/foo"));
+    }
+
+    #[test]
+    fn is_host_trusted_empty_list_rejects_all() {
+        let cfg = Config::default();
+        assert!(!cfg.is_host_trusted("https://example.com/foo"));
+    }
+
+    #[test]
+    fn is_host_trusted_non_url_returns_false() {
+        let cfg = Config {
+            trusted_hosts: vec!["example.com".to_string()],
+            ..Config::default()
+        };
+        assert!(!cfg.is_host_trusted("example.com"));
+    }
+
+    #[test]
+    fn deserializes_trusted_hosts_from_toml() {
+        let toml_content = r#"
+trusted-hosts = ["artifacts.example.com", "releases.example.org"]
+"#;
+        let cfg: Config = toml::from_str(toml_content).unwrap();
+        assert_eq!(
+            cfg.trusted_hosts,
+            vec!["artifacts.example.com", "releases.example.org"]
+        );
+    }
+
+    #[test]
+    fn missing_trusted_hosts_defaults_to_empty() {
+        let toml_content = "";
+        let cfg: Config = toml::from_str(toml_content).unwrap();
+        assert!(cfg.trusted_hosts.is_empty());
     }
 }


### PR DESCRIPTION
New `trusted-hosts` config key exempts unversioned URL fetches from flagged hosts. Exact hostname match, case-insensitive. Does not affect `/latest/` or pipe-to-shell rules.