### PR TITLE
feat: unify pin/update to dry-run by default with --write flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,8 @@ pinprick/
 
 ### Commands
 
-- `pinprick pin [PATH] [--dry-run]` — Scan `.github/workflows/*.yml`, resolve action tag refs to full SHAs via GitHub API, rewrite files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions. `--dry-run` previews changes without writing and exits 1 when there are unpinned actions.
-- `pinprick update [PATH] [--apply] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--apply` to write changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
+- `pinprick pin [PATH] [--write]` — Scan `.github/workflows/*.yml`, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
+- `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
 - `pinprick audit [PATH] [--verbose] [--sarif]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans only local `run:` blocks. With a token, also fetches and scans action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning.
 - `pinprick clean` — Remove locally cached audit results (`~/.cache/pinprick/audited/`).
 - `pinprick completions <SHELL>` — Generate shell completions for bash, zsh, fish, etc.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ All commands default to the current directory. Pass a path to target a different
 # Pin action tags to full SHAs
 pinprick pin
 
-# Preview without writing
-pinprick pin --dry-run
+# Write changes to files
+pinprick pin --write
 
 # Check pinned actions for newer releases (dry-run)
 pinprick update
 
-# Apply updates
-pinprick update --apply
+# Write updates to files
+pinprick update --write
 
 # Only check a specific action or org
 pinprick update --only actions/checkout
@@ -74,7 +74,7 @@ pinprick completions zsh
 
 ### Pin
 
-Resolve action tag references to full SHAs:
+Resolve action tag references to full SHAs (dry-run by default):
 
 ```
 $ pinprick pin
@@ -85,21 +85,22 @@ $ pinprick pin
   ! actions/checkout@v4 -- sliding tag, resolved to v6.0.2
   ! Homebrew/actions/setup-homebrew@main -- branch ref — pin to a SHA manually
 
-Pinned 2 actions across 1 file (2 skipped)
+Would pin 2 actions across 1 file (2 skipped)
+Run with --write to apply.
 ```
 
 Sliding tags like `@v4` are resolved to their exact version. Branch refs like `@main` are flagged.
 
 ### Update
 
