### PR TITLE
chore: add lychee broken-link checking (local + scheduled CI)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,46 @@
+name: Link Check
+
+on:
+  schedule:
+    - cron: "0 14 * * 1" # every Monday at 14:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: link-check
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+jobs:
+  lychee:
+    name: Check links
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install dependencies
+        working-directory: site
+        run: npm ci
+
+      - name: Build site
+        working-directory: site
+        run: npm run build
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: --config lychee.toml --root-dir ${{ github.workspace }}/site/dist/client './site/dist/client/**/*.html' README.md
+          fail: true

--- a/justfile
+++ b/justfile
@@ -121,6 +121,10 @@ site-install:
 site-preview:
     cd site && npm run preview
 
+# Check for broken links in the built site and README
+lychee: site-build
+    lychee --config lychee.toml --root-dir "$(pwd)/site/dist/client" 'site/dist/client/**/*.html' README.md
+
 # Check
 
 # Run all checks

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,8 @@
+# Configuration for https://github.com/lycheeverse/lychee
+# Checks links in the built Starlight docs site under `site/dist/client/`
+# and the repo root README.md.
+# Run: `just lychee` (requires `just site-build` first).
+
+max_concurrency = 20
+timeout = 20
+max_retries = 3


### PR DESCRIPTION
## Summary
- `lychee.toml` with sensible defaults.
- `just lychee` recipe that builds the site and scans `site/dist/client/**/*.html` plus `README.md`.
- `.github/workflows/link-check.yml` — scheduled weekly (Mondays, 14:00 UTC) + manual dispatch. Uses `lycheeverse/lychee-action` pinned to v2.8.0.

Currently clean: 0 errors across 286 links (276 from the Starlight site + 10 from the README). No SSR pages or cloud-blocked hosts to exclude, so the config is minimal.