### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.88"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
## Summary

- Bumps version to 0.4.0 for the `clean` subcommand release