### PR TITLE
ci: separate lint tools cache from build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,20 +97,30 @@ jobs:
           fetch-depth: ${{ matrix.fetch_depth || 1 }}
           persist-credentials: false
 
-      # --- Cargo cache ---
+      # --- Cargo caches ---
 
-      - name: Restore cargo cache (debug)
+      - name: Restore cargo build cache
         if: matrix.check == 'lint' || matrix.check == 'test'
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
+
+      - name: Restore lint tools cache
+        if: matrix.check == 'lint'
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-
 
       # --- Conventional Commits ---
 
@@ -191,17 +201,26 @@ jobs:
         if: matrix.check == 'lint'
         run: cargo deny check
 
-      - name: Save cargo cache
+      - name: Save cargo build cache
         if: matrix.check == 'lint' && github.event_name == 'push'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Save lint tools cache
+        if: matrix.check == 'lint' && github.event_name == 'push'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('**/Cargo.lock') }}
 
       # --- Test ---
 


### PR DESCRIPTION
## Summary

- Split the single cargo cache into two: a **build cache** (registry + target, shared by lint and test) and a **tools cache** (bin + crates metadata, lint only)
- Add `~/.cargo/.crates.toml` and `~/.cargo/.crates2.json` to the tools cache so `cargo install` can detect already-installed tools and skip recompilation
- Test jobs no longer restore lint tool binaries they don't use