### PR TITLE
fix(audit-actions): initialize TAG_SHAS before mode selection

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -92,6 +92,7 @@ jobs:
             OWNER=$(basename "$(dirname "${JSON_FILE}")")
             REPO=$(basename "${JSON_FILE}" .json)
             echo "--- ${OWNER}/${REPO} ---"
+            declare -A TAG_SHAS=()
 
             if [[ -n "${INPUT_REF}" && -n "${INPUT_ACTION}" ]]; then
               # Specific ref: resolve and audit exactly this tag/SHA.


### PR DESCRIPTION
## Summary

- Initialize `TAG_SHAS` as an empty associative array at the top of each loop iteration so the backfill and weekly paths don't hit a syntax error when checking the subscript