### PR TITLE
fix(audit-actions): sort entries by version when writing

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -162,8 +162,9 @@ jobs:
               if ./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null; then
                 echo "  Clean — adding ${TAG}"
                 jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
-                  (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end) as $u |
-                  "[\n" + ([$u[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
+                  (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end)
+                  | sort_by(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)) | reverse
+                  | "[\n" + ([.[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
                 ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
                 mv "${JSON_FILE}.tmp" "${JSON_FILE}"
                 UPDATED=1


### PR DESCRIPTION
## Summary

- Sort audited-actions JSON entries by version components descending (newest first) when writing, so backfill runs produce readable, ordered output instead of API creation-date order