### PR TITLE
fix(site): scope header rule to outer <header>

### DIFF
--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -57,7 +57,10 @@
 }
 
 /* ----- Header: 2px accent rule ----------------------------- */
-.header {
+/* Scoped to the outer <header> element. Starlight nests a second
+   <div class="header"> inside it for layout; an unscoped .header
+   selector would draw a second rule under the wordmark. */
+header.header {
   border-bottom: 2px solid var(--sl-color-accent) !important;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to [#148](https://github.com/starhaven-io/pinprick/pull/148). Starlight nests a `<div class="header">` inside the outer `<header class="header">`. The unscoped `.header` selector from #148 matched both, so the 2px accent rule rendered twice — once under the wordmark/search row (the inner div, drawn at content-area height) and once at the bottom of the bar (the outer header, drawn at full nav height).

Scope the selector to `header.header` so only the outer element gets the rule.