### PR TITLE
feat(score): add pinprick score subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ pinprick is a CLI tool for GitHub Actions supply chain security. It pins action 
 
 - **Language:** Rust (2024 edition)
 - **Platform:** macOS, Linux
-- **Architecture:** Single binary CLI with five subcommands (`audit`, `clean`, `completions`, `pin`, `update`)
+- **Architecture:** Single binary CLI with six subcommands (`audit`, `clean`, `completions`, `pin`, `score`, `update`)
 - **License:** AGPL-3.0-only
 - **Dependencies:** clap/clap_complete (CLI), tokio (async), reqwest (HTTP), serde/serde_norway (parsing), regex (pattern matching), colored (terminal output), toml (config parsing)
 
@@ -26,9 +26,11 @@ pinprick/
 │   ├── github.rs            # GitHub API client (tag→SHA, releases, file trees)
 │   ├── output.rs            # Human-readable (colored) and --json output formatting
 │   ├── pin.rs               # Pin command: resolve tags to SHAs, rewrite files
+│   ├── score.rs             # Score command: compute a posture grade per docs/scoring.md
 │   ├── update.rs            # Update command: check pinned actions for newer releases
 │   └── workflow.rs           # Regex-based uses: line scanning, ActionRef types
 ├── audited-actions/          # Pre-audited action SHAs (bundled into binary)
+├── docs/                     # Specs (scoring rubric, etc.) — source of truth for behaviors
 ├── scripts/                  # Helper scripts (release notes formatting)
 ├── site/                     # Astro Starlight docs site (pinprick.rs)
 ├── justfile                  # Task runner (build, test, lint, check)
@@ -47,6 +49,7 @@ pinprick/
 - `pinprick pin [PATH] [--write]` — Scan `.github/workflows/*.yml`, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
 - `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
 - `pinprick audit [PATH] [--verbose] [--sarif]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans only local `run:` blocks. With a token, also fetches and scans action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning.
