### PR TITLE
ci: automate cargo install tool version bumps

### DIFF
--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -1,0 +1,146 @@
+name: Bump Cargo Tools
+
+on:
+  schedule:
+    - cron: "31 7 * * 1"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+concurrency:
+  group: bump-cargo-tools
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  scan:
+    name: Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.bump.outputs.changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check for newer tool versions
+        id: bump
+        run: |
+          # Tools tracked in ci.yml. Each entry: crate name on crates.io.
+          TOOLS=("typos-cli" "cargo-deny")
+          CHANGED=0
+          for TOOL in "${TOOLS[@]}"; do
+            LATEST=$(curl -fsSL "https://crates.io/api/v1/crates/${TOOL}" | jq -r '.crate.max_stable_version')
+            if [[ -z "${LATEST}" || "${LATEST}" == "null" ]]; then
+              echo "::warning::Could not resolve latest version for ${TOOL}, skipping"
+              continue
+            fi
+
+            # Extract the currently pinned version, if any.
+            CURRENT=$(grep -oE "cargo install ${TOOL} --locked --version [0-9]+\.[0-9]+\.[0-9]+" .github/workflows/ci.yml | awk '{print $NF}' | head -1 || true)
+
+            if [[ "${LATEST}" == "${CURRENT}" ]]; then
+              echo "  ${TOOL}: up to date (${CURRENT})"
+              continue
+            fi
+
+            echo "  ${TOOL}: ${CURRENT:-<unpinned>} -> ${LATEST}"
+            if [[ -n "${CURRENT}" ]]; then
+              # Replace existing version pin.
+              sed -i "s|cargo install ${TOOL} --locked --version ${CURRENT}|cargo install ${TOOL} --locked --version ${LATEST}|" .github/workflows/ci.yml
+            else
+              # Add a version pin where there isn't one. Match `cargo install TOOL --locked`
+              # at end of line (no trailing flags after --locked).
+              sed -i "s|cargo install ${TOOL} --locked\$|cargo install ${TOOL} --locked --version ${LATEST}|" .github/workflows/ci.yml
+            fi
+            CHANGED=1
+          done
+          echo "changed=${CHANGED}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload updated workflow
+        if: steps.bump.outputs.changed == '1'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ci-yml
+          path: .github/workflows/ci.yml
+
+  update:
+    name: Update
+    needs: scan
+    if: needs.scan.outputs.changed == '1'
+    runs-on: ubuntu-slim
+    environment:
+      name: starhaven
+      deployment: false
+    permissions:
+      contents: read
+      actions: read # required by download-artifact
+    steps:
+      - name: Mint bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download updated workflow
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ci-yml
+          path: .github/workflows/
+
+      - name: Create signed commit and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          BOT_USER="${APP_SLUG}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
+          BASE_SHA=$(git rev-parse HEAD)
+          BRANCH="chore/bump-cargo-tools-$(date -u +%Y%m%d)"
+          TITLE="chore(ci): bump cargo-installed tool versions"
+          PR_BODY="Automated bump of cargo-installed lint tool versions in \`ci.yml\`."
+          COMMIT_BODY="Signed-off-by: ${BOT_USER} <${BOT_ID}+${BOT_USER}@users.noreply.github.com>"
+
+          CONTENT=$(base64 < .github/workflows/ci.yml | tr -d '\n')
+          ADDITIONS=$(jq -n --arg path ".github/workflows/ci.yml" --arg contents "${CONTENT}" \
+            '[{path: $path, contents: $contents}]')
+
+          gh api "repos/${REPOSITORY}/git/refs" -X POST \
+            -f "ref=refs/heads/${BRANCH}" \
+            -f "sha=${BASE_SHA}"
+
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg branch "${BRANCH}" \
+            --arg title "${TITLE}" \
+            --arg body "${COMMIT_BODY}" \
+            --arg head "${BASE_SHA}" \
+            --argjson additions "${ADDITIONS}" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: $title, body: $body },
+                  fileChanges: { additions: $additions },
+                  expectedHeadOid: $head
+                }
+              }
+            }' | gh api graphql --input -
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "${TITLE}" \
+            --body "${PR_BODY}"

--- a/.pinprick.toml
+++ b/.pinprick.toml
@@ -1,0 +1,9 @@
+# Hosts whose unversioned URL fetches are recorded as allowed matches.
+# Pinprick still records the match (visible under `--verbose`); it just
+# does not surface as a finding.
+#
+# - crates.io: the bump-cargo-tools workflow queries the registry API to
+#   resolve the latest stable version of each cargo-installed lint tool.
+#   Bad data from crates.io would only result in a reviewable PR being
+#   opened against `ci.yml`, not direct exploitation.
+trusted-hosts = ["crates.io"]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/bump-cargo-tools.yml` — weekly Monday cron + manual dispatch. Queries crates.io for the latest stable version of each tracked cargo-installed lint tool (`typos-cli`, `cargo-deny`), updates the pin in `ci.yml`, and opens a signed PR when a bump is available.
- Mirrors the scan/update pattern from `audit-actions.yml`, including the bot-token signed-commit flow.
- Add a minimal `.pinprick.toml` listing `crates.io` as a trusted host so the registry API fetch is an allowed match rather than a finding. The same trust applies to the `cargo install` commands themselves.

Pairs with #86, which introduces the version pins this workflow keeps current.