### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.88"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bump version for release including:
- fix: match bundled format when writing local audit cache (#49)
- fix(audit): recognize --tag flag in gh release download (#50)