### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Patch release for standardized 7-character short SHA display in audit output.