### PR TITLE
chore(zizmor): use the auditor persona everywhere

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,4 +26,4 @@ jobs:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
-          persona: pedantic
+          persona: auditor

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
 
 # Audit GitHub Actions workflows
 audit:
-    zizmor .github/workflows/
+    zizmor --persona auditor .github/workflows/
 
 # Run clippy
 clippy:
@@ -147,7 +147,7 @@ check:
         skip typos typos typos-cli
     fi
     if command -v zizmor &>/dev/null; then
-        run zizmor .github/workflows/
+        run zizmor --persona auditor .github/workflows/
     else
         skip audit zizmor zizmor
     fi


### PR DESCRIPTION
Bumps both the push-to-main workflow and local `just audit`/`just check` from pedantic (and default regular) to `auditor`. No new findings surfaced at auditor level.