### PR TITLE
ci: add weekly Cargo.lock refresh workflow

### DIFF
--- a/.github/workflows/refresh-cargo-lockfile.yml
+++ b/.github/workflows/refresh-cargo-lockfile.yml
@@ -1,0 +1,121 @@
+name: Refresh Cargo Lockfile
+
+on:
+  schedule:
+    - cron: "47 7 * * 1"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+concurrency:
+  group: refresh-cargo-lockfile
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  scan:
+    name: Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.update.outputs.changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run cargo update
+        id: update
+        run: |
+          cargo update
+          if git diff --quiet Cargo.lock; then
+            echo "changed=0" >> "${GITHUB_OUTPUT}"
+          else
+            echo "changed=1" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Upload updated lockfile
+        if: steps.update.outputs.changed == '1'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cargo-lock
+          path: Cargo.lock
+
+  update:
+    name: Update
+    needs: scan
+    if: needs.scan.outputs.changed == '1'
+    runs-on: ubuntu-slim
+    environment:
+      name: starhaven
+      deployment: false
+    permissions:
+      contents: read
+      actions: read # required by download-artifact
+    steps:
+      - name: Mint bot token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download updated lockfile
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cargo-lock
+
+      - name: Create signed commit and open PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          BOT_USER="${APP_SLUG}[bot]"
+          BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
+          BASE_SHA=$(git rev-parse HEAD)
+          BRANCH="chore/refresh-cargo-lockfile-$(date -u +%Y%m%d)"
+          TITLE="chore(deps): refresh Cargo.lock"
+          PR_BODY="Weekly \`cargo update\` to pick up transitive dependency bumps that Dependabot does not file PRs for."
+          COMMIT_BODY="Signed-off-by: ${BOT_USER} <${BOT_ID}+${BOT_USER}@users.noreply.github.com>"
+
+          CONTENT=$(base64 < Cargo.lock | tr -d '\n')
+          ADDITIONS=$(jq -n --arg path "Cargo.lock" --arg contents "${CONTENT}" \
+            '[{path: $path, contents: $contents}]')
+
+          gh api "repos/${REPOSITORY}/git/refs" -X POST \
+            -f "ref=refs/heads/${BRANCH}" \
+            -f "sha=${BASE_SHA}"
+
+          jq -n \
+            --arg repo "${REPOSITORY}" \
+            --arg branch "${BRANCH}" \
+            --arg title "${TITLE}" \
+            --arg body "${COMMIT_BODY}" \
+            --arg head "${BASE_SHA}" \
+            --argjson additions "${ADDITIONS}" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: $title, body: $body },
+                  fileChanges: { additions: $additions },
+                  expectedHeadOid: $head
+                }
+              }
+            }' | gh api graphql --input -
+
+          gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "${TITLE}" \
+            --body "${PR_BODY}"


### PR DESCRIPTION
## Summary

- Dependabot only files PRs when a direct dependency in \`Cargo.toml\` changes, so transitive bumps that only touch \`Cargo.lock\` go unnoticed.
- Add a Monday 07:47 UTC workflow that runs \`cargo update\` and opens a PR with the refreshed lockfile.
- Weekly cadence roughly matches the Dependabot 7-day cooldown — a freshly-released bad version could be picked up in the ≤1 day overlap before a yank, but that's the same exposure model other Rust projects accept for lockfile refresh.