### PR TITLE
ci: pass compareSha override to Codecov vite plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,7 @@ jobs:
         run: npm run build
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          GH_COMPARE_SHA: ${{ github.event.before || github.event.pull_request.base.sha }}
 
       # --- Verify Audited Actions ---
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -46,6 +46,7 @@ jobs:
         run: npm run build
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          GH_COMPARE_SHA: ${{ github.event.before }}
 
       - name: Deploy to Cloudflare Workers
         working-directory: site

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -29,7 +29,9 @@ export default defineConfig({
         uploadToken: process.env.CODECOV_TOKEN,
         gitService: 'github',
         telemetry: false,
-        debug: true,
+        uploadOverrides: {
+          compareSha: process.env.GH_COMPARE_SHA,
+        },
       }),
     ],
   },


### PR DESCRIPTION
Debug logs showed the plugin detects branch/slug/commit correctly but reports `compareSha: null`, which Codecov's dashboard surfaces as "missing head report". Pass `github.event.before` (push) or `github.event.pull_request.base.sha` (PR) through a `GH_COMPARE_SHA` env var and set it via `uploadOverrides.compareSha` in astro.config.mjs. Removes the debug flag now that we have the answer.