### PR TITLE
fix: update rustls-webpki to 0.103.12 for RUSTSEC-2026-0098 and RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,9 +1269,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Update `rustls-webpki` 0.103.10 → 0.103.12 to resolve two advisory disclosures:
  - [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098): URI name constraints incorrectly accepted
  - [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099): wildcard name constraints incorrectly accepted