### PR TITLE
feat(audit): detect package installs with trailing flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,11 @@ jobs:
 
       - name: Install typos-cli
         if: matrix.check == 'lint'
-        run: cargo install typos-cli --locked
+        run: cargo install typos-cli --locked --version 1.45.1
 
       - name: Install cargo-deny
         if: matrix.check == 'lint'
-        run: cargo install cargo-deny --locked
+        run: cargo install cargo-deny --locked --version 0.19.4
 
       - name: Clippy
         if: matrix.check == 'lint'

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -199,17 +199,20 @@ Also flagged in Dockerfile `RUN` instructions under the `pinprick/docker_unpinne
 
 **Severity:** Low
 
-Triggers on `pip install <package>` where `<package>` has no `==`/`>=` specifier and is the last argument.
+Triggers on `pip install <package>` where `<package>` has no `==`/`>=`/`~=` specifier and the line is not a `-r requirements.txt` install.
 
 ```bash
 pip install requests
 pip3 install flask
+pip install requests --quiet
+pip install requests --user
 ```
 
 Not flagged:
 
 ```bash
 pip install requests==2.31.0
+pip install requests>=2.0
 pip install -r requirements.txt
 ```
 
@@ -217,17 +220,19 @@ pip install -r requirements.txt
 
 **Severity:** Low
 
-Triggers on `npm install <package>` where `<package>` has no `@version` specifier.
+Triggers on `npm install <package>` where `<package>` has no `@version` specifier (a digit after `@`). Scoped packages like `@babel/core` are not version-pinned; `@babel/core@1.0.0` is.
 
 ```bash
 npm install typescript
 npm install @babel/core
+npm install typescript --save-dev
 ```
 
 Not flagged:
 
 ```bash
 npm install typescript@5.6.0
+npm install @babel/core@1.0.0
 npm install    # no package argument — uses package-lock.json
 ```
 
@@ -235,10 +240,12 @@ npm install    # no package argument — uses package-lock.json
 
 **Severity:** Low
 
-Triggers on `cargo install <crate>` where `<crate>` has no `@version` specifier and no `--version` flag.
+Triggers on `cargo install <crate>` where the line has neither `@version` on the crate name nor a `--version` flag. Note: `--locked` pins the crate's _dependencies_ via its lockfile, not the crate's own version, so it does not suppress this finding.
 
 ```bash
 cargo install ripgrep
+cargo install typos-cli --locked
+cargo install cargo-deny --locked
 ```
 
 Not flagged:
@@ -253,16 +260,18 @@ cargo install    # no crate argument — uses Cargo.toml
 
 **Severity:** Low
 
-Triggers on `gem install <gem>` where `<gem>` has no `-v` version specifier.
+Triggers on `gem install <gem>` where the line has neither `-v <version>` nor `--version <version>`.
 
 ```bash
 gem install rubocop
+gem install rubocop --no-document
 ```
 
 Not flagged:
 
 ```bash
 gem install rubocop -v 1.0.0
