### PR TITLE
feat(audit): detect four unpinned package-manager install patterns

### DIFF
--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -236,6 +236,48 @@ npm install @babel/core@1.0.0
 npm install    # no package argument — uses package-lock.json
 ```
 
+### npx without a version pin
+
+**Severity:** Medium
+
+Triggers on `npx <package>` (or `npx -p <package>`, `npx --package=<package>`) where no token on the line has an `@<digit>` version specifier. Rated higher than `npm install` because `npx` is fetch-and-execute with no lockfile: every CI run pulls whatever the registry currently resolves, and the resolved code runs immediately.
+
+```bash
+npx create-react-app my-app
+npx typescript
+npx -y @angular/cli new my-app
+npx --yes typescript
+```
+
+Not flagged:
+
+```bash
+npx typescript@5.6.0
+npx @angular/cli@17.0.0 new my-app
+npx -p typescript@5.6.0 tsc
+npx --package=typescript@5.6.0 tsc
+```
+
+### pip install git+URL without a ref
+
+**Severity:** Medium
+
+Triggers on `pip install git+https://…` (or `git+http://…`) where the VCS URL has no `@<ref>` suffix. Without a ref, pip installs from the repo's default branch at HEAD, which silently changes over time. Any ref — tag, branch name, or full SHA — suppresses the finding (mirrors `git clone --branch` handling: branch refs are accepted here rather than requiring a SHA).
+
+```bash
+pip install git+https://github.com/owner/repo.git
+pip install --user git+https://github.com/owner/repo.git
+pip3 install git+https://gitlab.example.com/team/tool.git
+```
+
+Not flagged:
+
+```bash
+pip install git+https://github.com/owner/repo.git@v1.2.3
+pip install git+https://github.com/owner/repo.git@main
+pip install git+https://github.com/owner/repo.git@abc1234567890abcdef1234567890abcdef123456
+```
+
 ### cargo install without a version pin
 
 **Severity:** Low
@@ -275,6 +317,24 @@ gem install rubocop --version 1.0.0
 gem install    # no gem argument
 ```
 
+### brew install --HEAD
+
+**Severity:** Medium
+
+Triggers on `brew install <pkg> --HEAD` (or `--head`). `--HEAD` ignores the formula's bottle/version and builds from the upstream repository's main branch, so the installed code silently changes between runs.
+
+```bash
+brew install ffmpeg --HEAD
+brew install imagemagick --head
+```
+
+Not flagged:
+
+```bash
+brew install ffmpeg
+brew install ffmpeg --with-chromaprint
+```
+
 ## PowerShell fetches
 
 Flagged in shell `run:` blocks that happen to be PowerShell.
@@ -301,6 +361,24 @@ Not flagged:
 
 ```powershell
 Invoke-WebRequest "https://example.com/releases/download/v1.2.3/tool"
