### PR TITLE
docs(CLAUDE): bump required co-author trailer to Opus 4.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
 
 All commits must:
 - Use `git commit -s` for DCO sign-off
-- Include a `Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>` trailer when authored with Claude
+- Include a `Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>` trailer when authored with Claude
 
 ## Git workflow
 


### PR DESCRIPTION
## Summary

Opus 4.7 is out; switch the required \`Co-authored-by\` trailer in \`CLAUDE.md\` so new commits are attributed to the current model.