### PR TITLE
feat(site): harden HTTP headers and add robots.txt/security.txt

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -1,0 +1,11 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-XSS-Protection: 0
+  Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/site/src/pages/.well-known/security.txt.ts
+++ b/site/src/pages/.well-known/security.txt.ts
@@ -1,0 +1,19 @@
+import type { APIRoute } from 'astro';
+
+const getSecurityTxt = (canonicalURL: URL) => {
+  // One year from build time, normalized to midnight UTC.
+  const expires = new Date();
+  expires.setUTCFullYear(expires.getUTCFullYear() + 1);
+  expires.setUTCHours(0, 0, 0, 0);
+
+  return `Contact: https://github.com/p-linnane/pinprick/security/advisories/new
+Expires: ${expires.toISOString()}
+Preferred-Languages: en
+Canonical: ${canonicalURL.href}
+`;
+};
+
+export const GET: APIRoute = ({ site }) => {
+  const canonicalURL = new URL('.well-known/security.txt', site);
+  return new Response(getSecurityTxt(canonicalURL));
+};

--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+
+const getRobotsTxt = (sitemapURL: URL) => `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemapURL = new URL('sitemap-index.xml', site);
+  return new Response(getRobotsTxt(sitemapURL));
+};


### PR DESCRIPTION
Adds a Cloudflare `_headers` file with HSTS, CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, X-Content-Type-Options, and X-XSS-Protection, plus a one-year immutable cache on `/_astro/*`. Also adds prerendered `/robots.txt` and `/.well-known/security.txt` endpoints — the latter points reporters at GitHub private vulnerability advisories.

The CSP allows `'wasm-unsafe-eval'` and `worker-src 'self'` so Starlight's pagefind search (which compiles WebAssembly inside a Web Worker) keeps working.