### PR TITLE
feat(audit): detect unpinned git clone, cargo install, and gem install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ pinprick/
 
 Six categories of runtime fetch detection:
 - **Pipe-to-shell:** `curl`/`wget` piped into `sh`/`bash`/`python`, `bash <(curl …)` process substitution, `bash -c "$(curl …)"` / `eval "$(…)"` command substitution, PowerShell `iex (iwr …)` / `Invoke-Expression (… DownloadString …)`. Flagged high severity regardless of URL versioning.
-- **Shell:** `curl`/`wget`/`gh release download` with unversioned URLs, `go install @latest`, unpinned `pip`/`npm` installs
+- **Shell:** `curl`/`wget`/`gh release download` with unversioned URLs, `git clone` without a pinned ref, `go install @latest`, unpinned `pip`/`npm`/`cargo install`/`gem install` installs
 - **PowerShell:** `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` with unversioned URLs
 - **JavaScript:** `fetch()`/`axios`/`got`/`http.get` with unversioned URLs, `exec()`/`child_process` shelling out to curl
 - **Python:** `urllib.request.urlopen`/`requests.get` with unversioned URLs, `subprocess` shelling out to curl/wget
@@ -83,6 +83,8 @@ URL "versioned" heuristic: a URL is considered versioned if any path segment mat
 Data-format exemption: unversioned-URL rules (shell, JS, Python) do **not** fire when the URL's path ends in a data-format extension (`.json`/`.jsonl`/`.ndjson`, `.yaml`/`.yml`/`.toml`, `.csv`/`.tsv`/`.xml`, `.txt`/`.md`/`.rst`). Matches are recorded as allowed (visible under `--verbose`) with reason `data format URL`. Applies only to the unversioned-URL rules — `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension. `.html` and `.svg` are intentionally excluded because both can carry embedded scripts.
 
 Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
+
+Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name (main, develop, feature/foo) is flagged medium severity. `--branch v1.2.3` (version-like ref) suppresses the finding. A `git checkout <40-char-SHA>` within 3 lines fully suppresses the finding (recorded as allowed, visible under `--verbose`), since the SHA checkout deterministically pins the repo content.
 
 ### Exit codes
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -162,6 +162,39 @@ Not flagged:
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
 ```
 
+### git clone without a pinned ref
+
+**Severity:** Medium
+
+Triggers on `git clone` without `--branch`/`-b` or with a branch name that doesn't look like a version tag.
+
+```bash
+git clone https://github.com/org/repo
+git clone --branch main https://github.com/org/repo
+git clone -b develop https://github.com/org/repo
+```
+
+Not flagged:
+
+```bash
+git clone --branch v1.2.3 https://github.com/org/repo
+git clone -b 2.0.1 https://github.com/org/repo
+git clone --depth 1 --branch v1.2.3 https://github.com/org/repo
+```
+
+A bare `git clone` defaults to HEAD of the default branch, which is mutable. Pinning to a version tag via `--branch` makes the clone deterministic (at least to the tag level).
+
+**SHA checkout suppression:** if `git checkout <40-character-SHA>` appears within 3 lines after an unpinned `git clone`, the finding is fully suppressed (recorded as an allowed match visible under `--verbose`). The SHA checkout deterministically pins the repository content.
+
+```bash
+# This produces zero findings:
+git clone https://github.com/org/repo
+cd repo
+git checkout abcdef1234567890abcdef1234567890abcdef12
+```
+
+Also flagged in Dockerfile `RUN` instructions under the `pinprick/docker_unpinned` rule.
+
 ### pip install without a version pin
 
 **Severity:** Low
@@ -196,6 +229,41 @@ Not flagged:
 ```bash
 npm install typescript@5.6.0
 npm install    # no package argument — uses package-lock.json
