### PR TITLE
chore: restrict cargo-deny to targeted platforms

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,13 @@
+[graph]
+# Matches the platforms built in .github/workflows/release.yml.
+# Restricts all cargo-deny checks to deps reachable on these targets,
+# silencing noise from Windows-only and Android-only transitive chains.
+targets = [
+    "aarch64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+]
+
 [licenses]
 allow = [
     "AGPL-3.0-only",
@@ -15,12 +25,7 @@ allow = [
     "Unlicense",
 ]
 confidence-threshold = 0.95
-
-# r-efi is LGPL-2.1-or-later but only compiled on UEFI targets —
-# never linked into pinprick on macOS/Linux.
-[[licenses.exceptions]]
-allow = ["LGPL-2.1-or-later"]
-name = "r-efi"
+unused-allowed-license = "allow"
 
 [advisories]
 


### PR DESCRIPTION
## Summary

- pinprick only ships binaries for \`aarch64-apple-darwin\` and \`{x86_64,aarch64}-unknown-linux-gnu\`, per \`.github/workflows/release.yml\`. Add a \`[graph].targets\` list so cargo-deny only evaluates deps reachable on those platforms — silences duplicate warnings for \`thiserror\`, \`thiserror-impl\`, and \`windows-sys\` that came from Windows- and Android-only transitive chains.
- Drop the \`r-efi\` LGPL exception: with the graph restricted it's no longer reachable (UEFI-only), so the carve-out is dead. If a future target ever needs it, re-adding the exception is the right review moment.
- Keep the general license allowlist untouched — it's forward-looking policy for AGPL-3.0 compatibility, not a snapshot of what's currently in the graph. Set \`unused-allowed-license = "allow"\` to silence "license not encountered" noise for entries that aren't currently exercised.

The only remaining cargo-deny warning after this change is the \`core-foundation\` 0.9.4/0.10.1 duplicate, which is structural: \`system-configuration\` (via \`hyper-util\`) still pins 0.9, while \`rustls-platform-verifier\` + \`security-framework\` use 0.10. Both are macOS-only and can't be deduped without upstream releases.