### PR TITLE
fix(ci): scope app-token permissions in bot workflows

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -200,6 +200,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -89,6 +89,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/refresh-cargo-lockfile.yml
+++ b/.github/workflows/refresh-cargo-lockfile.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

zizmor's `github-app` check flags the three workflows that mint an installation token without declaring `permission-*` inputs, since the token would otherwise inherit the app's blanket installation permissions.

Each of those jobs only opens a PR, so restrict the minted token to:
- `contents: write` — for branch ref creation and the `CreateCommitOnBranch` GraphQL mutation
- `pull-requests: write` — for `gh pr create`

Unblocks zizmor checks on subsequent PRs.