+```
+
+### cargo install without a version pin
+
+**Severity:** Low
+
+Triggers on `cargo install <crate>` where `<crate>` has no `@version` specifier and no `--version` flag.
+
+```bash
+cargo install ripgrep
+```
+
+Not flagged:
+
+```bash
+cargo install ripgrep@14.0.0
+cargo install ripgrep --version 14.0.0
+cargo install    # no crate argument — uses Cargo.toml
+```
+
+### gem install without a version pin
+
+**Severity:** Low
+
+Triggers on `gem install <gem>` where `<gem>` has no `-v` version specifier.
+
+```bash
+gem install rubocop
+```
+
+Not flagged:
+
+```bash
+gem install rubocop -v 1.0.0
+gem install    # no gem argument
 ```
 
 ## PowerShell fetches

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -6,9 +6,9 @@ use std::process::ExitCode;
 
 use crate::audit_patterns::{
     self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS,
-    PY_URL_PATTERNS, Pattern, SH_GH_RELEASE_LATEST, SHELL_PATTERNS, SHELL_PIPE_PATTERNS,
-    SHELL_URL_PATTERNS, category_str, extract_url, gh_release_has_tag, has_checksum_verify,
-    url_has_version,
+    PY_URL_PATTERNS, Pattern, SH_GH_RELEASE_LATEST, SH_GIT_CLONE, SHELL_PATTERNS,
+    SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, category_str, extract_url, gh_release_has_tag,
+    git_clone_has_pinned_ref, has_checksum_verify, has_git_checkout_sha, url_has_version,
 };
 use crate::audited_actions::{AuditSource, AuditedActions};
 use crate::auth;
@@ -361,6 +361,36 @@ fn scan_shell_content(
                 workflow_line: None,
             });
         }
+
+        if SH_GIT_CLONE.is_match(line) && !git_clone_has_pinned_ref(line) {
+            let has_sha_checkout = (1..=3)
+                .any(|offset| i + offset < lines.len() && has_git_checkout_sha(lines[i + offset]));
+
+            if has_sha_checkout {
+                collector.push_allowed(AuditMatch {
+                    severity: output::severity_str(&audit_patterns::Severity::Medium).to_string(),
+                    category: category_str(&audit_patterns::Category::ShellFetch).to_string(),
+                    action: action_name.to_string(),
+                    source_file: source_file.to_string(),
+                    line: Some(line_num),
+                    pattern_matched: line.trim().to_string(),
+                    reason: "followed by SHA checkout".to_string(),
+                });
+            } else {
+                collector.push_finding(AuditFinding {
+                    severity: output::severity_str(&audit_patterns::Severity::Medium).to_string(),
+                    category: category_str(&audit_patterns::Category::ShellFetch).to_string(),
+                    action: action_name.to_string(),
+                    source_file: source_file.to_string(),
+                    line: Some(line_num),
+                    pattern_matched: line.trim().to_string(),
+                    description: "git clone without pinned ref — clones HEAD of default branch"
+                        .to_string(),
+                    workflow_file: None,
+                    workflow_line: None,
+                });
+            }
+        }
     }
 
     // Downgrade severity for findings followed by checksum verification.
@@ -531,6 +561,20 @@ fn scan_dockerfile_content(
             collector,
             config,
         );
+
+        if SH_GIT_CLONE.is_match(line) && !git_clone_has_pinned_ref(line) {
+            collector.push_finding(AuditFinding {
+                severity: output::severity_str(&audit_patterns::Severity::Medium).to_string(),
+                category: category_str(&audit_patterns::Category::DockerUnpinned).to_string(),
+                action: action_name.to_string(),
+                source_file: source_file.to_string(),
+                line: Some(line_num),
+                pattern_matched: line.trim().to_string(),
+                description: "git clone in Dockerfile without pinned ref".to_string(),
+                workflow_file: None,
+                workflow_line: None,
+            });
+        }
     }
 }
 
@@ -1356,8 +1400,8 @@ runs:
     #[test]
     fn short_sha_full() {
         assert_eq!(
-            short_sha("abc1234567890abcdef1234567890abcdef123456"),
-            "abc1234"
+            short_sha("abcdef1234567890abcdef1234567890abcdef12"),
+            "abcdef1"
         );
     }
 
@@ -1429,5 +1473,95 @@ runs:
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
+    }
+
+    // ── git clone ─────────────────────────────────────────────────────
+
+    #[test]
+    fn git_clone_unpinned_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "git clone https://github.com/org/repo",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("git clone"));
+    }
+
+    #[test]
+    fn git_clone_versioned_branch_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "git clone --branch v1.2.3 https://github.com/org/repo",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn git_clone_main_branch_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "git clone --branch main https://github.com/org/repo",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn git_clone_depth_one_versioned_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "git clone --depth 1 --branch v1.2.3 https://github.com/org/repo",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn git_clone_followed_by_sha_checkout_is_allowed() {
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            "git clone https://github.com/org/repo\ncd repo\ngit checkout abcdef1234567890abcdef1234567890abcdef12",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "followed by SHA checkout");
+    }
+
+    #[test]
+    fn git_clone_sha_checkout_beyond_three_lines_still_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "git clone https://github.com/org/repo\necho 1\necho 2\necho 3\ngit checkout abcdef1234567890abcdef1234567890abcdef12",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -71,6 +71,17 @@ re!(
     r"(?i)\b(iex|Invoke-Expression)\b.*\b(iwr|Invoke-WebRequest|Invoke-RestMethod|irm|DownloadString)\b"
 );
 
+re!(SH_GIT_CLONE, r"git\s+clone\s");
+re!(GIT_CHECKOUT_SHA, r"git\s+checkout\s+[0-9a-f]{40}\b");
+re!(
+    SH_CARGO_INSTALL_UNVERSIONED,
+    r"cargo\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+);
+re!(
+    SH_GEM_INSTALL_UNVERSIONED,
+    r"gem\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+);
+
 pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![
         Pattern {
@@ -108,6 +119,18 @@ pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Low,
             category: Category::ShellFetch,
             description: "npm install without version pin",
+        },
+        Pattern {
+            regex: &SH_CARGO_INSTALL_UNVERSIONED,
+            severity: Severity::Low,
+            category: Category::ShellFetch,
+            description: "cargo install without --version pin",
+        },
+        Pattern {
+            regex: &SH_GEM_INSTALL_UNVERSIONED,
+            severity: Severity::Low,
+            category: Category::ShellFetch,
+            description: "gem install without version pin",
         },
     ]
 });
@@ -430,6 +453,33 @@ pub fn gh_release_has_tag(line: &str) -> bool {
     static GH_RELEASE_TAG: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"gh\s+release\s+download\s+(v?\d|--tag\s+v?\d)").unwrap());
     GH_RELEASE_TAG.is_match(line)
+}
+
+/// Check if a ref argument looks like a version tag rather than a branch name.
+/// Returns true for: v1.2.3, 1.2.3, release/1.0.0 (contains version segment).
+/// Returns false for: main, master, develop, feature/foo.
+fn ref_looks_versioned(ref_name: &str) -> bool {
+    static VERSION_REF: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"v?\d+(\.\d+)+").unwrap());
+    VERSION_REF.is_match(ref_name)
+}
+
+/// Check if a `git clone` line has a pinned ref via `--branch`/`-b`.
+///
+/// `git clone --branch v1.2.3 ...` is pinned.
+/// `git clone -b main ...` is not.
+/// `git clone ...` (no branch flag) is not.
+pub fn git_clone_has_pinned_ref(line: &str) -> bool {
+    static GIT_CLONE_BRANCH: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"git\s+clone\s+.*(?:--branch|-b)\s+(\S+)").unwrap());
+    let Some(caps) = GIT_CLONE_BRANCH.captures(line) else {
+        return false;
+    };
+    ref_looks_versioned(&caps[1])
+}
+
+/// Check if a line contains a `git checkout <full-SHA>`.
+pub fn has_git_checkout_sha(line: &str) -> bool {
+    GIT_CHECKOUT_SHA.is_match(line)
 }
 
 pub fn category_str(c: &Category) -> &'static str {
@@ -1047,5 +1097,146 @@ mod tests {
     #[test]
     fn no_checksum() {
         assert!(!has_checksum_verify("echo done"));
+    }
+
+    // ── git clone patterns ─────────────────────────────────────────────
+
+    #[test]
+    fn git_clone_basic_detected() {
+        assert!(SH_GIT_CLONE.is_match("git clone https://github.com/org/repo"));
+    }
+
+    #[test]
+    fn git_clone_with_depth_detected() {
+        assert!(SH_GIT_CLONE.is_match("git clone --depth 1 https://github.com/org/repo"));
+    }
+
+    #[test]
+    fn git_clone_with_branch_detected() {
+        assert!(SH_GIT_CLONE.is_match("git clone --branch main https://github.com/org/repo"));
+    }
+
+    #[test]
+    fn git_clone_pinned_versioned_branch() {
+        assert!(git_clone_has_pinned_ref(
+            "git clone --branch v1.2.3 https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_pinned_short_flag() {
+        assert!(git_clone_has_pinned_ref(
+            "git clone -b v1.2.3 https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_pinned_no_v_prefix() {
+        assert!(git_clone_has_pinned_ref(
+            "git clone --branch 2.0.1 https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_pinned_release_branch_with_version() {
+        assert!(git_clone_has_pinned_ref(
+            "git clone --branch release/1.0.0 https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_pinned_depth_one_versioned() {
+        assert!(git_clone_has_pinned_ref(
+            "git clone --depth 1 --branch v1.2.3 https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_unpinned_main() {
+        assert!(!git_clone_has_pinned_ref(
+            "git clone --branch main https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_unpinned_master() {
+        assert!(!git_clone_has_pinned_ref(
+            "git clone -b master https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_unpinned_develop() {
+        assert!(!git_clone_has_pinned_ref(
+            "git clone -b develop https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_unpinned_feature_branch() {
+        assert!(!git_clone_has_pinned_ref(
+            "git clone --branch feature/my-feature https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_clone_no_branch_flag() {
+        assert!(!git_clone_has_pinned_ref(
+            "git clone https://github.com/org/repo"
+        ));
+    }
+
+    #[test]
+    fn git_checkout_sha_detected() {
+        assert!(has_git_checkout_sha(
+            "git checkout abcdef1234567890abcdef1234567890abcdef12"
+        ));
+    }
+
+    #[test]
+    fn git_checkout_branch_not_sha() {
+        assert!(!has_git_checkout_sha("git checkout main"));
+    }
+
+    #[test]
+    fn git_checkout_short_sha_not_matched() {
+        assert!(!has_git_checkout_sha("git checkout abc1234"));
+    }
+
+    // ── cargo/gem install patterns ─────────────────────────────────────
+
+    #[test]
+    fn cargo_install_unversioned_detected() {
+        assert!(SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install ripgrep"));
+    }
+
+    #[test]
+    fn cargo_install_versioned_not_flagged() {
+        assert!(!SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install ripgrep@14.0.0"));
+    }
+
+    #[test]
+    fn cargo_install_with_version_flag_not_flagged() {
+        assert!(!SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install ripgrep --version 14.0.0"));
+    }
+
+    #[test]
+    fn cargo_install_no_args_not_flagged() {
+        assert!(!SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install"));
+    }
+
+    #[test]
+    fn gem_install_unversioned_detected() {
+        assert!(SH_GEM_INSTALL_UNVERSIONED.is_match("gem install rubocop"));
+    }
+
+    #[test]
+    fn gem_install_versioned_not_flagged() {
+        assert!(!SH_GEM_INSTALL_UNVERSIONED.is_match("gem install rubocop -v 1.0.0"));
+    }
+
+    #[test]
+    fn gem_install_no_args_not_flagged() {
+        assert!(!SH_GEM_INSTALL_UNVERSIONED.is_match("gem install"));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -527,7 +527,7 @@ const SARIF_RULES: &[RuleDef] = &[
         id: "pinprick/shell_fetch",
         name: "ShellFetch",
         short: "Shell runtime fetch without pinning",
-        full: "Shell commands (curl, wget, gh release download, go install, pip, npm, PowerShell Invoke-WebRequest) that download content at runtime without pinning to a specific version. These bypass action SHA pinning.",
+        full: "Shell commands (curl, wget, gh release download, git clone, go install, pip, npm, cargo install, gem install, PowerShell Invoke-WebRequest) that download content at runtime without pinning to a specific version. These bypass action SHA pinning.",
     },
     RuleDef {
         id: "pinprick/javascript_fetch",

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -476,3 +476,46 @@ jobs:
         "expected .proto to be exempt via extra-data-formats"
     );
 }
+
+// ── git clone ─────────────────────────────────────────────────────────────
+
+#[test]
+fn git_clone_unpinned_finding() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_GIT_CLONE);
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["severity"], "medium");
+    assert!(
+        findings[0]["description"]
+            .as_str()
+            .unwrap()
+            .contains("git clone")
+    );
+}
+
+#[test]
+fn git_clone_versioned_branch_clean() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_GIT_CLONE_VERSIONED);
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert!(findings.is_empty());
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -154,3 +154,29 @@ jobs:
     runs-on: ubuntu-latest
     steps: []
 ";
+
+/// git clone without pinned ref. Expect one medium-severity finding.
+pub const WORKFLOW_GIT_CLONE: &str = "\
+name: git-clone
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          git clone https://github.com/org/repo
+          cd repo && make install
+";
+
+/// git clone with versioned --branch. Expect zero findings.
+pub const WORKFLOW_GIT_CLONE_VERSIONED: &str = "\
+name: git-clone-versioned
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: git clone --depth 1 --branch v1.2.3 https://github.com/org/repo
+";


### PR DESCRIPTION
## Summary

- Add `git clone` detection: flags clones without a pinned ref (medium severity), suppresses when `--branch`/`-b` has a version-like tag, or when `git checkout <SHA>` follows within 3 lines
- Add `cargo install` and `gem install` without version pin detection (low severity), matching the existing `pip`/`npm` patterns
- Detect `RUN git clone` in Dockerfiles under the `docker_unpinned` category
- Update SARIF rule description and detections reference docs