### PR TITLE
ci: enable debug logging on the Codecov vite plugin

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',
         telemetry: false,
+        debug: true,
       }),
     ],
   },


### PR DESCRIPTION
Diagnostic-only. Bundle uploads succeed per the plugin's logs but nothing surfaces on the Bundles dashboard under `main`. `debug: true` will log the branch/sha/slug payload on the next push-to-main Site run so we can see what Codecov is actually receiving. Revert once we have the data or file a support ticket.