### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Patch release. Since v0.8.0:

- `chore(audited-actions)`: refresh scanned actions (#153, #159) — bundled into the binary via `build.rs`
- `chore(deps)`: refresh `Cargo.lock` (#154, #160)
- `chore(ci)`: bump cargo-installed tool versions (#161)
- Site: starhaven-io design system + header rule scope fix (#148, #149) — not shipped in the binary
- Misc: dependabot bumps for github-actions and /site npm groups