### PR TITLE
ci(audit): disable deployment status for starhaven environment

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -143,7 +143,9 @@ jobs:
     needs: scan
     if: needs.scan.result == 'success' && !inputs.dry-run
     runs-on: ubuntu-slim
-    environment: starhaven
+    environment:
+      name: starhaven
+      deployment: false
     permissions:
       contents: read
       actions: read # required by download-artifact


### PR DESCRIPTION
Use the expanded environment syntax with `deployment: false` to prevent the scan job from creating deployment status entries.