### PR TITLE
ci(codecov): disable PR comments via repo-level config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%   # tolerate 1% drop on overall project coverage
+    patch:
+      default:
+        target: auto
+        threshold: 0%   # new/changed code should be covered
+  precision: 2
+  round: down
+
+comment: false
+
+github_checks:
+  annotations: true       # inline coverage gutter on PRs


### PR DESCRIPTION
Adds `.github/codecov.yml` setting `comment: false` to stop Codecov from posting comments on PRs regardless of whether coverage moved. Coverage statuses and PR gutter annotations still work.

Background: the org-level global YAML had `comment.require_changes: true`, but Codecov's current behavior still emits a minimal header comment when there are modified coverable lines — even when the delta is zero. The repo-level file is the reliable path to suppress comments entirely. Config is inlined (thresholds, precision, `github_checks`) so behavior is explicit once a repo-level file exists.