### PR TITLE
fix(dependabot): remove unsupported versioning-strategy for Cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: increase
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
## Summary

- Remove `versioning-strategy: increase` from the Cargo ecosystem — Dependabot only supports `lockfile-only` and `auto` for Cargo