### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
## Summary

Minor release. Highlights since v0.8.1:

- [pinprick#185](https://github.com/starhaven-io/pinprick/pull/185) — `feat(score)`: add `source.archived` rule, bump scoring rubric to 0.4.0
- [pinprick#184](https://github.com/starhaven-io/pinprick/pull/184) — `fix(ci)`: scope app-token permissions in bot workflows
- [pinprick#186](https://github.com/starhaven-io/pinprick/pull/186) — `test(score)`: extract `archived_findings` helper for unit coverage

Plus the usual dependency bumps. Trigger `release.yml` after merge to cut the release.