### PR TITLE
feat(audit): show which layer satisfied each audited-action lookup

### DIFF
--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -21,7 +21,11 @@ For the full list of every rule, including examples and severity, see the [Detec
 
 ## Audited actions list
 
-pinprick ships with a bundled list of popular actions that have been scanned and confirmed clean. These are skipped automatically during audit, avoiding redundant API calls.
+pinprick skips actions whose `owner/repo@sha` is already known to be clean. The check consults three sources, in order, and reports which one answered:
+
+- `bundled` — ships with the pinprick binary from `audited-actions/` in the repo
+- `local cache` — written to `~/.cache/pinprick/audited/` after a successful live scan on this machine
+- `pinprick.rs` — fetched from the public audited-actions list (opt-in via `fetch-remote = true` in `.pinprick.toml`)
 
 See [Audited Actions](/configuration/audited-actions) for details on how the list works and how to contribute.
 
@@ -41,10 +45,11 @@ When no GitHub token is available, audit scans only workflow `run:` blocks. Acti
 ```
 $ pinprick audit
 Scanning .github/workflows/ci.yml... done
-  actions/checkout@de0fac2e audited
-  actions/upload-artifact@bbbca2dd audited
+  actions/checkout@de0fac2e audited (bundled)
+  actions/upload-artifact@bbbca2dd audited (bundled)
 Scanning .github/workflows/release.yml... done
-  actions/attest@59d89421 audited
+  actions/attest@59d89421 audited (bundled)
+  rust-lang/crates-io-auth-action@bbd81622 audited (local cache)
 
 No runtime fetch risks found.
 ```

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -107,15 +107,16 @@ pub async fn run(
                     continue;
                 }
 
-                if audited
+                if let Some(source) = audited
                     .check(&action.owner, &action.repo, &action.ref_string)
                     .await
                 {
                     if !quiet {
                         eprintln!(
-                            "  {}@{} audited",
+                            "  {}@{} audited ({})",
                             action.full_name(),
-                            short_sha(&action.ref_string)
+                            short_sha(&action.ref_string),
+                            source.label()
                         );
                     }
                     continue;

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -10,6 +10,28 @@ struct AuditedEntry {
     sha: String,
 }
 
+/// Which layer in the lookup satisfied an audited-action check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditSource {
+    /// Compiled into the pinprick binary from `audited-actions/`.
+    Bundled,
+    /// Read from `~/.cache/pinprick/audited/` (populated by previous scans).
+    LocalCache,
+    /// Fetched from `https://pinprick.rs/audited-actions/`.
+    Remote,
+}
+
+impl AuditSource {
+    /// Short human-readable label for terminal output.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Bundled => "bundled",
+            Self::LocalCache => "local cache",
+            Self::Remote => "pinprick.rs",
+        }
+    }
+}
+
 /// Layered lookup for pre-audited action SHAs.
 ///
 /// Resolution order:
@@ -39,8 +61,9 @@ impl AuditedActions {
         }
     }
 
-    /// Check if an action at a specific SHA has been pre-audited.
-    pub async fn check(&mut self, owner: &str, repo: &str, sha: &str) -> bool {
+    /// Check if an action at a specific SHA has been pre-audited. Returns
+    /// which lookup layer satisfied the check, or `None` if no layer matched.
+    pub async fn check(&mut self, owner: &str, repo: &str, sha: &str) -> Option<AuditSource> {
         let key = format!("{owner}/{repo}");
 
         if self
@@ -48,7 +71,7 @@ impl AuditedActions {
             .get(&key)
             .is_some_and(|shas| shas.contains(sha))
         {
-            return true;
+            return Some(AuditSource::Bundled);
         }
 
         if !self.local.contains_key(&key) {
@@ -56,7 +79,7 @@ impl AuditedActions {
             self.local.insert(key.clone(), shas);
         }
         if self.local.get(&key).is_some_and(|shas| shas.contains(sha)) {
-            return true;
+            return Some(AuditSource::LocalCache);
         }
 
         if self.fetch_remote {
@@ -65,11 +88,11 @@ impl AuditedActions {
                 self.remote.insert(key.clone(), shas);
             }
             if self.remote.get(&key).is_some_and(|shas| shas.contains(sha)) {
-                return true;
+                return Some(AuditSource::Remote);
             }
         }
 
-        false
+        None
     }
 
     /// Record a clean scan result in the local cache.


### PR DESCRIPTION
`audited` lines now report the source: `bundled`, `local cache`, or `pinprick.rs`.