### PR TITLE
test: add integration tests and improve unit test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,10 +68,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -106,6 +127,17 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -259,6 +291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,10 +339,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -739,6 +792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +845,21 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -846,14 +920,17 @@ name = "pinprick"
 version = "0.5.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap_complete",
  "colored",
+ "predicates",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "serde_norway",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
@@ -875,6 +952,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1083,6 +1190,19 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -1392,6 +1512,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1796,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ toml = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"
+
 [profile.release]
 lto = true
 strip = true

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1234,4 +1234,200 @@ mod tests {
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "trusted host");
     }
+
+    #[test]
+    fn gh_release_download_without_tag_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "gh release download -R owner/repo -p '*.tar.gz'",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("gh release download"));
+    }
+
+    #[test]
+    fn js_minified_line_splitting() {
+        let mut c = AuditCollector::new(false);
+        // Build a line > 500 chars with a fetch call buried in it
+        let padding = "a".repeat(450);
+        let minified = format!(
+            r#"{}; const r = await fetch("https://example.com/api/data"); {}"#,
+            padding, padding
+        );
+        scan_js_content(&minified, "dist/index.js", "", &mut c, &DEFAULT_CONFIG);
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn dockerfile_digest_pinned_skipped() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890\nRUN echo hello\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn dockerfile_from_latest_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu:latest\nRUN echo hello\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn dockerfile_from_no_tag_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu\nRUN echo hello\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn scan_action_yml_composite_steps() {
+        let yaml: serde_norway::Value = serde_norway::from_str(
+            r#"
+runs:
+  using: composite
+  steps:
+    - run: curl -L https://example.com/install.sh -o install.sh
+"#,
+        )
+        .unwrap();
+        let mut c = AuditCollector::new(false);
+        scan_action_yml_runs(&yaml, "action.yml", "test-action", &mut c, &DEFAULT_CONFIG);
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn scan_action_yml_args() {
+        let yaml: serde_norway::Value = serde_norway::from_str(
+            r#"
+runs:
+  using: node20
+  args: |
+    curl -L https://example.com/install.sh -o install.sh
+"#,
+        )
+        .unwrap();
+        let mut c = AuditCollector::new(false);
+        scan_action_yml_runs(&yaml, "action.yml", "test-action", &mut c, &DEFAULT_CONFIG);
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn scan_action_yml_no_runs_key() {
+        let yaml: serde_norway::Value = serde_norway::from_str("name: test\n").unwrap();
+        let mut c = AuditCollector::new(false);
+        scan_action_yml_runs(&yaml, "action.yml", "test-action", &mut c, &DEFAULT_CONFIG);
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn downgrade_low_stays_low() {
+        assert_eq!(downgrade_severity("low"), "low");
+    }
+
+    #[test]
+    fn downgrade_unknown_unchanged() {
+        assert_eq!(downgrade_severity("info"), "info");
+    }
+
+    #[test]
+    fn short_sha_full() {
+        assert_eq!(
+            short_sha("abc1234567890abcdef1234567890abcdef123456"),
+            "abc1234"
+        );
+    }
+
+    #[test]
+    fn short_sha_short() {
+        assert_eq!(short_sha("abc"), "abc");
+    }
+
+    #[test]
+    fn py_scan_trusted_host_is_allowed() {
+        let config = Config {
+            trusted_hosts: vec!["api.example.com".to_string()],
+            ..Config::default()
+        };
+        let mut c = AuditCollector::new(true);
+        scan_py_content(
+            r#"r = requests.get("https://api.example.com/data")"#,
+            "test.py",
+            "",
+            &mut c,
+            &config,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "trusted host");
+    }
+
+    #[test]
+    fn finding_includes_action_name() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/install.sh -o foo",
+            "test.sh",
+            1,
+            "actions/checkout@abc1234",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].action, "actions/checkout@abc1234");
+    }
+
+    #[test]
+    fn checksum_at_boundary_of_three_lines() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/releases/latest/download/tool -o tool\necho step1\necho step2\nsha256sum --check tool.sha256",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("checksum verified"));
+    }
+
+    #[test]
+    fn checksum_beyond_three_lines_no_downgrade() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -L https://example.com/releases/latest/download/tool -o tool\necho 1\necho 2\necho 3\nsha256sum --check tool.sha256",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+    }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -815,11 +815,28 @@ mod audit_summary_tests {
         }
     }
 
