### PR TITLE
ci(dependabot): bump version requirements for all new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
## Summary

- Add `versioning-strategy: increase` to the Cargo ecosystem so Dependabot PRs new major/minor releases, not just compatible bumps