### PR TITLE
ci: exclude claude.ai URLs from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -6,3 +6,6 @@
 max_concurrency = 20
 timeout = 20
 max_retries = 3
+
+# claude.ai returns 403 to automated link checkers
+exclude = ["https://claude.ai/.*"]


### PR DESCRIPTION
claude.ai returns 403 to lychee's automated requests, failing the scheduled link-check workflow on the README's "Built with Claude Code" attribution link ([example failing run](https://github.com/starhaven-io/pinprick/actions/runs/25328945356)).