### PR TITLE
chore: lower MSRV to 1.85.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pinprick"
 version = "0.4.2"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.85.0"
 description = "GitHub Actions supply chain security tool"
 license = "AGPL-3.0-only"
 repository = "https://github.com/p-linnane/pinprick"


### PR DESCRIPTION
Lower MSRV from 1.88 to 1.85.0, the Rust version that stabilized the 2024 edition. Verified with `cargo msrv verify`.