### PR TITLE
ci: drop ~/.cargo/bin/ from audit workflow cache paths

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -41,7 +41,6 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
@@ -50,7 +49,6 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/


### PR DESCRIPTION
pinprick-audit.yml and audit-actions.yml cached under the same `cargo-debug-<Cargo.lock>` key as ci.yml but listed an extra `~/.cargo/bin/` in the path list. The cache action hashes the path list into the cache's internal version, so key-matching entries had different versions and coexisted — two cache entries with the same key but different sizes, neither usable as a clean hit from the other workflow. Neither audit workflow installs cargo binaries; dropping `~/.cargo/bin/` aligns all three workflows on a single cache version.