### PR TITLE
fix(audit-actions): add tag name as sort tiebreaker

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -160,7 +160,7 @@ jobs:
                 echo "  Clean — adding ${TAG}"
                 jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
                   (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end)
-                  | sort_by(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)) | reverse
+                  | sort_by([(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)), .tag]) | reverse
                   | "[\n" + ([.[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
                 ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
                 mv "${JSON_FILE}.tmp" "${JSON_FILE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         run: |
           FAILED=0
           for JSON_FILE in audited-actions/*/*.json; do
-            SORTED=$(jq 'sort_by(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)) | reverse' "${JSON_FILE}")
+            SORTED=$(jq 'sort_by([(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)), .tag]) | reverse' "${JSON_FILE}")
             ACTUAL=$(jq '.' "${JSON_FILE}")
             if [[ "${SORTED}" != "${ACTUAL}" ]]; then
               echo "::error::${JSON_FILE} is not sorted by version"


### PR DESCRIPTION
## Summary

- Use the tag name as a secondary sort key so tags with identical numeric versions (e.g. `v3.1.0` and `v3.1.0-node20`) produce deterministic order, fixing a CI lint mismatch