+```
+
+### Install-Module / Install-Script without -RequiredVersion
+
+**Severity:** Medium
+
+Triggers on `Install-Module` or `Install-Script` without `-RequiredVersion <version>`. Only `-RequiredVersion` pins to a single release; `-MinimumVersion` and `-MaximumVersion` (alone or together) leave at least one end of the range unbounded and are not accepted as a pin.
+
+```powershell
+Install-Module -Name Pester -Force
+Install-Script -Name Get-WindowsAutoPilotInfo
+Install-Module -Name Pester -MinimumVersion 5.0.0
+```
+
+Not flagged:
+
+```powershell
+Install-Module -Name Pester -RequiredVersion 5.3.1 -Force
 ```
 
 ## JavaScript / TypeScript fetches

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -5,12 +5,15 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use crate::audit_patterns::{
-    self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS, PY_PATTERNS,
-    PY_URL_PATTERNS, Pattern, SH_CARGO_INSTALL_UNVERSIONED, SH_GEM_INSTALL_UNVERSIONED,
-    SH_GH_RELEASE_LATEST, SH_GIT_CLONE, SH_NPM_UNVERSIONED, SH_PIP_UNVERSIONED, SHELL_PATTERNS,
-    SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, cargo_install_has_version, category_str, extract_url,
-    gem_install_has_version, gh_release_has_tag, git_clone_has_pinned_ref, has_checksum_verify,
-    has_git_checkout_sha, npm_install_has_version, pip_install_has_version, url_has_version,
+    self, DOCKER_PATTERNS, DOCKER_URL_PATTERNS, JS_PATTERNS, JS_URL_PATTERNS,
+    PS_INSTALL_MODULE_UNVERSIONED, PY_PATTERNS, PY_URL_PATTERNS, Pattern,
+    SH_CARGO_INSTALL_UNVERSIONED, SH_GEM_INSTALL_UNVERSIONED, SH_GH_RELEASE_LATEST, SH_GIT_CLONE,
+    SH_NPM_UNVERSIONED, SH_NPX_UNVERSIONED, SH_PIP_GIT_URL_UNVERSIONED, SH_PIP_UNVERSIONED,
+    SHELL_PATTERNS, SHELL_PIPE_PATTERNS, SHELL_URL_PATTERNS, cargo_install_has_version,
+    category_str, extract_url, gem_install_has_version, gh_release_has_tag,
+    git_clone_has_pinned_ref, has_checksum_verify, has_git_checkout_sha, npm_install_has_version,
+    npx_has_version, pip_git_url_has_ref, pip_install_has_version, ps_install_has_required_version,
+    url_has_version,
 };
 use crate::audited_actions::{AuditSource, AuditedActions};
 use crate::auth;
@@ -466,6 +469,7 @@ fn scan_shell_content(
         if SH_PIP_UNVERSIONED.is_match(line) && !pip_install_has_version(line) {
             push_pkg_finding(
                 "pip install without version pin",
+                audit_patterns::Severity::Low,
                 line,
                 source_file,
                 line_num,
@@ -476,6 +480,7 @@ fn scan_shell_content(
         if SH_NPM_UNVERSIONED.is_match(line) && !npm_install_has_version(line) {
             push_pkg_finding(
                 "npm install without version pin",
+                audit_patterns::Severity::Low,
                 line,
                 source_file,
                 line_num,
@@ -486,6 +491,7 @@ fn scan_shell_content(
         if SH_CARGO_INSTALL_UNVERSIONED.is_match(line) && !cargo_install_has_version(line) {
             push_pkg_finding(
                 "cargo install without --version pin",
+                audit_patterns::Severity::Low,
                 line,
                 source_file,
                 line_num,
@@ -496,6 +502,40 @@ fn scan_shell_content(
         if SH_GEM_INSTALL_UNVERSIONED.is_match(line) && !gem_install_has_version(line) {
             push_pkg_finding(
                 "gem install without version pin",
+                audit_patterns::Severity::Low,
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if SH_NPX_UNVERSIONED.is_match(line) && !npx_has_version(line) {
+            push_pkg_finding(
+                "npx without version pin — fetches and executes latest on every run",
+                audit_patterns::Severity::Medium,
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if PS_INSTALL_MODULE_UNVERSIONED.is_match(line) && !ps_install_has_required_version(line) {
+            push_pkg_finding(
+                "PowerShell Install-Module/Install-Script without -RequiredVersion",
+                audit_patterns::Severity::Medium,
+                line,
+                source_file,
+                line_num,
+                action_name,
+                collector,
+            );
+        }
+        if SH_PIP_GIT_URL_UNVERSIONED.is_match(line) && !pip_git_url_has_ref(line) {
+            push_pkg_finding(
+                "pip install git+URL without @<ref> — tracks default branch HEAD",
+                audit_patterns::Severity::Medium,
                 line,
                 source_file,
                 line_num,
@@ -692,6 +732,7 @@ fn scan_dockerfile_content(
 
 fn push_pkg_finding(
     description: &str,
+    severity: audit_patterns::Severity,
     line: &str,
     source_file: &str,
     line_num: usize,
@@ -699,7 +740,7 @@ fn push_pkg_finding(
     collector: &mut AuditCollector,
 ) {
     collector.push_finding(AuditFinding {
-        severity: output::severity_str(&audit_patterns::Severity::Low).to_string(),
+        severity: output::severity_str(&severity).to_string(),
         category: category_str(&audit_patterns::Category::ShellFetch).to_string(),
         action: action_name.to_string(),
         source_file: source_file.to_string(),
@@ -1839,5 +1880,124 @@ runs:
             &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn shell_scan_npx_unversioned_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "npx create-react-app my-app",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("npx"));
+    }
+
+    #[test]
+    fn shell_scan_npx_version_pinned_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "npx typescript@5.6.0",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_brew_head_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "brew install ffmpeg --HEAD",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("--HEAD"));
+    }
+
+    #[test]
+    fn shell_scan_brew_install_without_head_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "brew install ffmpeg",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_ps_install_module_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "Install-Module -Name Pester -Force",
+            "test.ps1",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+    }
+
+    #[test]
+    fn shell_scan_ps_install_module_required_version_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "Install-Module -Name Pester -RequiredVersion 5.3.1 -Force",
+            "test.ps1",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_pip_git_url_unversioned_is_finding() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "pip install git+https://github.com/owner/repo.git",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("git+URL"));
+    }
+
+    #[test]
+    fn shell_scan_pip_git_url_with_ref_clean() {
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "pip install git+https://github.com/owner/repo.git@v1.2.3",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
     }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -81,6 +81,19 @@ re!(
     SH_GEM_INSTALL_UNVERSIONED,
     r"gem\s+install\s+[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
 );
+re!(
+    SH_NPX_UNVERSIONED,
+    r"\bnpx\s+(-\S+\s+)*(@[a-zA-Z][a-zA-Z0-9_-]*/)?[a-zA-Z][a-zA-Z0-9_-]*"
+);
+re!(SH_BREW_HEAD, r"(?i)\bbrew\s+install\b[^\n]*--head\b");
+re!(
+    PS_INSTALL_MODULE_UNVERSIONED,
+    r"(?i)\bInstall-(Module|Script)\b"
+);
+re!(
+    SH_PIP_GIT_URL_UNVERSIONED,
+    r"pip3?\s+install\b[^#\n]*\bgit\+https?://\S+"
+);
 
 pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![
@@ -107,6 +120,12 @@ pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "PowerShell fetching from a 'latest' URL — can change without notice",
+        },
+        Pattern {
+            regex: &SH_BREW_HEAD,
+            severity: Severity::Medium,
+            category: Category::ShellFetch,
+            description: "brew install --HEAD — builds from upstream main, bypasses pinning",
         },
     ]
 });
@@ -492,6 +511,27 @@ pub fn gem_install_has_version(line: &str) -> bool {
     static GEM_VERSION: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"gem\s+install\s+.*(-v\s+\d|--version\s)").unwrap());
     GEM_VERSION.is_match(line)
+}
+
+/// Check if an `npx` line has a version pin on any token (`@<version>`).
+pub fn npx_has_version(line: &str) -> bool {
+    static NPX_VERSION: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\bnpx\s+.*\S+@\d").unwrap());
+    NPX_VERSION.is_match(line)
+}
+
+/// Check if a PowerShell `Install-Module`/`Install-Script` line has `-RequiredVersion`.
+pub fn ps_install_has_required_version(line: &str) -> bool {
+    static PS_VERSION: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)-RequiredVersion\s+\S+").unwrap());
+    PS_VERSION.is_match(line)
+}
+
+/// Check if a `pip install git+https://...` line has a ref (`@<ref>`) on the git URL.
+pub fn pip_git_url_has_ref(line: &str) -> bool {
+    static GIT_URL_REF: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\bgit\+https?://\S+@\S+").unwrap());
+    GIT_URL_REF.is_match(line)
 }
 
 pub fn category_str(c: &Category) -> &'static str {