+- `pinprick score [PATH]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md`. v0.1.0 emits `pin.*` and `workflow.*` findings (offline, no token required). Exits 1 when any findings exist (matches `audit` for CI gating); outputs JSON with `--json`. Serves as the reference implementation MintMarq wraps.
 - `pinprick clean` — Remove locally cached audit results (`~/.cache/pinprick/audited/`).
 - `pinprick completions <SHELL>` — Generate shell completions for bash, zsh, fish, etc.
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,221 @@
+# pinprick scoring rubric
+
+**Status:** draft (rubric version `0.1.0`)
+
+This document defines how pinprick computes a single score for a GitHub repository's Actions supply chain posture. It is the public specification that the `pinprick score` CLI subcommand and the MintMarq dashboard both implement against.
+
+Keeping this document public and versioned is deliberate: security scoring is only trustworthy if anyone can re-derive the score from the raw findings. Vendors that hide the rubric behind "proprietary algorithms" end up being distrusted by the security teams they want as customers.
+
+## Design principles
+
+1. **Transparent.** Every point deducted is tied to an explicit rule and finding. Given the raw findings, a third party can re-compute the score by hand.
+2. **Actionable.** Every rule maps to a concrete remediation. The score is always accompanied by a prioritized fix list.
+3. **Deterministic.** The same inputs always produce the same score. No stochastic inputs, no ML models, no "confidence-weighted" signals in v1.
+4. **Versioned.** The rubric has a semantic version. Every scan records the rubric version used. Re-scoring is always explicit — we never silently mutate historical scores.
+5. **Unique-finding basis.** Action-level rules (`pin.*`, `source.*`, `runtime.*`) fire once per unique `(rule, action_ref)` across the repo, with an `occurrences` list recording every `(workflow, line)` where the action is used. Workflow-level rules (`workflow.*`) fire once per `(rule, workflow_path)`. A repo with 20 workflows that all call `actions/checkout@main` has one fix to make, so the score reflects one finding.
+6. **Absolute before relative.** v1 is an absolute rubric ("47/100"). Percentile scoring across a corpus is a later feature and needs real data first.
+
+## Score formula
+
+Each scan produces findings. Each finding has a severity that maps to a point deduction.
+
+```
+repo_score = max(0, 100 - sum(finding.points for finding in findings))
+```
+
+Grade bands (absolute):
+
+| Grade | Range    |
+|-------|----------|
+| A     | 90 – 100 |
+| B     | 80 – 89  |
+| C     | 70 – 79  |
+| D     | 60 – 69  |
+| F     |  0 – 59  |
+
+Rationale for the flat deduction model: it's trivial to explain, easy to audit, and composes cleanly across rules. Weighted-average models require calibrating weights against each other, which invites arguments that nobody can win. We can always move to a more nuanced formula later; we cannot retroactively earn back trust lost to an opaque one.
+
+## Rule catalog
+
+Each rule has an ID, a category, a severity, a point deduction, and a remediation hint. The **Status** column marks what is live in the current rubric version vs. reserved for a future release.
+
+### Pinning rules (category: `pin`)
+
+| ID            | Condition                                          | Severity | Points | Status | Remediation                                           |
+|---------------|----------------------------------------------------|----------|--------|--------|-------------------------------------------------------|
+| `pin.none`    | Action `uses:` has no `@ref` at all                | high     |   20   | reserved | Pin to a full 40-char SHA                           |
+| `pin.branch`  | `@ref` is a branch name (`main`, `master`, custom) | high     |   15   | live   | Pin to a full 40-char SHA                             |
+| `pin.sliding` | `@ref` is a sliding tag (e.g., `@v4`)              | medium   |    5   | live   | Pin to a full 40-char SHA; keep the tag as a comment  |
+| `pin.full_tag`| `@ref` is a full version tag (e.g., `@v4.2.1`)     | low      |    2   | live   | Pin to a full 40-char SHA                             |
+
+A SHA-pinned reference incurs no pinning deduction.
+
+`pin.none` is catalogued for completeness but currently unreachable: pinprick's `uses:` parser rejects lines without an `@ref`, so no-ref references never reach the scorer. The rule id is reserved so future parser changes (or other tooling that implements this rubric) can emit it without colliding.
+
+### Action-source rules (category: `source`) — **planned for v0.2.0**
+
+These rules fire against properties of the referenced action itself and require a GitHub token to resolve. They are specified here so the rubric is stable across implementations, but the v0.1.0 scorer does not emit them.
+
+| ID                    | Condition                                                    | Severity | Points | Remediation                                      |
+|-----------------------|--------------------------------------------------------------|----------|--------|--------------------------------------------------|
+| `source.archived`     | Referenced repo is archived                                  | high     |   10   | Migrate to an actively maintained replacement    |
+| `source.stale`        | Referenced SHA was committed >365 days ago and no newer tag  | medium   |    5   | Update to a newer maintained version             |
+| `source.advisory`     | Referenced version has a published GHSA advisory             | high     |   15   | Update to a patched version                      |
+| `source.unverified`   | Publisher is not GitHub-verified and not in a trusted-owners allowlist | low |  1   | Confirm publisher trust; consider vendoring      |
+
+### Runtime-fetch rules (category: `runtime`) — **planned for v0.2.0**
+
+These reuse findings from the existing `pinprick audit` pipeline. Severity comes straight from the audit finding. Not emitted in v0.1.0; the integration with the audit pipeline lands alongside these rules.
+
+| ID                      | Condition                                          | Severity | Points | Remediation                                        |
+|-------------------------|----------------------------------------------------|----------|--------|----------------------------------------------------|
+| `runtime.pipe_to_shell` | `curl \| sh`, `bash <(curl …)`, `iex (iwr …)`, etc. | high     |   20   | Download, verify, then execute; never pipe         |
+| `runtime.fetch.high`    | Audit finding, severity high                       | high     |   15   | Pin the fetched artifact; add checksum verification|
+| `runtime.fetch.medium`  | Audit finding, severity medium                     | medium   |    8   | Pin or version-lock the fetched resource           |
+| `runtime.fetch.low`     | Audit finding, severity low                        | low      |    3   | Review; often acceptable if the URL is versioned   |
+
+Note: the audit pipeline already applies the `data format URL` and nearby-checksum adjustments. `runtime.*` scoring uses the post-adjustment severity, so double-counting doesn't happen.
+
+### Workflow-level rules (category: `workflow`)
+
+These fire once per workflow, not per action use.
+
+| ID                          | Condition                                             | Severity | Points | Status | Remediation                                          |
+|-----------------------------|-------------------------------------------------------|----------|--------|--------|------------------------------------------------------|
+| `workflow.permissions_write_all` | Workflow declares `permissions: write-all`       | high     |   10   | live   | Declare minimal per-job `permissions:` blocks        |
+| `workflow.pull_request_target` | Workflow uses the `pull_request_target` trigger     | high     |    5   | live   | Validate the checkout ref; avoid running PR code with elevated tokens |
+| `workflow.workflow_run`     | Workflow uses the `workflow_run` trigger              | medium   |    3   | live   | Explicitly validate trigger provenance                |
+
+The `pull_request_target` and `workflow_run` rules fire on trigger *presence* in v0.1.0. A future release may narrow to "without explicit guardrails" once the parser can recognize common safe patterns (e.g., validating the checkout ref).
+
+### Future categories (not in v1)
+
+- `secret.*` — detections of hard-coded secrets, improper `${{ secrets.* }}` exposure in logs, etc.
+- `registry.*` — signals from the vetted-mirror layer once it exists (unvetted action used when a vetted equivalent is available).
+- `sbom.*` — SBOM / provenance attestation coverage.
+
+These are deliberately out of scope for v1 to keep the initial rubric defensible. Adding them bumps the rubric to `0.2.0`.
+
+## Output
+
+`pinprick score <path>` produces a stable JSON document. A static HTML report is generated from the same JSON.
+
+### JSON schema (sketch)
+
+```jsonc
+{
+  "rubric_version": "0.1.0",
+  "pinprick_version": "…",
+  "scanned_at": "2026-04-22T20:00:00Z",
+  "target": { "kind": "repo", "path": "./" },
+  "score": 72,
+  "grade": "C",
+  "totals": {
+    "points_deducted": 28,
+    "findings": 11,
+    "workflows_scanned": 4,
+    "unique_actions": 17
+  },
+  "findings": [
+    {
+      "id": "pin.sliding",
+      "category": "pin",
+      "severity": "medium",
+      "points": 5,
+      "action_ref": "actions/checkout@v4",
+      "occurrences": [
+        { "workflow": ".github/workflows/ci.yml", "line": 22 },
+        { "workflow": ".github/workflows/release.yml", "line": 15 }
+      ],
+      "remediation": "Pin to a full 40-char SHA; keep the tag as a comment"
+    }
+    // …
+  ]
+}
+```
+
+### Terminal output (human-readable)
+
+A compact summary:
+
+```
+pinprick score  v0.1.0 rubric
+
+  Grade:  C   (72 / 100)
+
+  Findings (11 unique, 24 occurrences):
+    high    2  pin.branch           actions/foo@main
+    high    1  source.archived      bar/baz@abc1234
+    medium  6  pin.sliding          7 actions
+    low     2  pin.full_tag         2 actions
+
+  Top remediations:
+    1. Pin actions/foo@main to a full SHA             (-15)
+    2. Replace bar/baz (archived) with a maintained action (-10)
+    …
+
+  Run `pinprick score --json` for the full report.
+```
+
+### HTML report
+
+A single self-contained HTML file with:
+
+- Score + grade banner
+- Per-category breakdown with expandable finding lists
+- Per-workflow drill-down
+- Prioritized remediation list (sorted by points recovered)
+
+No JavaScript frameworks; plain HTML + a little CSS. The HTML report is shareable as a static artifact and works as a customer-discovery demo.
+
+## Roll-ups
+
+The CLI's natural scope is a single repo. The MintMarq app rolls findings up further:
+
+- **Workflow score**: `max(0, 100 - sum(points for findings in that workflow))`. Used for within-repo drill-down.
+- **Org score**: weighted mean of repo scores, weighted by action-use count (so a single tiny repo with a bad score doesn't tank the whole org).
+- **Time series**: every scan persists its full finding list plus rubric version; the dashboard shows trend lines and diffs between scans.
+
+Org-level scoring is defined here for reference but is implemented in the MintMarq app, not the pinprick CLI.
+
+## Versioning
+
+The rubric version is semver-ish:
+
+- **Patch** (`0.1.0 → 0.1.1`): wording/remediation text changes; no score impact.
+- **Minor** (`0.1.0 → 0.2.0`): new rules added, or point values adjusted. Existing repos may score differently; scans are re-labeled with the new version. Historical scans retain their original rubric version.
+- **Major** (`0.x → 1.0`): structural change to the formula or output schema. Requires a migration note.
+
+Re-scoring an existing scan against a newer rubric is always explicit in the UI. We never silently change a score.
+
+## Worked example
+
+A hypothetical small repo:
+
+- 1 workflow (`ci.yml`) with:
+  - `actions/checkout@v4` (sliding tag)
+  - `actions/setup-node@v4.2.1` (full tag)
+  - `some-org/custom-action@main` (branch ref)
+  - A `run:` block that does `curl https://example.com/install.sh | sh`
+  - `permissions: write-all` at workflow level
+
+Findings:
+
+| Rule              | Points |
+|-------------------|--------|
+| `pin.sliding`     |    5   |
+| `pin.full_tag`    |    2   |
+| `pin.branch`      |   15   |
+| `runtime.pipe_to_shell` | 20 |
+| `workflow.permissions_write_all` | 10 |
+
+Total deducted: **52**. Score: **48**. Grade: **F**.
+
+Remediation priority (biggest point recovery first):
+1. Remove the `curl | sh` (+20)
+2. Pin `some-org/custom-action` to a SHA (+15)
+3. Scope `permissions:` per-job (+10)
+4. Pin `actions/checkout` to a SHA (+5)
+5. Pin `actions/setup-node` to a SHA (+2)
+
+Post-remediation score: **100**.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod config;
 mod github;
 mod output;
 mod pin;
+mod score;
 mod update;
 mod workflow;
 
@@ -76,6 +77,12 @@ enum Command {
         #[arg(long = "write")]
         apply: bool,
     },
+    /// Score a repository's Actions supply chain posture
+    Score {
+        /// Repository root
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
     /// Check for updates to pinned actions
     Update {
         /// Repository root
@@ -138,6 +145,7 @@ async fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         Command::Pin { path, apply } => pin::run(path, cli.json, *apply).await,
+        Command::Score { path } => score::run(path, cli.json).await,
         Command::Update { path, apply, only } => {
             update::run(path, *apply, cli.json, only.as_deref()).await
         }

--- a/src/score.rs
+++ b/src/score.rs
@@ -1,0 +1,729 @@
+//! Scoring: turn workflow scan findings into a single posture grade.
+//!
+//! The rubric is specified in `docs/scoring.md`. Every rule id, point value,
+//! and category here must match that document — the whole value of scoring
+//! is that a third party can re-derive it from the public rubric.
+
+use anyhow::Result;
+use colored::Colorize;
+use serde::Serialize;
+use serde_norway::Value;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::ExitCode;
+
+use crate::workflow::{self, ActionRef, RefType};
+
+pub const RUBRIC_VERSION: &str = "0.1.0";
+
+// ── Rule catalog ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Category {
+    Pin,
+    Workflow,
+    // Source and Runtime categories are defined in the rubric spec but have
+    // no rules implemented in v0.1.0. They will be added alongside their rules.
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RuleId {
+    PinBranch,
+    PinSliding,
+    PinFullTag,
+    WorkflowPermissionsWriteAll,
+    WorkflowPullRequestTarget,
+    WorkflowWorkflowRun,
+}
+
+impl RuleId {
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::PinBranch => "pin.branch",
+            Self::PinSliding => "pin.sliding",
+            Self::PinFullTag => "pin.full_tag",
+            Self::WorkflowPermissionsWriteAll => "workflow.permissions_write_all",
+            Self::WorkflowPullRequestTarget => "workflow.pull_request_target",
+            Self::WorkflowWorkflowRun => "workflow.workflow_run",
+        }
+    }
+
+    pub fn category(self) -> Category {
+        match self {
+            Self::PinBranch | Self::PinSliding | Self::PinFullTag => Category::Pin,
+            Self::WorkflowPermissionsWriteAll
+            | Self::WorkflowPullRequestTarget
+            | Self::WorkflowWorkflowRun => Category::Workflow,
+        }
+    }
+
+    pub fn severity(self) -> Severity {
+        match self {
+            Self::PinBranch
+            | Self::WorkflowPermissionsWriteAll
+            | Self::WorkflowPullRequestTarget => Severity::High,
+            Self::PinSliding | Self::WorkflowWorkflowRun => Severity::Medium,
+            Self::PinFullTag => Severity::Low,
+        }
+    }
+
+    pub fn points(self) -> u32 {
+        match self {
+            Self::PinBranch => 15,
+            Self::WorkflowPermissionsWriteAll => 10,
+            Self::PinSliding => 5,
+            Self::WorkflowPullRequestTarget => 5,
+            Self::WorkflowWorkflowRun => 3,
+            Self::PinFullTag => 2,
+        }
+    }
+
+    pub fn remediation(self) -> &'static str {
+        match self {
+            Self::PinBranch | Self::PinSliding | Self::PinFullTag => {
+                "Pin to a full 40-char SHA; keep the tag as a comment"
+            }
+            Self::WorkflowPermissionsWriteAll => {
+                "Declare minimal per-job `permissions:` blocks instead of `write-all`"
+            }
+            Self::WorkflowPullRequestTarget => {
+                "Validate the checkout ref; avoid running PR code with elevated tokens"
+            }
+            Self::WorkflowWorkflowRun => "Explicitly validate trigger provenance",
+        }
+    }
+}
+
+// ── Finding / Report types ──────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Occurrence {
+    pub workflow: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Finding {
+    pub id: &'static str,
+    pub category: Category,
+    pub severity: Severity,
+    pub points: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_ref: Option<String>,
+    pub occurrences: Vec<Occurrence>,
+    pub remediation: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Totals {
+    pub points_deducted: u32,
+    pub findings: usize,
+    pub workflows_scanned: usize,
+    pub unique_actions: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Target {
+    pub kind: &'static str,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoreReport {
+    pub rubric_version: &'static str,
+    pub pinprick_version: &'static str,
+    pub target: Target,
+    pub score: u32,
+    pub grade: &'static str,
+    pub totals: Totals,
+    pub findings: Vec<Finding>,
+}
+
+// ── Scoring ─────────────────────────────────────────────────────────────────
+
+pub fn grade_for(score: u32) -> &'static str {
+    match score {
+        90..=100 => "A",
+        80..=89 => "B",
+        70..=79 => "C",
+        60..=69 => "D",
+        _ => "F",
+    }
+}
+
+/// Collect findings across all workflows, dedupe by rule + target, and roll
+/// up into a single report.
+pub fn score_repo(repo_root: &Path) -> Result<ScoreReport> {
+    let files = workflow::find_workflows(repo_root)?;
+
+    // Accumulate action-level findings keyed by (rule, action_ref).
+    // Accumulate workflow-level findings keyed by (rule, workflow_path).
+    let mut action_findings: BTreeMap<(RuleId, String), Vec<Occurrence>> = BTreeMap::new();
+    let mut workflow_findings: BTreeMap<(RuleId, String), Vec<Occurrence>> = BTreeMap::new();
+    let mut unique_actions: std::collections::BTreeSet<String> = Default::default();
+
+    for file in &files {
+        let display = workflow::display_path(file, repo_root);
+        let content = std::fs::read_to_string(file)
+            .map_err(|e| anyhow::anyhow!("reading {}: {e}", file.display()))?;
+
+        // Action-level findings (pin.*)
+        for a in workflow::scan_content(&content) {
+            unique_actions.insert(format!("{}@{}", a.full_name(), a.ref_string));
+            if let Some(rule) = pin_rule_for(&a) {
+                let key = (rule, format!("{}@{}", a.full_name(), a.ref_string));
+                action_findings.entry(key).or_default().push(Occurrence {
+                    workflow: display.clone(),
+                    line: a.line_number,
+                });
+            }
+        }
+
+        // Workflow-level findings (workflow.*)
+        let doc: Option<Value> = serde_norway::from_str(&content).ok();
+        if let Some(doc) = doc {
+            for rule in workflow_rules_for(&doc) {
+                workflow_findings
+                    .entry((rule, display.clone()))
+                    .or_default()
+                    .push(Occurrence {
+                        workflow: display.clone(),
+                        line: 0, // workflow-level finding has no specific line
+                    });
+            }
+        }
+    }
+
+    let mut findings: Vec<Finding> = Vec::new();
+
+    for ((rule, action_ref), mut occurrences) in action_findings {
+        occurrences.sort_by(|a, b| a.workflow.cmp(&b.workflow).then(a.line.cmp(&b.line)));
+        findings.push(Finding {
+            id: rule.id(),
+            category: rule.category(),
+            severity: rule.severity(),
+            points: rule.points(),
+            action_ref: Some(action_ref),
+            occurrences,
+            remediation: rule.remediation(),
+        });
+    }
+
+    for ((rule, _workflow_path), occurrences) in workflow_findings {
+        findings.push(Finding {
+            id: rule.id(),
+            category: rule.category(),
+            severity: rule.severity(),
+            points: rule.points(),
+            action_ref: None,
+            occurrences,
+            remediation: rule.remediation(),
+        });
+    }
+
+    // Stable ordering: highest severity + highest points first, then rule id.
+    findings.sort_by(|a, b| {
+        b.points
+            .cmp(&a.points)
+            .then_with(|| a.id.cmp(b.id))
+            .then_with(|| {
+                a.action_ref
+                    .as_deref()
+                    .unwrap_or("")
+                    .cmp(b.action_ref.as_deref().unwrap_or(""))
+            })
+    });
+
+    let points_deducted: u32 = findings.iter().map(|f| f.points).sum();
+    let score = 100u32.saturating_sub(points_deducted);
+
+    Ok(ScoreReport {
+        rubric_version: RUBRIC_VERSION,
+        pinprick_version: env!("CARGO_PKG_VERSION"),
+        target: Target {
+            kind: "repo",
+            path: repo_root.display().to_string(),
+        },
+        score,
+        grade: grade_for(score),
+        totals: Totals {
+            points_deducted,
+            findings: findings.len(),
+            workflows_scanned: files.len(),
+            unique_actions: unique_actions.len(),
+        },
+        findings,
+    })
+}
+
+fn pin_rule_for(a: &ActionRef) -> Option<RuleId> {
+    // `pin.none` (no `@ref`) is unreachable: the `uses:` parser rejects
+    // lines without an `@ref`, so no-ref references never reach the scorer.
+    match a.ref_type {
+        RefType::Sha => None,
+        RefType::Branch => Some(RuleId::PinBranch),
+        RefType::SlidingTag => Some(RuleId::PinSliding),
+        RefType::Tag => Some(RuleId::PinFullTag),
+    }
+}
+
+fn workflow_rules_for(doc: &Value) -> Vec<RuleId> {
+    let mut rules = Vec::new();
+
+    // Top-level `permissions: write-all`
+    if let Some(Value::String(s)) = doc.get("permissions")
+        && s == "write-all"
+    {
+        rules.push(RuleId::WorkflowPermissionsWriteAll);
+    }
+
+    // `on.pull_request_target` — presence is the signal
+    if let Some(on) = doc.get("on")
+        && trigger_present(on, "pull_request_target")
+    {
+        rules.push(RuleId::WorkflowPullRequestTarget);
+    }
+
+    // `on.workflow_run`
+    if let Some(on) = doc.get("on")
+        && trigger_present(on, "workflow_run")
+    {
+        rules.push(RuleId::WorkflowWorkflowRun);
+    }
+
+    rules
+}
+
+fn trigger_present(on: &Value, name: &str) -> bool {
+    match on {
+        Value::String(s) => s == name,
+        Value::Sequence(seq) => seq
+            .iter()
+            .any(|v| matches!(v, Value::String(s) if s == name)),
+        Value::Mapping(map) => map
+            .keys()
+            .any(|k| matches!(k, Value::String(s) if s == name)),
+        _ => false,
+    }
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────────────
+
+pub async fn run(repo_root: &Path, json: bool) -> Result<ExitCode> {
+    let report = score_repo(repo_root)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human(&report);
+    }
+
+    // Exit 1 whenever findings exist — matches `audit`'s convention so the
+    // subcommand gates CI cleanly. Grade bands are a presentation detail.
+    if report.findings.is_empty() {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Ok(ExitCode::from(1))
+    }
+}
+
+fn print_human(report: &ScoreReport) {
+    let (grade_colored, _) = color_for_grade(report.grade);
+    println!(
+        "pinprick score  {} rubric",
+        format!("v{}", report.rubric_version).dimmed()
+    );
+    println!();
+    println!(
+        "  Grade:  {}   ({} / 100)",
+        grade_colored,
+        report.score.to_string().bold()
+    );
+    println!();
+
+    if report.findings.is_empty() {
+        println!("  {}", "No findings.".green());
+        return;
+    }
+
+    let total_occurrences: usize = report.findings.iter().map(|f| f.occurrences.len()).sum();
+    println!(
+        "  Findings ({} unique, {} occurrences):",
+        report.totals.findings.to_string().bold(),
+        total_occurrences.to_string().bold()
+    );
+
+    for f in &report.findings {
+        let target = f
+            .action_ref
+            .as_deref()
+            .or_else(|| f.occurrences.first().map(|o| o.workflow.as_str()))
+            .unwrap_or("");
+        let sev = severity_label(f.severity);
+        println!(
+            "    {}  -{:<3}  {:<32}  {}",
+            sev,
+            f.points,
+            f.id.cyan(),
+            target.dimmed()
+        );
+    }
+
+    println!();
+    println!(
+        "  {} workflows scanned, {} unique actions.",
+        report.totals.workflows_scanned, report.totals.unique_actions
+    );
+    println!();
+    println!("  Run with {} for the full report.", "--json".bold());
+}
+
+fn color_for_grade(grade: &str) -> (colored::ColoredString, &'static str) {
+    match grade {
+        "A" => (grade.green().bold(), "green"),
+        "B" => (grade.green(), "green"),
+        "C" => (grade.yellow(), "yellow"),
+        "D" => (grade.yellow().bold(), "yellow"),
+        _ => (grade.red().bold(), "red"),
+    }
+}
+
+fn severity_label(s: Severity) -> colored::ColoredString {
+    match s {
+        Severity::High => "high  ".red(),
+        Severity::Medium => "medium".yellow(),
+        Severity::Low => "low   ".dimmed(),
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grade_bands() {
+        assert_eq!(grade_for(100), "A");
+        assert_eq!(grade_for(90), "A");
+        assert_eq!(grade_for(89), "B");
+        assert_eq!(grade_for(80), "B");
+        assert_eq!(grade_for(79), "C");
+        assert_eq!(grade_for(70), "C");
+        assert_eq!(grade_for(69), "D");
+        assert_eq!(grade_for(60), "D");
+        assert_eq!(grade_for(59), "F");
+        assert_eq!(grade_for(0), "F");
+    }
+
+    #[test]
+    fn pin_rule_for_each_ref_type() {
+        use crate::workflow::parse_uses_line;
+
+        let sha = parse_uses_line(
+            "      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6",
+            1,
+        )
+        .unwrap();
+        assert_eq!(pin_rule_for(&sha), None);
+
+        let branch = parse_uses_line("      - uses: foo/bar@main", 1).unwrap();
+        assert_eq!(pin_rule_for(&branch), Some(RuleId::PinBranch));
+
+        let sliding = parse_uses_line("      - uses: actions/checkout@v4", 1).unwrap();
+        assert_eq!(pin_rule_for(&sliding), Some(RuleId::PinSliding));
+
+        let full_tag = parse_uses_line("      - uses: actions/checkout@v4.2.1", 1).unwrap();
+        assert_eq!(pin_rule_for(&full_tag), Some(RuleId::PinFullTag));
+    }
+
+    #[test]
+    fn workflow_rules_permissions_write_all() {
+        let yaml = "on: push\npermissions: write-all\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowPermissionsWriteAll));
+    }
+
+    #[test]
+    fn workflow_rules_no_permissions_block() {
+        let yaml = "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(!rules.contains(&RuleId::WorkflowPermissionsWriteAll));
+    }
+
+    #[test]
+    fn workflow_rules_permissions_map_is_fine() {
+        let yaml =
+            "on: push\npermissions:\n  contents: read\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(!rules.contains(&RuleId::WorkflowPermissionsWriteAll));
+    }
+
+    #[test]
+    fn workflow_rules_pull_request_target_string_form() {
+        let yaml = "on: pull_request_target\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowPullRequestTarget));
+    }
+
+    #[test]
+    fn workflow_rules_pull_request_target_list_form() {
+        let yaml =
+            "on:\n  - push\n  - pull_request_target\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowPullRequestTarget));
+    }
+
+    #[test]
+    fn workflow_rules_pull_request_target_map_form() {
+        let yaml = "on:\n  pull_request_target:\n    branches: [main]\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowPullRequestTarget));
+    }
+
+    #[test]
+    fn workflow_rules_workflow_run_map_form() {
+        let yaml = "on:\n  workflow_run:\n    workflows: [CI]\n    types: [completed]\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowWorkflowRun));
+    }
+
+    #[test]
+    fn worked_example_from_spec() {
+        // Reproduces the worked example in docs/scoring.md.
+        // One workflow with: sliding tag (5) + full tag (2) + branch (15) +
+        // permissions: write-all (10). No runtime rules implemented yet.
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: ci
+on: push
+permissions: write-all
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.2.1
+      - uses: some-org/custom-action@main
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let report = score_repo(dir.path()).unwrap();
+        // 5 + 2 + 15 + 10 = 32; score = 68; grade = D
+        assert_eq!(report.totals.points_deducted, 32);
+        assert_eq!(report.score, 68);
+        assert_eq!(report.grade, "D");
+    }
+
+    #[test]
+    fn clean_repo_scores_100() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: ci
+on: push
+permissions:
+  contents: read
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let report = score_repo(dir.path()).unwrap();
+        assert_eq!(report.score, 100);
+        assert_eq!(report.grade, "A");
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn dedupes_same_action_across_workflows() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = "name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n";
+        std::fs::write(wfdir.join("a.yml"), yaml).unwrap();
+        std::fs::write(wfdir.join("b.yml"), yaml).unwrap();
+
+        let report = score_repo(dir.path()).unwrap();
+        // Two workflows, same sliding-tag action -> ONE finding with 2 occurrences.
+        let pin_findings: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|f| f.id == "pin.sliding")
+            .collect();
+        assert_eq!(pin_findings.len(), 1);
+        assert_eq!(pin_findings[0].occurrences.len(), 2);
+        // And the deduction is a single 5, not 10.
+        assert_eq!(report.totals.points_deducted, 5);
+    }
+
+    // Exhaustive check that every RuleId variant has consistent id/category/
+    // severity/points/remediation — easy to catch a missing match arm when
+    // adding rules, and keeps every variant's helpers exercised.
+    #[test]
+    fn every_rule_id_has_metadata() {
+        for rule in [
+            RuleId::PinBranch,
+            RuleId::PinSliding,
+            RuleId::PinFullTag,
+            RuleId::WorkflowPermissionsWriteAll,
+            RuleId::WorkflowPullRequestTarget,
+            RuleId::WorkflowWorkflowRun,
+        ] {
+            assert!(!rule.id().is_empty(), "rule {rule:?} has empty id");
+            assert!(
+                !rule.remediation().is_empty(),
+                "rule {rule:?} has empty remediation"
+            );
+            assert!(rule.points() > 0, "rule {rule:?} has zero points");
+            // Just call category/severity to exercise every match arm.
+            let _ = rule.category();
+            let _ = rule.severity();
+        }
+    }
+
+    #[test]
+    fn pull_request_target_and_workflow_run_score_end_to_end() {
+        // Covers the id/points/remediation arms for PullRequestTarget and
+        // WorkflowRun by firing both rules through score_repo.
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: x
+on:
+  pull_request_target:
+    branches: [main]
+  workflow_run:
+    workflows: [CI]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let report = score_repo(dir.path()).unwrap();
+        let ids: Vec<_> = report.findings.iter().map(|f| f.id).collect();
+        assert!(ids.contains(&"workflow.pull_request_target"));
+        assert!(ids.contains(&"workflow.workflow_run"));
+        // 5 + 3 = 8
+        assert_eq!(report.totals.points_deducted, 8);
+        assert_eq!(report.score, 92);
+        assert_eq!(report.grade, "A");
+    }
+
+    #[test]
+    fn print_human_does_not_panic_across_grades() {
+        // Exercises print_human, color_for_grade, and severity_label for
+        // clean and populated reports. We don't assert on stdout content
+        // (terminal formatting is not worth locking down) — just that the
+        // rendering paths don't panic and reach every helper branch.
+        let clean = ScoreReport {
+            rubric_version: RUBRIC_VERSION,
+            pinprick_version: env!("CARGO_PKG_VERSION"),
+            target: Target {
+                kind: "repo",
+                path: ".".to_string(),
+            },
+            score: 100,
+            grade: "A",
+            totals: Totals {
+                points_deducted: 0,
+                findings: 0,
+                workflows_scanned: 0,
+                unique_actions: 0,
+            },
+            findings: vec![],
+        };
+        print_human(&clean);
+
+        let populated = ScoreReport {
+            rubric_version: RUBRIC_VERSION,
+            pinprick_version: env!("CARGO_PKG_VERSION"),
+            target: Target {
+                kind: "repo",
+                path: ".".to_string(),
+            },
+            score: 55,
+            grade: "F",
+            totals: Totals {
+                points_deducted: 45,
+                findings: 3,
+                workflows_scanned: 1,
+                unique_actions: 3,
+            },
+            findings: vec![
+                Finding {
+                    id: "pin.branch",
+                    category: Category::Pin,
+                    severity: Severity::High,
+                    points: 15,
+                    action_ref: Some("foo/bar@main".to_string()),
+                    occurrences: vec![Occurrence {
+                        workflow: ".github/workflows/ci.yml".to_string(),
+                        line: 10,
+                    }],
+                    remediation: "Pin to SHA",
+                },
+                Finding {
+                    id: "pin.sliding",
+                    category: Category::Pin,
+                    severity: Severity::Medium,
+                    points: 5,
+                    action_ref: Some("actions/checkout@v4".to_string()),
+                    occurrences: vec![Occurrence {
+                        workflow: ".github/workflows/ci.yml".to_string(),
+                        line: 12,
+                    }],
+                    remediation: "Pin to SHA",
+                },
+                Finding {
+                    id: "workflow.permissions_write_all",
+                    category: Category::Workflow,
+                    severity: Severity::High,
+                    points: 10,
+                    action_ref: None,
+                    occurrences: vec![Occurrence {
+                        workflow: ".github/workflows/ci.yml".to_string(),
+                        line: 0,
+                    }],
+                    remediation: "Declare minimal permissions",
+                },
+            ],
+        };
+        print_human(&populated);
+
+        // Touch every grade band's color path.
+        for grade in ["A", "B", "C", "D", "F"] {
+            let _ = color_for_grade(grade);
+        }
+        // And every severity label.
+        let _ = severity_label(Severity::Low);
+        let _ = severity_label(Severity::Medium);
+        let _ = severity_label(Severity::High);
+    }
+}

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -1,0 +1,122 @@
+mod common;
+
+use predicates::prelude::*;
+
+const WORKFLOW_UNPINNED_SLIDING: &str = "\
+name: sliding
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+";
+
+const WORKFLOW_PERMISSIONS_WRITE_ALL: &str = "\
+name: write-all
+on: push
+permissions: write-all
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+";
+
+const WORKFLOW_PR_TARGET: &str = "\
+name: pr-target
+on:
+  pull_request_target:
+    branches: [main]
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+";
+
+#[test]
+fn clean_repo_exits_zero() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("Grade:  A"))
+        .stdout(predicate::str::contains("100 / 100"));
+}
+
+#[test]
+fn sliding_tag_exits_one() {
+    let dir = common::repo_with_workflow("ci.yml", WORKFLOW_UNPINNED_SLIDING);
+    common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("pin.sliding"));
+}
+
+#[test]
+fn permissions_write_all_fires_workflow_rule() {
+    let dir = common::repo_with_workflow("ci.yml", WORKFLOW_PERMISSIONS_WRITE_ALL);
+    common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("workflow.permissions_write_all"));
+}
+
+#[test]
+fn pull_request_target_fires_workflow_rule() {
+    let dir = common::repo_with_workflow("ci.yml", WORKFLOW_PR_TARGET);
+    common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("workflow.pull_request_target"));
+}
+
+#[test]
+fn json_output_shape() {
+    let dir = common::repo_with_workflow("ci.yml", WORKFLOW_UNPINNED_SLIDING);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert_eq!(json["rubric_version"], "0.1.0");
+    assert_eq!(json["grade"], "A");
+    assert_eq!(json["score"], 95);
+    assert_eq!(json["totals"]["findings"], 1);
+    assert_eq!(json["totals"]["workflows_scanned"], 1);
+    assert_eq!(json["findings"][0]["id"], "pin.sliding");
+    assert_eq!(json["findings"][0]["points"], 5);
+    assert_eq!(json["findings"][0]["category"], "pin");
+    assert_eq!(json["findings"][0]["severity"], "medium");
+    assert_eq!(json["findings"][0]["action_ref"], "actions/checkout@v4");
+    assert_eq!(
+        json["findings"][0]["occurrences"][0]["workflow"],
+        ".github/workflows/ci.yml"
+    );
+}
+
+#[test]
+fn no_workflows_directory_errors() {
+    // Temp dir with no .github/workflows/ — score should fail cleanly.
+    let dir = tempfile::TempDir::new().unwrap();
+    common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("No .github/workflows/"));
+}


### PR DESCRIPTION
Adds a `pinprick score [PATH]` subcommand that computes a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows, implementing the public rubric in a new `docs/scoring.md`.

v0.1.0 emits `pin.*` and `workflow.*` findings fully offline. `source.*` and `runtime.*` rules are catalogued in the spec as reserved for v0.2.0. Findings are deduplicated per `(rule, action_ref)` with an occurrences list, so a repo using `actions/checkout@main` in 20 workflows scores one finding, not twenty.

The rubric is public so any third party can re-derive the score from raw findings; keeping the reference implementation open in the CLI is what makes that trust property real.

Outputs colored terminal by default or stable JSON with `--json`. Exits 1 when any findings exist (matches `audit`'s CI convention).