### PR TITLE
fix(deploy-site): trigger redeploy on Cargo.toml version changes

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "site/**"
       - "audited-actions/**"
+      - "Cargo.toml"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
The site version badge is read from Cargo.toml at build time, but the deploy workflow only triggers on changes to `site/**` and `audited-actions/**`. This adds `Cargo.toml` to the paths filter so version bumps redeploy the site.