### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,7 +917,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Prep for release. 12 commits since v0.6.1:
- **feat**: detect four new unpinned package-manager install patterns (#103)
- **chore**: lychee broken-link check + scheduled workflow, and the cask-bump job we just merged
- ci / deps: action bumps, bot-token refactor, CLOUDFLARE_ACCOUNT_ID + DEVELOPMENT_TEAM moved to variables