### PR TITLE
fix: audit multiple releases per scan and improve version filtering

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -58,6 +58,23 @@ jobs:
           INPUT_ACTION: ${{ inputs.action }}
           INPUT_REF: ${{ inputs.ref }}
         run: |
+          # Resolve a tag to its commit SHA, dereferencing annotated tags.
+          resolve_tag_sha() {
+            local owner="$1" repo="$2" tag="$3"
+            local sha obj_type
+            sha=$(gh api "repos/${owner}/${repo}/git/ref/tags/${tag}" --jq '.object.sha' 2>/dev/null || echo "")
+            [[ -z "${sha}" ]] && return
+            obj_type=$(gh api "repos/${owner}/${repo}/git/ref/tags/${tag}" --jq '.object.type' 2>/dev/null || echo "commit")
+            if [[ "${obj_type}" == "tag" ]]; then
+              sha=$(gh api "repos/${owner}/${repo}/git/tags/${sha}" --jq '.object.sha' 2>/dev/null || echo "${sha}")
+            fi
+            echo "${sha}"
+          }
+
+          # Filter: non-draft, non-prerelease, tag looks like a version number.
+          # Rejects non-action tags like codeql-bundle-v2.25.1.
+          VERSION_FILTER='.[] | select(.draft == false and .prerelease == false and (.tag_name | test("^v?\\d"))) | .tag_name'
+
           UPDATED=0
           if [[ -n "${INPUT_ACTION}" ]]; then
             if [[ "${INPUT_ACTION}" != */* ]]; then
@@ -77,6 +94,7 @@ jobs:
             echo "--- ${OWNER}/${REPO} ---"
 
             if [[ -n "${INPUT_REF}" && -n "${INPUT_ACTION}" ]]; then
+              # Specific ref: resolve and audit exactly this tag/SHA.
               TAG="${INPUT_REF}"
               if [[ "${TAG}" =~ ^[0-9a-f]{40}$ ]] || [[ "${TAG}" =~ ^[0-9a-f]{7}$ ]]; then
                 TAG_SHA=$(gh api "repos/${OWNER}/${REPO}/commits/${TAG}" --jq '.sha' 2>/dev/null || echo "")
@@ -86,70 +104,74 @@ jobs:
                 fi
                 TAG="sha:${TAG_SHA:0:7}"
               else
-                TAG_SHA=$(gh api "repos/${OWNER}/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null || echo "")
+                TAG_SHA=$(resolve_tag_sha "${OWNER}" "${REPO}" "${TAG}")
                 if [[ -z "${TAG_SHA}" ]]; then
                   echo "  Could not resolve ref '${TAG}', skipping"
                   continue
                 fi
-                OBJ_TYPE=$(gh api "repos/${OWNER}/${REPO}/git/ref/tags/${TAG}" --jq '.object.type' 2>/dev/null || echo "commit")
-                if [[ "${OBJ_TYPE}" == "tag" ]]; then
-                  TAG_SHA=$(gh api "repos/${OWNER}/${REPO}/git/tags/${TAG_SHA}" --jq '.object.sha' 2>/dev/null || echo "${TAG_SHA}")
-                fi
               fi
-              LATEST="${TAG}"
-              LATEST_SHA="${TAG_SHA}"
+              TAGS=("${TAG}")
+              declare -A TAG_SHAS=(["${TAG}"]="${TAG_SHA}")
+            elif [[ -n "${INPUT_ACTION}" ]]; then
+              # Backfill: paginate all releases for this action.
+              readarray -t TAGS < <(gh api --paginate "repos/${OWNER}/${REPO}/releases" \
+                --jq "${VERSION_FILTER}" 2>/dev/null)
             else
-              LATEST=$(gh api "repos/${OWNER}/${REPO}/releases?per_page=10" \
-                --jq '[.[] | select(.draft == false and .prerelease == false and (.tag_name | test("^v")))][0].tag_name' \
-                2>/dev/null || echo "")
-              if [[ -z "${LATEST}" ]]; then
-                echo "  No releases found, skipping"
-                continue
-              fi
-
-              LATEST_SHA=$(gh api "repos/${OWNER}/${REPO}/git/ref/tags/${LATEST}" --jq '.object.sha' 2>/dev/null || echo "")
-              if [[ -z "${LATEST_SHA}" ]]; then
-                echo "  Could not resolve ${LATEST}, skipping"
-                continue
-              fi
-
-              OBJ_TYPE=$(gh api "repos/${OWNER}/${REPO}/git/ref/tags/${LATEST}" --jq '.object.type' 2>/dev/null || echo "commit")
-              if [[ "${OBJ_TYPE}" == "tag" ]]; then
-                LATEST_SHA=$(gh api "repos/${OWNER}/${REPO}/git/tags/${LATEST_SHA}" --jq '.object.sha' 2>/dev/null || echo "${LATEST_SHA}")
-              fi
+              # Weekly scan: check recent releases only.
+              readarray -t TAGS < <(gh api "repos/${OWNER}/${REPO}/releases?per_page=10" \
+                --jq "${VERSION_FILTER}" 2>/dev/null)
             fi
 
-            if jq -e ".[] | select(.sha == \"${LATEST_SHA}\")" "${JSON_FILE}" > /dev/null 2>&1; then
-              echo "  ${LATEST} already audited"
+            if [[ ${#TAGS[@]} -eq 0 ]]; then
+              echo "  No releases found, skipping"
               continue
             fi
 
-            echo "  New release: ${LATEST} (${LATEST_SHA:0:7})"
+            for TAG in "${TAGS[@]}"; do
+              # Resolve tag to SHA (skip if already resolved in the specific-ref path).
+              if [[ -z "${TAG_SHAS["${TAG}"]+x}" ]]; then
+                TAG_SHA=$(resolve_tag_sha "${OWNER}" "${REPO}" "${TAG}")
+                if [[ -z "${TAG_SHA}" ]]; then
+                  echo "  Could not resolve ${TAG}, skipping"
+                  continue
+                fi
+              else
+                TAG_SHA="${TAG_SHAS["${TAG}"]}"
+              fi
 
-            TMPDIR=$(mktemp -d)
-            mkdir -p "${TMPDIR}/.github/workflows"
-            cat > "${TMPDIR}/.github/workflows/test.yml" <<YAML
+              if jq -e ".[] | select(.sha == \"${TAG_SHA}\")" "${JSON_FILE}" > /dev/null 2>&1; then
+                echo "  ${TAG} already audited"
+                continue
+              fi
+
+              echo "  New release: ${TAG} (${TAG_SHA:0:7})"
+
+              TMPDIR=$(mktemp -d)
+              mkdir -p "${TMPDIR}/.github/workflows"
+              cat > "${TMPDIR}/.github/workflows/test.yml" <<YAML
           name: test
           on: push
           jobs:
             test:
               runs-on: ubuntu-latest
               steps:
-                - uses: ${OWNER}/${REPO}@${LATEST_SHA} # ${LATEST}
+                - uses: ${OWNER}/${REPO}@${TAG_SHA} # ${TAG}
           YAML
 
-            if ./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null; then
-              echo "  Clean — adding ${LATEST}"
-              jq -r --arg sha "${LATEST_SHA}" --arg tag "${LATEST}" '
-                (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end) as $u |
-                "[\n" + ([$u[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
-              ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
-              mv "${JSON_FILE}.tmp" "${JSON_FILE}"
-              UPDATED=1
-            else
-              echo "  Findings detected — skipping ${LATEST}"
-            fi
-            rm -rf "${TMPDIR}"
+              if ./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null; then
+                echo "  Clean — adding ${TAG}"
+                jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
+                  (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end) as $u |
+                  "[\n" + ([$u[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
+                ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
+                mv "${JSON_FILE}.tmp" "${JSON_FILE}"
+                UPDATED=1
+              else
+                echo "  Findings detected — skipping ${TAG}"
+              fi
+              rm -rf "${TMPDIR}"
+            done
+            unset TAG_SHAS
           done
 
           echo "updated=${UPDATED}" >> "${GITHUB_OUTPUT}"

--- a/src/update.rs
+++ b/src/update.rs
@@ -65,9 +65,27 @@ pub async fn run(
                 }
             };
 
+            // Filter to tags that look like version numbers (rejects non-action
+            // releases like codeql-bundle-*) and pick the highest version rather
+            // than the most-recently-created release (handles backport releases
+            // like v3.1.0-node20 published after v8.0.1).
             let latest = releases
                 .iter()
-                .find(|r| !r.draft && !r.prerelease && r.tag_name.starts_with('v'));
+                .filter(|r| {
+                    !r.draft
+                        && !r.prerelease
+                        && r.tag_name
+                            .strip_prefix('v')
+                            .unwrap_or(&r.tag_name)
+                            .starts_with(|c: char| c.is_ascii_digit())
+                })
+                .reduce(|best, r| {
+                    if is_newer(&best.tag_name, &r.tag_name) {
+                        r
+                    } else {
+                        best
+                    }
+                });
 
             let latest = match latest {
                 Some(r) => r,


### PR DESCRIPTION
## Summary

- Audit all unaudited action releases per scan instead of just one — weekly scans check the 10 most recent, manual dispatch without a ref paginates all releases for a full backfill
- Widen the tag filter from `^v` to `^v?\d` so it matches any version-like tag while still rejecting non-action releases like `codeql-bundle-*`
- Use version comparison (`reduce` with `is_newer`) instead of creation order to find the latest release in the `update` command, so backport releases like `v3.1.0-node20` published after `v8.0.1` don't get picked
- Extract tag-to-SHA resolution into a `resolve_tag_sha` helper to deduplicate across code paths