### PR TITLE
ci: migrate CLOUDFLARE_ACCOUNT_ID and DEVELOPMENT_TEAM to variables

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -50,5 +50,5 @@ jobs:
         run: npm run deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           WRANGLER_SEND_METRICS: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.sign
         env:
           TARGET: ${{ matrix.target }}
-          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+          DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM }}
         run: |
           codesign --sign "Developer ID Application: Patrick Linnane (${DEVELOPMENT_TEAM})" \
             --options runtime \
@@ -92,7 +92,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           APPLE_ID: ${{ secrets.NOTARIZATION_APPLE_ID }}
           NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
-          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+          DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM }}
         run: |
           mkdir -p "${RUNNER_TEMP}/notarize-staging"
           cp "target/${TARGET}/release/pinprick" "${RUNNER_TEMP}/notarize-staging/"


### PR DESCRIPTION
Both the Cloudflare account ID and the Apple Team ID are public identifiers — not credentials — so per GitHub's recommendation for non-sensitive config, they should live as environment variables rather than secrets. Makes them visible in logs and removes the maintenance overhead of treating them as secret.