### PR TITLE
feat: add `clean` subcommand to remove local audit cache

### DIFF
--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -168,7 +168,7 @@ fn parse_entries(json: &str) -> HashSet<String> {
     entries.into_iter().map(|e| e.sha).collect()
 }
 
-fn cache_dir() -> Option<PathBuf> {
+pub fn cache_dir() -> Option<PathBuf> {
     let home = std::env::var("HOME").ok()?;
     Some(PathBuf::from(home).join(".cache/pinprick/audited"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,8 @@ enum Command {
         #[arg(long, conflicts_with = "json")]
         sarif: bool,
     },
+    /// Remove locally cached audit results
+    Clean,
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for
@@ -110,6 +112,22 @@ async fn main() -> ExitCode {
         } => {
             let config = config::Config::load(path);
             audit::run(path, cli.json, *sarif, *verbose, &config).await
+        }
+        Command::Clean => {
+            let removed = match audited_actions::cache_dir() {
+                Some(dir) if dir.is_dir() => std::fs::remove_dir_all(&dir).is_ok(),
+                _ => false,
+            };
+
+            if cli.json {
+                let msg = serde_json::json!({ "cleaned": removed });
+                println!("{msg}");
+            } else if removed {
+                println!("Cache cleaned.");
+            } else {
+                println!("Nothing to clean.");
+            }
+            return ExitCode::SUCCESS;
         }
         Command::Completions { shell } => {
             clap_complete::generate(


### PR DESCRIPTION
## Summary

- Adds a `clean` subcommand that removes the local audit cache (`~/.cache/pinprick/audited/`)
- Supports `--json` output (`{ "cleaned": true/false }`)
- Makes `cache_dir()` in `audited_actions.rs` public to reuse path resolution