### PR TITLE
ci: fix cargo tool cache keys and include crates metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,17 +123,21 @@ jobs:
           path: |
             ~/.cargo/bin/cargo-nextest
             ~/.cargo/bin/cargo-llvm-cov
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-v1
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-
 
       - name: Restore lint tools cache
         if: matrix.check == 'lint'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
+            ~/.cargo/bin/typos
+            ~/.cargo/bin/cargo-deny
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-
 
       # --- Conventional Commits ---
@@ -231,10 +235,11 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
+            ~/.cargo/bin/typos
+            ~/.cargo/bin/cargo-deny
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('.github/workflows/ci.yml') }}
 
       # --- Test ---
 
@@ -283,7 +288,9 @@ jobs:
           path: |
             ~/.cargo/bin/cargo-nextest
             ~/.cargo/bin/cargo-llvm-cov
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-v1
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-${{ hashFiles('.github/workflows/ci.yml') }}
 
       # --- Site ---
 


### PR DESCRIPTION
The cov-tools cache used a static `-v1` key that never invalidated on version bumps, and it didn't cache `~/.cargo/.crates.toml` / `.crates2.json`, so `cargo install` rebuilt nextest and llvm-cov from source every run (the Coverage job took ~6m on consecutive push-to-main runs). Switch both cache keys to hash `.github/workflows/ci.yml` (version pins drive invalidation), add the crates metadata to the cov-tools cache, and narrow the lint-tools path to the specific binaries it owns so the two caches don't conceptually overlap.