### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0 for the `--write` flag unification (breaking CLI change: `pin --dry-run` and `update --apply` replaced with `--write` on both commands)