### PR TITLE
perf(pin,update): memoize GitHub API calls across workflows

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -44,7 +44,7 @@ struct MatchingRef {
     object: GitObject,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Release {
     pub tag_name: String,
     pub draft: bool,

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::ExitCode;
 
@@ -17,6 +18,8 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
         skipped: Vec::new(),
         applied: apply,
     };
+
+    let mut resolve_cache: HashMap<String, (String, String)> = HashMap::new();
 
     for file in &files {
         let display_name = workflow::display_path(file, repo_root);
@@ -39,6 +42,9 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
                     });
                 }
                 RefType::SlidingTag | RefType::Tag => {
+                    let cache_key =
+                        format!("{}/{}@{}", action.owner, action.repo, action.ref_string);
+
                     if !json {
                         eprint!(
                             "  Resolving {}@{}...",
@@ -46,22 +52,43 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
                             action.ref_string
                         );
                     }
-                    match client
-                        .resolve_tag(&action.owner, &action.repo, &action.ref_string)
-                        .await
-                    {
-                        Ok(sha) => {
-                            let tag = client
-                                .find_exact_tag(
-                                    &action.owner,
-                                    &action.repo,
-                                    &sha,
-                                    &action.ref_string,
-                                )
-                                .await;
-                            if !json {
-                                eprintln!(" done");
+
+                    let resolved = if let Some(hit) = resolve_cache.get(&cache_key) {
+                        if !json {
+                            eprintln!(" cached");
+                        }
+                        Ok(hit.clone())
+                    } else {
+                        match client
+                            .resolve_tag(&action.owner, &action.repo, &action.ref_string)
+                            .await
+                        {
+                            Ok(sha) => {
+                                let tag = client
+                                    .find_exact_tag(
+                                        &action.owner,
+                                        &action.repo,
+                                        &sha,
+                                        &action.ref_string,
+                                    )
+                                    .await;
+                                if !json {
+                                    eprintln!(" done");
+                                }
+                                resolve_cache.insert(cache_key, (sha.clone(), tag.clone()));
+                                Ok((sha, tag))
                             }
+                            Err(e) => {
+                                if !json {
+                                    eprintln!(" failed");
+                                }
+                                Err(e)
+                            }
+                        }
+                    };
+
+                    match resolved {
+                        Ok((sha, tag)) => {
                             if action.ref_type == RefType::SlidingTag {
                                 report.skipped.push(PinSkip {
                                     file: workflow::display_path(file, repo_root),
@@ -85,9 +112,6 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
                             }
                         }
                         Err(e) => {
-                            if !json {
-                                eprintln!(" failed");
-                            }
                             report.skipped.push(PinSkip {
                                 file: workflow::display_path(file, repo_root),
                                 action: format!("{}@{}", action.full_name(), action.ref_string),

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::ExitCode;
 
 use crate::auth;
-use crate::github::GitHubClient;
+use crate::github::{GitHubClient, Release};
 use crate::output::{UpdateReport, UpdateResult};
 use crate::workflow::{self, RefType};
 
@@ -22,6 +23,10 @@ pub async fn run(
         up_to_date: 0,
         applied: apply,
     };
+
+    let mut releases_cache: HashMap<String, Vec<Release>> = HashMap::new();
+    let mut releases_failed: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut tag_sha_cache: HashMap<String, String> = HashMap::new();
 
     for file in &files {
         let display_name = workflow::display_path(file, repo_root);
@@ -50,18 +55,35 @@ pub async fn run(
                 eprint!("  Checking {}@{}...", action.full_name(), current_tag);
             }
 
-            let releases = match client.list_releases(&action.owner, &action.repo).await {
-                Ok(r) => {
-                    if !json {
-                        eprintln!(" done");
-                    }
-                    r
+            let owner_repo = action.owner_repo();
+            if releases_failed.contains(&owner_repo) {
+                if !json {
+                    eprintln!(" skipped");
                 }
-                Err(_) => {
-                    if !json {
-                        eprintln!(" failed");
+                continue;
+            }
+
+            let releases = if let Some(cached) = releases_cache.get(&owner_repo) {
+                if !json {
+                    eprintln!(" cached");
+                }
+                cached.clone()
+            } else {
+                match client.list_releases(&action.owner, &action.repo).await {
+                    Ok(r) => {
+                        if !json {
+                            eprintln!(" done");
+                        }
+                        releases_cache.insert(owner_repo.clone(), r.clone());
+                        r
                     }
-                    continue;
+                    Err(_) => {
+                        if !json {
+                            eprintln!(" failed");
+                        }
+                        releases_failed.insert(owner_repo);
+                        continue;
+                    }
                 }
             };
 
@@ -105,12 +127,20 @@ pub async fn run(
                 continue;
             }
 
-            let new_sha = match client
-                .resolve_tag(&action.owner, &action.repo, &latest.tag_name)
-                .await
-            {
-                Ok(sha) => sha,
-                Err(_) => continue,
+            let tag_key = format!("{}@{}", owner_repo, latest.tag_name);
+            let new_sha = if let Some(cached) = tag_sha_cache.get(&tag_key) {
+                cached.clone()
+            } else {
+                match client
+                    .resolve_tag(&action.owner, &action.repo, &latest.tag_name)
+                    .await
+                {
+                    Ok(sha) => {
+                        tag_sha_cache.insert(tag_key, sha.clone());
+                        sha
+                    }
+                    Err(_) => continue,
+                }
             };
 
             report.updates.push(UpdateResult {


### PR DESCRIPTION
`pin` caches `resolve_tag` + `find_exact_tag` by (owner, repo, ref); `update` caches `list_releases` by (owner, repo) and `resolve_tag` by (owner, repo, tag). Re-checking pinprick.rs itself drops `list_releases` calls from 37 to 10.