### PR TITLE
ci: add cargo-deny for license and advisory enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
         if: matrix.check == 'lint'
         run: cargo install typos-cli --locked
 
+      - name: Install cargo-deny
+        if: matrix.check == 'lint'
+        run: cargo install cargo-deny --locked
+
       - name: Clippy
         if: matrix.check == 'lint'
         run: cargo clippy -- -D warnings
@@ -172,6 +176,10 @@ jobs:
       - name: Typos
         if: matrix.check == 'lint'
         run: typos
+
+      - name: Cargo deny
+        if: matrix.check == 'lint'
+        run: cargo deny check
 
       # --- Test ---
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,29 @@
+[licenses]
+allow = [
+    "AGPL-3.0-only",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+]
+confidence-threshold = 0.95
+
+# r-efi is LGPL-2.1-or-later but only compiled on UEFI targets —
+# never linked into pinprick on macOS/Linux.
+[[licenses.exceptions]]
+allow = ["LGPL-2.1-or-later"]
+name = "r-efi"
+
+[advisories]
+
+[sources]
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/justfile
+++ b/justfile
@@ -146,6 +146,11 @@ check:
     else
         skip typos typos typos-cli
     fi
+    if command -v cargo-deny &>/dev/null; then
+        run cargo deny check
+    else
+        skip cargo-deny cargo-deny cargo-deny
+    fi
     if command -v zizmor &>/dev/null; then
         run zizmor --persona auditor .github/workflows/
     else


### PR DESCRIPTION
## Summary

- Add `deny.toml` with an allowlist of AGPL-3.0-compatible licenses and RustSec advisory checks
- Add `cargo deny check` to the justfile `check` recipe and CI lint job
- Restrict dependency sources to crates.io only