### PR TITLE
ci: force explicit branch and sha on Codecov bundle uploads

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -29,6 +29,10 @@ export default defineConfig({
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',
         telemetry: false,
+        uploadOverrides: {
+          branch: process.env.GITHUB_REF_NAME,
+          sha: process.env.GITHUB_SHA,
+        },
       }),
     ],
   },


### PR DESCRIPTION
Bundle reports have only appeared under the original PR branch (`ci/codecov-integration`); subsequent push-to-main uploads produce `Successfully uploaded stats` in the logs but never surface on the Bundles dashboard under `main`. Strongest hypothesis is the plugin's auto-detection failing on push events. Pass `GITHUB_REF_NAME` and `GITHUB_SHA` through `uploadOverrides` so the plugin stops guessing. Diagnostic on pinprick first — if it fixes bundle reports on main, replicate on the other Astro configs.