+gem install rubocop --version 1.0.0
 gem install    # no gem argument
 ```
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -6,9 +6,11 @@ use std::process::ExitCode;
 
 use crate::audit_patterns::{
     self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS,
-    PY_URL_PATTERNS, Pattern, SH_GH_RELEASE_LATEST, SH_GIT_CLONE, SHELL_PATTERNS,
-    SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, category_str, extract_url, gh_release_has_tag,
-    git_clone_has_pinned_ref, has_checksum_verify, has_git_checkout_sha, url_has_version,
+    PY_URL_PATTERNS, Pattern, SH_CARGO_INSTALL_UNVERSIONED, SH_GEM_INSTALL_UNVERSIONED,
+    SH_GH_RELEASE_LATEST, SH_GIT_CLONE, SH_NPM_UNVERSIONED, SH_PIP_UNVERSIONED, SHELL_PATTERNS,
+    SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, cargo_install_has_version, category_str, extract_url,
+    gem_install_has_version, gh_release_has_tag, git_clone_has_pinned_ref, has_checksum_verify,
+    has_git_checkout_sha, npm_install_has_version, pip_install_has_version, url_has_version,
 };
 use crate::audited_actions::{AuditSource, AuditedActions};
 use crate::auth;
@@ -391,6 +393,47 @@ fn scan_shell_content(
                 });
             }
         }
+
+        if SH_PIP_UNVERSIONED.is_match(line) && !pip_install_has_version(line) {
+            push_pkg_finding(
+                "pip install without version pin",
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if SH_NPM_UNVERSIONED.is_match(line) && !npm_install_has_version(line) {
+            push_pkg_finding(
+                "npm install without version pin",
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if SH_CARGO_INSTALL_UNVERSIONED.is_match(line) && !cargo_install_has_version(line) {
+            push_pkg_finding(
+                "cargo install without --version pin",
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if SH_GEM_INSTALL_UNVERSIONED.is_match(line) && !gem_install_has_version(line) {
+            push_pkg_finding(
+                "gem install without version pin",
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
     }
 
     // Downgrade severity for findings followed by checksum verification.
@@ -576,6 +619,27 @@ fn scan_dockerfile_content(
             });
         }
     }
+}
+
+fn push_pkg_finding(
+    description: &str,
+    line: &str,
+    source_file: &str,
+    line_num: usize,
+    action_name: &str,
+    collector: &mut AuditCollector,
+) {
+    collector.push_finding(AuditFinding {
+        severity: output::severity_str(&audit_patterns::Severity::Low).to_string(),
+        category: category_str(&audit_patterns::Category::ShellFetch).to_string(),
+        action: action_name.to_string(),
+        source_file: source_file.to_string(),
+        line: Some(line_num),
+        pattern_matched: line.trim().to_string(),
+        description: description.to_string(),
+        workflow_file: None,
+        workflow_line: None,
+    });
 }
 
 fn check_url_patterns(

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -38,11 +38,11 @@ re!(SH_CURL_UNVERSIONED, r#"curl\b.*https?://[^\s"']+"#);
 re!(SH_WGET_UNVERSIONED, r#"wget\b.*https?://[^\s"']+"#);
 re!(
     SH_PIP_UNVERSIONED,
-    r"pip3?\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+    r"pip3?\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
 );
 re!(
     SH_NPM_UNVERSIONED,
-    r"npm\s+install\s+(@[a-zA-Z][a-zA-Z0-9_-]*/)?[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+    r"npm\s+install\s+(@[a-zA-Z][a-zA-Z0-9_-]*/)?[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
 );
 re!(SH_GO_INSTALL_LATEST, r"go\s+install\s+\S+@latest");
 re!(
@@ -75,11 +75,11 @@ re!(SH_GIT_CLONE, r"git\s+clone\s");
 re!(GIT_CHECKOUT_SHA, r"git\s+checkout\s+[0-9a-f]{40}\b");
 re!(
     SH_CARGO_INSTALL_UNVERSIONED,
-    r"cargo\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+    r"cargo\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
 );
 re!(
     SH_GEM_INSTALL_UNVERSIONED,
-    r"gem\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*\s*$"
+    r"gem\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
 );
 
 pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
@@ -107,30 +107,6 @@ pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "PowerShell fetching from a 'latest' URL — can change without notice",
-        },
-        Pattern {
-            regex: &SH_PIP_UNVERSIONED,
-            severity: Severity::Low,
-            category: Category::ShellFetch,
-            description: "pip install without version pin",
-        },
-        Pattern {
-            regex: &SH_NPM_UNVERSIONED,
-            severity: Severity::Low,
-            category: Category::ShellFetch,
-            description: "npm install without version pin",
-        },
-        Pattern {
-            regex: &SH_CARGO_INSTALL_UNVERSIONED,
-            severity: Severity::Low,
-            category: Category::ShellFetch,
-            description: "cargo install without --version pin",
-        },
-        Pattern {
-            regex: &SH_GEM_INSTALL_UNVERSIONED,
-            severity: Severity::Low,
-            category: Category::ShellFetch,
-            description: "gem install without version pin",
         },
     ]
 });
@@ -480,6 +456,37 @@ pub fn git_clone_has_pinned_ref(line: &str) -> bool {
 /// Check if a line contains a `git checkout <full-SHA>`.
 pub fn has_git_checkout_sha(line: &str) -> bool {
     GIT_CHECKOUT_SHA.is_match(line)
+}
+
+/// Check if a `pip install` line has a version specifier or uses `-r`.
+pub fn pip_install_has_version(line: &str) -> bool {
+    static PIP_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"pip3?\s+install\s+\S*[=>~]=|pip3?\s+install\s+-r\s").unwrap()
+    });
+    PIP_VERSION.is_match(line)
+}
+
+/// Check if an `npm install` line has a version pin (`@version` after the package name).
+/// Scoped packages (`@babel/core`) are not version-pinned; `@babel/core@1.0.0` is.
+pub fn npm_install_has_version(line: &str) -> bool {
+    static NPM_VERSION: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"npm\s+install\s+\S+@\d").unwrap());
+    NPM_VERSION.is_match(line)
+}
+
+/// Check if a `cargo install` line has a version pin (`@version` or `--version`).
+pub fn cargo_install_has_version(line: &str) -> bool {
+    static CARGO_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"cargo\s+install\s+\S+@\d|cargo\s+install\s+.*--version\s").unwrap()
+    });
+    CARGO_VERSION.is_match(line)
+}
+
+/// Check if a `gem install` line has a version pin (`-v` or `--version`).
+pub fn gem_install_has_version(line: &str) -> bool {
+    static GEM_VERSION: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"gem\s+install\s+.*(-v\s+\d|--version\s)").unwrap());
+    GEM_VERSION.is_match(line)
 }
 
 pub fn category_str(c: &Category) -> &'static str {
@@ -1211,13 +1218,9 @@ mod tests {
     }
 
     #[test]
-    fn cargo_install_versioned_not_flagged() {
-        assert!(!SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install ripgrep@14.0.0"));
-    }
-
-    #[test]
-    fn cargo_install_with_version_flag_not_flagged() {
-        assert!(!SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install ripgrep --version 14.0.0"));
+    fn cargo_install_with_flags_detected() {
+        assert!(SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install typos-cli --locked"));
+        assert!(SH_CARGO_INSTALL_UNVERSIONED.is_match("cargo install cargo-deny --locked"));
     }
 
     #[test]
@@ -1231,12 +1234,92 @@ mod tests {
     }
 
     #[test]
-    fn gem_install_versioned_not_flagged() {
-        assert!(!SH_GEM_INSTALL_UNVERSIONED.is_match("gem install rubocop -v 1.0.0"));
+    fn gem_install_with_flags_detected() {
+        assert!(SH_GEM_INSTALL_UNVERSIONED.is_match("gem install rubocop --no-document"));
     }
 
     #[test]
     fn gem_install_no_args_not_flagged() {
         assert!(!SH_GEM_INSTALL_UNVERSIONED.is_match("gem install"));
+    }
+
+    // ── pip/npm install with trailing flags ─────────────────────────────
+
+    #[test]
+    fn pip_install_with_flags_detected() {
+        assert!(SH_PIP_UNVERSIONED.is_match("pip install requests --quiet"));
+        assert!(SH_PIP_UNVERSIONED.is_match("pip3 install flask --user"));
+    }
+
+    #[test]
+    fn npm_install_with_flags_detected() {
+        assert!(SH_NPM_UNVERSIONED.is_match("npm install typescript --save-dev"));
+        assert!(SH_NPM_UNVERSIONED.is_match("npm install @babel/core --save-dev"));
+    }
+
+    // ── version-pin check functions ────────────────────────────────────
+
+    #[test]
+    fn pip_version_pinned() {
+        assert!(pip_install_has_version("pip install requests==2.31.0"));
+        assert!(pip_install_has_version("pip install requests>=2.0"));
+        assert!(pip_install_has_version("pip install requests~=2.31"));
+        assert!(pip_install_has_version("pip install -r requirements.txt"));
+    }
+
+    #[test]
+    fn pip_version_not_pinned() {
+        assert!(!pip_install_has_version("pip install requests"));
+        assert!(!pip_install_has_version("pip install requests --quiet"));
+    }
+
+    #[test]
+    fn npm_version_pinned() {
+        assert!(npm_install_has_version("npm install typescript@5.6.0"));
+        assert!(npm_install_has_version("npm install @babel/core@1.0.0"));
+    }
+
+    #[test]
+    fn npm_version_not_pinned() {
+        assert!(!npm_install_has_version("npm install typescript"));
+        assert!(!npm_install_has_version("npm install @babel/core"));
+        assert!(!npm_install_has_version(
+            "npm install typescript --save-dev"
+        ));
+    }
+
+    #[test]
+    fn cargo_version_pinned() {
+        assert!(cargo_install_has_version("cargo install ripgrep@14.0.0"));
+        assert!(cargo_install_has_version(
+            "cargo install ripgrep --version 14.0.0"
+        ));
+    }
+
+    #[test]
+    fn cargo_version_not_pinned() {
+        assert!(!cargo_install_has_version("cargo install ripgrep"));
+        assert!(!cargo_install_has_version(
+            "cargo install typos-cli --locked"
+        ));
+        assert!(!cargo_install_has_version(
+            "cargo install cargo-deny --locked"
+        ));
+    }
+
+    #[test]
+    fn gem_version_pinned() {
+        assert!(gem_install_has_version("gem install rubocop -v 1.0.0"));
+        assert!(gem_install_has_version(
+            "gem install rubocop --version 1.0.0"
+        ));
+    }
+
+    #[test]
+    fn gem_version_not_pinned() {
+        assert!(!gem_install_has_version("gem install rubocop"));
+        assert!(!gem_install_has_version(
+            "gem install rubocop --no-document"
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Broaden the `pip`/`npm`/`cargo install`/`gem install` regexes to no longer require end-of-line, then use dedicated `*_install_has_version()` functions to filter out properly version-pinned commands. This catches cases like `cargo install typos-cli --locked` that the previous end-of-line anchor missed.
- Pin the `typos-cli` and `cargo-deny` versions in `ci.yml` since the project now flags its own previously-unpinned installs. A follow-up PR will add an automated workflow to bump these.