### PR TITLE
fix: raise MSRV to 1.87.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pinprick"
 version = "0.4.2"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"
 license = "AGPL-3.0-only"
 repository = "https://github.com/p-linnane/pinprick"


### PR DESCRIPTION
1.85.0 causes cargo to downgrade ICU and wasip2 dependencies. 1.87.0 is the minimum that avoids all downgrades.