### PR TITLE
fix: filter non-action releases from update and audit-actions scan

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -99,7 +99,9 @@ jobs:
               LATEST="${TAG}"
               LATEST_SHA="${TAG_SHA}"
             else
-              LATEST=$(gh api "repos/${OWNER}/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null || echo "")
+              LATEST=$(gh api "repos/${OWNER}/${REPO}/releases?per_page=10" \
+                --jq '[.[] | select(.draft == false and .prerelease == false and (.tag_name | test("^v")))][0].tag_name' \
+                2>/dev/null || echo "")
               if [[ -z "${LATEST}" ]]; then
                 echo "  No releases found, skipping"
                 continue

--- a/src/update.rs
+++ b/src/update.rs
@@ -65,7 +65,9 @@ pub async fn run(
                 }
             };
 
-            let latest = releases.iter().find(|r| !r.draft && !r.prerelease);
+            let latest = releases
+                .iter()
+                .find(|r| !r.draft && !r.prerelease && r.tag_name.starts_with('v'));
 
             let latest = match latest {
                 Some(r) => r,


### PR DESCRIPTION
## Summary

- Filter release discovery to `v`-prefixed tags so non-action releases (e.g. `codeql-bundle-v2.25.1` from `github/codeql-action`) are skipped
- Applies to both the audit-actions workflow (`/releases` list with jq filter) and the `update` command (`starts_with('v')` guard)