### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Release cut for v0.8.0. Main additions since v0.7.0:

- New `pinprick score` subcommand with a public scoring rubric at `docs/scoring.md`.
- Rubric covers four rule families: `pin.*`, `source.*`, `workflow.*`, `runtime.*`. All scored offline, no token required.
- Output as colored terminal, stable JSON (`--json`), or self-contained HTML report (`--html`).
- `source.unverified` honors a `trusted-owners` list in `.pinprick.toml`.
- Rubric at `0.3.0`.