-    fn lines_without_ansi(r: &AuditReport) -> Vec<String> {
-        colored::control::set_override(false);
-        let out = r.audit_summary_lines();
-        colored::control::unset_override();
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut in_escape = false;
+        for c in s.chars() {
+            if in_escape {
+                if c.is_ascii_alphabetic() {
+                    in_escape = false;
+                }
+            } else if c == '\x1b' {
+                in_escape = true;
+            } else {
+                out.push(c);
+            }
+        }
         out
+    }
+
+    fn lines_without_ansi(r: &AuditReport) -> Vec<String> {
+        r.audit_summary_lines()
+            .into_iter()
+            .map(|s| strip_ansi(&s))
+            .collect()
     }
 
     #[test]
@@ -998,6 +1015,55 @@ mod audit_summary_tests {
                 "1 branch ref scanned. Pin to a SHA manually.",
                 "1 action ignored per config.",
             ]
+        );
+    }
+
+    #[test]
+    fn local_cache_only() {
+        let r = AuditReport {
+            audited_local_cache: 3,
+            ..empty_report()
+        };
+        assert_eq!(
+            lines_without_ansi(&r),
+            vec!["Audited 3 actions: 3 local cache."]
+        );
+    }
+
+    #[test]
+    fn remote_only() {
+        let r = AuditReport {
+            audited_remote: 1,
+            ..empty_report()
+        };
+        assert_eq!(
+            lines_without_ansi(&r),
+            vec!["Audited 1 action: 1 pinprick.rs."]
+        );
+    }
+
+    #[test]
+    fn unpinned_only_no_audited_line() {
+        let r = AuditReport {
+            scanned_unpinned_sliding: 1,
+            scanned_unpinned_branch: 2,
+            ..empty_report()
+        };
+        let lines = lines_without_ansi(&r);
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("1 sliding tag scanned"));
+        assert!(lines[1].contains("2 branch refs scanned"));
+    }
+
+    #[test]
+    fn plural_ignored() {
+        let r = AuditReport {
+            ignored: 5,
+            ..empty_report()
+        };
+        assert_eq!(
+            lines_without_ansi(&r),
+            vec!["5 actions ignored per config."]
         );
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -214,4 +214,33 @@ mod tests {
         assert!(is_newer("v3", "v4"));
         assert!(!is_newer("v4", "v3"));
     }
+
+    #[test]
+    fn prerelease_suffix_ignored() {
+        // "rc1" is not numeric, so filter_map drops it: v1.2.3-rc1 → [1,2,3]
+        assert!(!is_newer("v1.2.3", "v1.2.3-rc1"));
+    }
+
+    #[test]
+    fn leading_zeros() {
+        assert!(is_newer("v01.02.03", "v01.02.04"));
+    }
+
+    #[test]
+    fn empty_segments_skipped() {
+        // "v1..3" splits into ["1", "", "3"], empty string fails parse → [1, 3]
+        assert!(is_newer("v1.2", "v1.3"));
+    }
+
+    #[test]
+    fn long_version() {
+        assert!(is_newer("v1.2.3.4.5", "v1.2.3.4.6"));
+        assert!(!is_newer("v1.2.3.4.6", "v1.2.3.4.5"));
+    }
+
+    #[test]
+    fn both_empty_after_parse() {
+        // No numeric components at all
+        assert!(!is_newer("alpha", "beta"));
+    }
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -395,6 +395,108 @@ jobs:
         assert_eq!(refs[0].full_name(), "real/a");
         assert_eq!(refs[1].full_name(), "real/b");
     }
