### PR TITLE
ci: verify audited-actions entries are sorted by version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,20 @@ jobs:
 
       # --- Verify Audited Actions ---
 
+      - name: Check sort order
+        if: matrix.check == 'verify-audited'
+        run: |
+          FAILED=0
+          for JSON_FILE in audited-actions/*/*.json; do
+            SORTED=$(jq 'sort_by(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)) | reverse' "${JSON_FILE}")
+            ACTUAL=$(jq '.' "${JSON_FILE}")
+            if [[ "${SORTED}" != "${ACTUAL}" ]]; then
+              echo "::error::${JSON_FILE} is not sorted by version"
+              FAILED=1
+            fi
+          done
+          exit "${FAILED}"
+
       - name: Build pinprick
         if: matrix.check == 'verify-audited'
         run: cargo build --release


### PR DESCRIPTION
## Summary

- Add a sort-order check to the Verify Audited Actions CI job that fails if any JSON file has entries out of version-descending order