### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Minor bump covering new audit detections added since 0.5.2 (`git clone`, `cargo install`, `gem install`, trailing-flags variant), plus a batch of audit/scanner fixes and a GitHub client that retries transient errors.