### PR TITLE
ci: migrate test-results upload to codecov-action v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,11 +276,12 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && matrix.check == 'coverage' }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/nextest/ci/junit.xml
           fail_ci_if_error: false
+          report_type: test_results
 
       - name: Save coverage tools cache
         if: matrix.check == 'coverage' && github.event_name == 'push'


### PR DESCRIPTION
`codecov/test-results-action` is deprecated; its functionality is now a `report_type` on `codecov-action`. Use `codecov-action@v5.5.4` (already pinned for coverage) with `report_type: test_results` for the JUnit upload. Consolidates on a single action.