### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
## Summary

Minor release. Highlights since v0.9.0:

- [pinprick#188](https://github.com/starhaven-io/pinprick/pull/188) — `feat(score)`: add `source.advisory` rule (-15, high), bump scoring rubric to 0.5.0; matches pinned actions against published GHSA advisories via semver range comparison.

Trigger `release.yml` after merge to cut v0.10.0.