### PR TITLE
ci: disable @codecov/vite-plugin telemetry

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
         bundleName: 'pinprick-site',
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',
+        telemetry: false,
       }),
     ],
   },


### PR DESCRIPTION
Silences the `[codecov] Sending telemetry data...` line the plugin emits on every build.