+
+    // ── classify_ref edge cases ────────────────────────────────────────
+
+    #[test]
+    fn classify_39_hex_chars_is_branch() {
+        let short = "a".repeat(39);
+        assert!(matches!(classify_ref(&short), RefType::Branch));
+    }
+
+    #[test]
+    fn classify_41_hex_chars_is_branch() {
+        let long = "a".repeat(41);
+        assert!(matches!(classify_ref(&long), RefType::Branch));
+    }
+
+    #[test]
+    fn classify_40_hex_chars_is_sha() {
+        let sha = "a".repeat(40);
+        assert!(matches!(classify_ref(&sha), RefType::Sha));
+    }
+
+    #[test]
+    fn classify_mixed_case_hex_is_sha() {
+        let sha = "aAbBcCdDeEfF0011223344556677889900112233";
+        assert!(matches!(classify_ref(sha), RefType::Sha));
+    }
+
+    #[test]
+    fn classify_prerelease_tag_is_branch() {
+        assert!(matches!(classify_ref("v1.2.3-alpha"), RefType::Branch));
+    }
+
+    #[test]
+    fn classify_main_is_branch() {
+        assert!(matches!(classify_ref("main"), RefType::Branch));
+    }
+
+    // ── build_pinned_line ──────────────────────────────────────────────
+
+    #[test]
+    fn build_pinned_line_non_uses_returns_none() {
+        assert!(build_pinned_line("  - run: echo hello", "abc123", "v1").is_none());
+    }
+
+    // ── display_path ───────────────────────────────────────────────────
+
+    #[test]
+    fn display_path_relative() {
+        let root = Path::new("/repo");
+        let path = Path::new("/repo/.github/workflows/ci.yml");
+        assert_eq!(display_path(path, root), ".github/workflows/ci.yml");
+    }
+
+    #[test]
+    fn display_path_outside_root() {
+        let root = Path::new("/repo");
+        let path = Path::new("/other/ci.yml");
+        assert_eq!(display_path(path, root), "/other/ci.yml");
+    }
+
+    // ── rewrite_actions ────────────────────────────────────────────────
+
+    #[test]
+    fn rewrite_preserves_trailing_newline() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("test.yml");
+        std::fs::write(&file, "line1\nline2\n").unwrap();
+        let count = rewrite_actions(&file, &[(1, "replaced".to_string())]).unwrap();
+        assert_eq!(count, 1);
+        let result = std::fs::read_to_string(&file).unwrap();
+        assert!(result.ends_with('\n'));
+        assert_eq!(result, "replaced\nline2\n");
+    }
+
+    #[test]
+    fn rewrite_no_trailing_newline() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("test.yml");
+        std::fs::write(&file, "line1\nline2").unwrap();
+        let count = rewrite_actions(&file, &[(1, "replaced".to_string())]).unwrap();
+        assert_eq!(count, 1);
+        let result = std::fs::read_to_string(&file).unwrap();
+        assert!(!result.ends_with('\n'));
+    }
+
+    #[test]
+    fn rewrite_out_of_bounds_skipped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("test.yml");
+        std::fs::write(&file, "line1\n").unwrap();
+        let count = rewrite_actions(&file, &[(99, "nope".to_string())]).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn rewrite_empty_replacements() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("test.yml");
+        std::fs::write(&file, "line1\n").unwrap();
+        let count = rewrite_actions(&file, &[]).unwrap();
+        assert_eq!(count, 0);
+    }
 }
 
 /// Format a file path relative to the repo root for display.

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -1,0 +1,478 @@
+mod common;
+
+use predicates::prelude::*;
+
+// ── Exit codes ──────────────────────────────────────────────────────────────
+
+#[test]
+fn clean_workflow_exits_zero() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn clean_workflow_human_output() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No runtime fetch risks found."));
+}
+
+#[test]
+fn pipe_to_shell_exits_one() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PIPE_TO_SHELL);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn pipe_to_shell_json_fields() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PIPE_TO_SHELL);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["severity"], "high");
+    assert_eq!(findings[0]["category"], "shell_fetch");
+    assert!(findings[0]["line"].is_number());
+}
+
+#[test]
+fn curl_latest_finding() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CURL_LATEST);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["severity"], "high");
+}
+
+#[test]
+fn versioned_url_is_clean() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_VERSIONED);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn data_format_exempt() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_DATA_FORMAT);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn checksum_downgrade() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CHECKSUM);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // Still a finding, but severity should be downgraded from high to medium.
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["severity"], "medium");
+    assert!(
+        findings[0]["description"]
+            .as_str()
+            .unwrap()
+            .contains("checksum verified")
+    );
+}
+
+#[test]
+fn multiple_findings() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_MULTI_FINDINGS);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(
+        findings.len() >= 2,
+        "expected at least 2 findings, got {}",
+        findings.len()
+    );
+
+    // Findings should be sorted high-first.
+    let severities: Vec<&str> = findings
+        .iter()
+        .map(|f| f["severity"].as_str().unwrap())
+        .collect();
+    for window in severities.windows(2) {
+        let order = |s: &str| match s {
+            "high" => 0,
+            "medium" => 1,
+            _ => 2,
+        };
+        assert!(
+            order(window[0]) <= order(window[1]),
+            "findings not sorted by severity: {:?}",
+            severities
+        );
+    }
+}
+
+#[test]
+fn empty_workflow() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_EMPTY);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn multiple_workflow_files() {
+    let dir = common::repo_with_workflows(&[
+        ("clean.yml", common::WORKFLOW_CLEAN),
+        ("risky.yml", common::WORKFLOW_PIPE_TO_SHELL),
+    ]);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+}
+
+// ── Missing workflows directory ─────────────────────────────────────────────
+
+#[test]
+fn missing_workflows_dir_exits_two() {
+    let dir = tempfile::TempDir::new().unwrap();
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "No .github/workflows/ directory found",
+        ));
+}
+
+#[test]
+fn missing_workflows_dir_json() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("No .github/workflows/ directory found")
+    );
+}
+
+// ── Token status ────────────────────────────────────────────────────────────
+
+#[test]
+fn no_token_json_had_token_false() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["had_token"], false);
+}
+
+// ── SARIF output ────────────────────────────────────────────────────────────
+
+#[test]
+fn sarif_valid_structure() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg("--sarif")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert!(
+        json["$schema"]
+            .as_str()
+            .unwrap()
+            .contains("sarif-schema-2.1.0")
+    );
+    assert_eq!(json["version"], "2.1.0");
+
+    let runs = json["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0]["tool"]["driver"]["name"], "pinprick");
+
+    let rules = runs[0]["tool"]["driver"]["rules"].as_array().unwrap();
+    assert!(!rules.is_empty());
+    for rule in rules {
+        assert!(rule["id"].is_string());
+        assert!(rule["name"].is_string());
+        assert!(rule["shortDescription"]["text"].is_string());
+        assert!(rule["fullDescription"]["text"].is_string());
+    }
+}
+
+#[test]
+fn sarif_findings_mapped() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PIPE_TO_SHELL);
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg("--sarif")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let results = json["runs"][0]["results"].as_array().unwrap();
+    assert!(!results.is_empty());
+    for result in results {
+        assert!(result["ruleId"].is_string());
+        assert!(result["level"].is_string());
+        assert!(result["message"]["text"].is_string());
+        assert!(result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"].is_string());
+        assert!(result["locations"][0]["physicalLocation"]["region"]["startLine"].is_number());
+    }
+}
+
+#[test]
+fn sarif_no_findings() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg("--sarif")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let results = json["runs"][0]["results"].as_array().unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn sarif_takes_precedence_over_json() {
+    // When both --json and --sarif are passed, SARIF output wins.
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg("--sarif")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["version"], "2.1.0");
+}
+
+// ── Verbose output ──────────────────────────────────────────────────────────
+
+#[test]
+fn verbose_shows_allowed() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_VERSIONED);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg("--verbose")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("OK"));
+}
+
+#[test]
+fn verbose_json_includes_allowed() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_VERSIONED);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg("--verbose")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let allowed = json["allowed"].as_array().unwrap();
+    assert!(
+        !allowed.is_empty(),
+        "expected allowed matches for versioned URL"
+    );
+}
+
+// ── Config integration ──────────────────────────────────────────────────────
+
+#[test]
+fn config_severity_high_filters_lower() {
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_MULTI_FINDINGS,
+        "severity = \"high\"\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(
+        findings.iter().all(|f| f["severity"] == "high"),
+        "expected only high findings when severity=high"
+    );
+}
+
+#[test]
+fn config_ignore_patterns() {
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_PIPE_TO_SHELL,
+        "[ignore]\npatterns = [\"piped to shell\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(
+        findings.is_empty(),
+        "expected finding to be suppressed by ignore.patterns"
+    );
+}
+
+#[test]
+fn config_trusted_hosts() {
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_TRUSTED_HOST,
+        "trusted-hosts = [\"artifacts.internal.example.com\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(
+        findings.is_empty(),
+        "expected trusted host to suppress finding"
+    );
+}
+
+#[test]
+fn config_extra_data_formats() {
+    let workflow = "\
+name: proto
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -L https://example.com/schema.proto -o schema.proto
+";
+    let dir = common::repo_with_config("ci.yml", workflow, "extra-data-formats = [\"proto\"]\n");
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(
+        findings.is_empty(),
+        "expected .proto to be exempt via extra-data-formats"
+    );
+}

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -1,0 +1,39 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn human_output() {
+    common::pinprick_cmd()
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Cache cleaned.")
+                .or(predicate::str::contains("Nothing to clean.")),
+        );
+}
+
+#[test]
+fn json_output() {
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("clean")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["cleaned"].is_boolean());
+}
+
+#[test]
+fn always_exits_zero() {
+    common::pinprick_cmd().arg("clean").assert().success();
+}
+
+#[test]
+fn idempotent() {
+    common::pinprick_cmd().arg("clean").assert().success();
+    common::pinprick_cmd().arg("clean").assert().success();
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,75 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn version_flag() {
+    common::pinprick_cmd()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("pinprick 0."));
+}
+
+#[test]
+fn help_flag() {
+    common::pinprick_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "GitHub Actions supply chain security",
+        ));
+}
+
+#[test]
+fn help_subcommand() {
+    common::pinprick_cmd()
+        .arg("help")
+        .arg("audit")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Audit actions for runtime fetch risks",
+        ));
+}
+
+#[test]
+fn no_subcommand_exits_two() {
+    // pinprick with no subcommand prints usage to stderr and exits 2.
+    // Must build a command without `--color never` since there's no subcommand
+    // to attach global flags to. clap treats this as an error.
+    let mut cmd = assert_cmd::Command::cargo_bin("pinprick").unwrap();
+    cmd.env("GITHUB_TOKEN", "");
+    cmd.assert()
+        .code(2)
+        .stderr(predicate::str::contains("Usage:"));
+}
+
+#[test]
+fn unknown_subcommand_exits_two() {
+    let mut cmd = assert_cmd::Command::cargo_bin("pinprick").unwrap();
+    cmd.env("GITHUB_TOKEN", "");
+    cmd.arg("bogus")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn json_flag_is_global() {
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("clean")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.get("cleaned").is_some());
+}
+
+#[test]
+fn color_never_flag() {
+    common::pinprick_cmd().arg("clean").assert().success();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,156 @@
+#![allow(dead_code)]
+
+use std::fs;
+use tempfile::TempDir;
+
+/// Create a temporary repo directory with one workflow file.
+pub fn repo_with_workflow(filename: &str, content: &str) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let workflows = dir.path().join(".github").join("workflows");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(workflows.join(filename), content).unwrap();
+    dir
+}
+
+/// Create a temporary repo directory with multiple workflow files.
+pub fn repo_with_workflows(files: &[(&str, &str)]) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let workflows = dir.path().join(".github").join("workflows");
+    fs::create_dir_all(&workflows).unwrap();
+    for (name, content) in files {
+        fs::write(workflows.join(name), content).unwrap();
+    }
+    dir
+}
+
+/// Create a temporary repo directory with a workflow file and a `.pinprick.toml` config.
+pub fn repo_with_config(filename: &str, workflow: &str, config: &str) -> TempDir {
+    let dir = repo_with_workflow(filename, workflow);
+    fs::write(dir.path().join(".pinprick.toml"), config).unwrap();
+    dir
+}
+
+/// Build an `assert_cmd::Command` for pinprick with token stripped, colors off,
+/// and HOME pointed at a temp location to avoid global config interference.
+pub fn pinprick_cmd() -> assert_cmd::Command {
+    let mut cmd = assert_cmd::Command::cargo_bin("pinprick").unwrap();
+    cmd.env("GITHUB_TOKEN", "");
+    cmd.env("GH_TOKEN", "");
+    cmd.env("HOME", "/tmp/pinprick-test-home");
+    cmd.env("XDG_CONFIG_HOME", "/tmp/pinprick-test-config");
+    cmd.arg("--color").arg("never");
+    cmd
+}
+
+// ── Workflow fixtures ───────────────────────────────────────────────────────
+
+/// A clean workflow: SHA-pinned action, safe run block. Expect zero findings.
+pub const WORKFLOW_CLEAN: &str = "\
+name: clean
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: echo \"Hello World\"
+";
+
+/// Pipe-to-shell: curl piped to bash. Expect one high-severity finding.
+pub const WORKFLOW_PIPE_TO_SHELL: &str = "\
+name: risky
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -fsSL https://example.com/install.sh | bash
+";
+
+/// Curl with /latest/ in URL. Expect one high-severity finding.
+pub const WORKFLOW_CURL_LATEST: &str = "\
+name: curl-latest
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -L \"https://github.com/owner/repo/releases/latest/download/tool\" -o tool
+";
+
+/// Curl with versioned URL. Expect zero findings.
+pub const WORKFLOW_VERSIONED: &str = "\
+name: versioned
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -L \"https://github.com/owner/repo/releases/download/v1.2.3/tool\" -o tool
+";
+
+/// Curl fetching a JSON file. Expect data-format exemption (no finding).
+pub const WORKFLOW_DATA_FORMAT: &str = "\
+name: data
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -L https://example.com/api/data.json -o data.json
+";
+
+/// Multiple finding categories in one workflow.
+pub const WORKFLOW_MULTI_FINDINGS: &str = "\
+name: multi
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          curl -fsSL https://example.com/install.sh | bash
+          go install golang.org/x/tools/gopls@latest
+          pip install requests
+";
+
+/// Curl with checksum verification on the next line.
+pub const WORKFLOW_CHECKSUM: &str = "\
+name: checksum
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          curl -L \"https://github.com/owner/repo/releases/latest/download/tool\" -o tool
+          sha256sum --check tool.sha256
+";
+
+/// Curl with unversioned URL hitting a trusted host.
+pub const WORKFLOW_TRUSTED_HOST: &str = "\
+name: trusted
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -L https://artifacts.internal.example.com/tool -o tool
+";
+
+/// Empty steps list. Expect zero findings.
+pub const WORKFLOW_EMPTY: &str = "\
+name: empty
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: []
+";

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -1,0 +1,53 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn bash() {
+    common::pinprick_cmd()
+        .arg("completions")
+        .arg("bash")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pinprick"));
+}
+
+#[test]
+fn zsh() {
+    common::pinprick_cmd()
+        .arg("completions")
+        .arg("zsh")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pinprick"));
+}
+
+#[test]
+fn fish() {
+    common::pinprick_cmd()
+        .arg("completions")
+        .arg("fish")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pinprick"));
+}
+
+#[test]
+fn powershell() {
+    common::pinprick_cmd()
+        .arg("completions")
+        .arg("powershell")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn invalid_shell_exits_two() {
+    common::pinprick_cmd()
+        .arg("completions")
+        .arg("invalid_shell")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/tests/pin.rs
+++ b/tests/pin.rs
@@ -1,0 +1,45 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn no_token_exits_two() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("No GitHub token found"));
+}
+
+#[test]
+fn no_token_human_error() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("gh auth login"));
+}
+
+#[test]
+fn no_token_json_error() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("pin")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("No GitHub token found")
+    );
+}

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -1,0 +1,34 @@
+mod common;
+
+use predicates::prelude::*;
+
+#[test]
+fn no_token_exits_two() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("update")
+        .arg(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("No GitHub token found"));
+}
+
+#[test]
+fn no_token_json_error() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("update")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("No GitHub token found")
+    );
+}


### PR DESCRIPTION
## Summary

- Add 45 integration tests across 6 test files (cli, audit, clean, completions, pin, update) using assert_cmd + predicates + tempfile
- Add 38 new unit tests targeting uncovered code paths in audit.rs, output.rs, workflow.rs, and update.rs
- Fix thread-safety issue in audit summary test helper (strip ANSI codes instead of toggling global colored override)
- Line coverage: 77% → 81%