### PR TITLE
ci: run wrangler via npm script to satisfy audit

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         working-directory: site
-        run: npx wrangler deploy --config dist/server/wrangler.json
+        run: npm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "deploy": "wrangler deploy --config dist/server/wrangler.json",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
## Summary
- Add `deploy` script to `site/package.json` that runs `wrangler deploy --config dist/server/wrangler.json`
- Switch `.github/workflows/deploy-site.yml` from `npx wrangler …` to `npm run deploy`

`npx wrangler` was resolving to the locally-pinned binary (wrangler is in `site/devDependencies` and `npm ci` runs just before), but pinprick's audit couldn't see that statically. `npm run deploy` removes the fallback-to-fetch path and makes pinning verifiable from the workflow alone.

Closes code-scanning alert [#3](https://github.com/starhaven-io/pinprick/security/code-scanning/3).