-Check pinned actions for newer releases:
+Check pinned actions for newer releases (dry-run by default):
 
 ```
 $ pinprick update
 .github/workflows/ci.yml
   actions/checkout  v4.1.0 -> v6.0.2
 
-1 update available. Run with --apply to apply.
+1 update available. Run with --write to apply.
 ```
 
 ### Audit

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -55,10 +55,10 @@ export default defineConfig({
         {
           label: 'Commands',
           items: [
-            { label: 'pin', slug: 'commands/pin' },
-            { label: 'update', slug: 'commands/update' },
             { label: 'audit', slug: 'commands/audit' },
             { label: 'clean', slug: 'commands/clean' },
+            { label: 'pin', slug: 'commands/pin' },
+            { label: 'update', slug: 'commands/update' },
           ],
         },
         {

--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -6,20 +6,20 @@ description: Resolve action tag references to full SHAs.
 Scan `.github/workflows/*.yml` files and resolve action tag references to full SHA-pinned references.
 
 ```bash
-pinprick pin                # write changes in place
-pinprick pin --dry-run      # preview without writing
+pinprick pin                # dry-run (show what would be pinned)
+pinprick pin --write        # write changes to files
 pinprick pin /path/to/repo
 ```
 
 ## Behavior
 
+- Dry-run by default — shows what would change without writing files, exits 1 when there are unpinned actions (useful for CI gating)
+- `--write` rewrites files in-place with `@sha # tag` format, preserving all comments and formatting
 - Tag refs (e.g., `@v4.3.1`) are resolved to their commit SHA via the GitHub API
 - Sliding tags (e.g., `@v4`) are resolved to the exact release version — `@v4` becomes `# v4.3.1`, not `# v4`
 - Already-pinned refs (40-char hex SHAs) are skipped silently
 - Branch refs (e.g., `@main`) are flagged — pin to a SHA manually
 - Annotated tags are followed to their underlying commit SHA
-- Files are rewritten in-place with `@sha # tag` format, preserving all comments and formatting
-- `--dry-run` prints the same preview without touching any files and exits 1 when there are unpinned actions — useful for CI gating
 
 ## Example
 
@@ -32,5 +32,6 @@ $ pinprick pin
   ! actions/checkout@v4 -- sliding tag, resolved to v4.3.1
   ! Homebrew/actions/setup-homebrew@main -- branch ref — pin to a SHA manually
 
-Pinned 2 actions across 1 file (2 skipped)
+Would pin 2 actions across 1 file (2 skipped)
+Run with --write to apply.
 ```

--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -7,7 +7,7 @@ Check SHA-pinned actions for newer releases and optionally update them.
 
 ```bash
 pinprick update                       # dry-run (show available updates)
-pinprick update --apply               # write updates to files
+pinprick update --write               # write updates to files
 pinprick update --only actions/       # only check actions in the `actions/` org
 pinprick update --only actions/checkout
 pinprick update /path/to/repo
@@ -44,5 +44,5 @@ $ pinprick update
   actions/setup-node v4.0.0 -> v6.3.0
     https://github.com/actions/setup-node/releases/tag/v6.3.0
 
-2 updates available. Run with --apply to apply.
+2 updates available. Run with --write to apply.
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,10 +72,9 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
 
-        /// Preview changes without writing files. Exits 1 when there are
-        /// unpinned actions — useful for CI gating.
-        #[arg(long)]
-        dry_run: bool,
+        /// Write changes to files (default is dry-run)
+        #[arg(long = "write")]
+        apply: bool,
     },
     /// Check for updates to pinned actions
     Update {
@@ -83,8 +82,8 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
 
-        /// Apply updates (default is dry-run)
-        #[arg(long)]
+        /// Write changes to files (default is dry-run)
+        #[arg(long = "write")]
         apply: bool,
 
         /// Only check actions whose owner/repo contains this substring
@@ -138,7 +137,7 @@ async fn main() -> ExitCode {
             );
             return ExitCode::SUCCESS;
         }
-        Command::Pin { path, dry_run } => pin::run(path, cli.json, *dry_run).await,
+        Command::Pin { path, apply } => pin::run(path, cli.json, *apply).await,
         Command::Update { path, apply, only } => {
             update::run(path, *apply, cli.json, only.as_deref()).await
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -86,7 +86,7 @@ impl PinReport {
             }
         );
         if !self.applied && !self.pinned.is_empty() {
-            println!("Run without {} to write changes.", "--dry-run".bold());
+            println!("Run with {} to apply.", "--write".bold());
         }
     }
 
@@ -157,7 +157,7 @@ impl UpdateReport {
                 "{} update{} available. Run with {} to apply.",
                 self.updates.len(),
                 if self.updates.len() == 1 { "" } else { "s" },
-                "--apply".bold()
+                "--write".bold()
             );
         }
     }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -7,7 +7,7 @@ use crate::github::GitHubClient;
 use crate::output::{PinReport, PinResult, PinSkip};
 use crate::workflow::{self, RefType};
 
-pub async fn run(repo_root: &Path, json: bool, dry_run: bool) -> Result<ExitCode> {
+pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> {
     let token = auth::require_token().await?;
     let client = GitHubClient::new(token);
 
@@ -15,7 +15,7 @@ pub async fn run(repo_root: &Path, json: bool, dry_run: bool) -> Result<ExitCode
     let mut report = PinReport {
         pinned: Vec::new(),
         skipped: Vec::new(),
-        applied: !dry_run,
+        applied: apply,
     };
 
     for file in &files {
@@ -100,7 +100,7 @@ pub async fn run(repo_root: &Path, json: bool, dry_run: bool) -> Result<ExitCode
             }
         }
 
-        if !dry_run && !replacements.is_empty() {
+        if apply && !replacements.is_empty() {
             workflow::rewrite_actions(file, &replacements)?;
         }
     }
@@ -111,7 +111,7 @@ pub async fn run(repo_root: &Path, json: bool, dry_run: bool) -> Result<ExitCode
         report.print_human();
     }
 
-    if dry_run && !report.pinned.is_empty() {
+    if !apply && !report.pinned.is_empty() {
         Ok(ExitCode::from(1))
     } else {
         Ok(ExitCode::SUCCESS)


### PR DESCRIPTION
## Summary

- Both `pin` and `update` now default to dry-run and use `--write` to apply changes
- Previously `pin` wrote by default (`--dry-run` to preview) while `update` was dry-run by default (`--apply` to write)
- Alphabetize the site sidebar commands