@@ -1326,5 +1366,149 @@ mod tests {
         assert!(!gem_install_has_version(
             "gem install rubocop --no-document"
         ));
+    }
+
+    // ── npx patterns ───────────────────────────────────────────────────
+
+    #[test]
+    fn npx_unversioned_detected() {
+        assert!(SH_NPX_UNVERSIONED.is_match("npx typescript"));
+        assert!(SH_NPX_UNVERSIONED.is_match("npx create-react-app my-app"));
+    }
+
+    #[test]
+    fn npx_scoped_unversioned_detected() {
+        assert!(SH_NPX_UNVERSIONED.is_match("npx @angular/cli new my-app"));
+    }
+
+    #[test]
+    fn npx_with_flags_detected() {
+        assert!(SH_NPX_UNVERSIONED.is_match("npx -y create-react-app my-app"));
+        assert!(SH_NPX_UNVERSIONED.is_match("npx --yes typescript"));
+    }
+
+    #[test]
+    fn npx_version_pinned_helper_suppresses() {
+        assert!(npx_has_version("npx typescript@5.6.0"));
+        assert!(npx_has_version("npx @angular/cli@17.0.0 new my-app"));
+        assert!(npx_has_version("npx -p typescript@5.6.0 tsc"));
+        assert!(npx_has_version("npx --package=typescript@5.6.0 tsc"));
+    }
+
+    #[test]
+    fn npx_version_not_pinned_helper() {
+        assert!(!npx_has_version("npx typescript"));
+        assert!(!npx_has_version("npx -y create-react-app"));
+        assert!(!npx_has_version("npx @angular/cli"));
+    }
+
+    // ── brew install --HEAD ────────────────────────────────────────────
+
+    #[test]
+    fn brew_install_head_detected() {
+        assert!(SH_BREW_HEAD.is_match("brew install ffmpeg --HEAD"));
+        assert!(SH_BREW_HEAD.is_match("brew install ffmpeg --head"));
+    }
+
+    #[test]
+    fn brew_install_head_with_other_flags_detected() {
+        assert!(SH_BREW_HEAD.is_match("brew install --with-flags ffmpeg --HEAD"));
+    }
+
+    #[test]
+    fn brew_install_without_head_not_flagged() {
+        assert!(!SH_BREW_HEAD.is_match("brew install ffmpeg"));
+        assert!(!SH_BREW_HEAD.is_match("brew install ffmpeg --with-chromaprint"));
+    }
+
+    // ── PowerShell Install-Module ──────────────────────────────────────
+
+    #[test]
+    fn ps_install_module_detected() {
+        assert!(PS_INSTALL_MODULE_UNVERSIONED.is_match("Install-Module -Name Pester -Force"));
+        assert!(PS_INSTALL_MODULE_UNVERSIONED.is_match("install-module PSReadLine"));
+    }
+
+    #[test]
+    fn ps_install_script_detected() {
+        assert!(
+            PS_INSTALL_MODULE_UNVERSIONED.is_match("Install-Script -Name Get-WindowsAutoPilotInfo")
+        );
+    }
+
+    #[test]
+    fn ps_install_required_version_helper() {
+        assert!(ps_install_has_required_version(
+            "Install-Module -Name Pester -RequiredVersion 5.3.1"
+        ));
+        assert!(ps_install_has_required_version(
+            "Install-Module Pester -requiredversion 5.3.1"
+        ));
+    }
+
+    #[test]
+    fn ps_install_minimum_version_not_accepted() {
+        // -MinimumVersion alone is unbounded above — not a real pin.
+        assert!(!ps_install_has_required_version(
+            "Install-Module -Name Pester -MinimumVersion 5.0.0"
+        ));
+    }
+
+    #[test]
+    fn ps_install_no_version_flag() {
+        assert!(!ps_install_has_required_version(
+            "Install-Module -Name Pester -Force"
+        ));
+    }
+
+    // ── pip install git+URL ────────────────────────────────────────────
+
+    #[test]
+    fn pip_install_git_url_detected() {
+        assert!(
+            SH_PIP_GIT_URL_UNVERSIONED
+                .is_match("pip install git+https://github.com/owner/repo.git")
+        );
+        assert!(
+            SH_PIP_GIT_URL_UNVERSIONED
+                .is_match("pip3 install git+https://github.com/owner/repo.git")
+        );
+    }
+
+    #[test]
+    fn pip_install_git_url_with_flags_detected() {
+        assert!(
+            SH_PIP_GIT_URL_UNVERSIONED
+                .is_match("pip install --user git+https://github.com/owner/repo.git")
+        );
+    }
+
+    #[test]
+    fn pip_install_git_url_with_ref_helper() {
+        assert!(pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@v1.2.3"
+        ));
+        assert!(pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@main"
+        ));
+        assert!(pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@abc1234567890abcdef1234567890abcdef123456"
+        ));
+    }
+
+    #[test]
+    fn pip_install_git_url_without_ref() {
+        assert!(!pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git"
+        ));
+        assert!(!pip_git_url_has_ref(
+            "pip install --user git+https://github.com/owner/repo.git"
+        ));
+    }
+
+    #[test]
+    fn pip_install_plain_package_not_git_url() {
+        assert!(!SH_PIP_GIT_URL_UNVERSIONED.is_match("pip install requests"));
+        assert!(!SH_PIP_GIT_URL_UNVERSIONED.is_match("pip install requests==2.31.0"));
     }
 }


### PR DESCRIPTION
Adds shell-scan detections for `npx <pkg>` without a version pin, `brew install --HEAD`, PowerShell `Install-Module`/`Install-Script` without `-RequiredVersion`, and `pip install git+https://…` without an `@<ref>` suffix — all Medium severity. `push_pkg_finding` now takes severity as a parameter so the existing pip/npm/cargo/gem Low callers and the three new Medium callers share one helper.