### PR TITLE
ci: bump zizmorcore/zizmor-action from v0.5.5 to v0.5.6

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: zizmorcore/zizmor-action@a16621b09c6db4281f81a93cb393b05dcd7b7165 # v0.5.5
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           persona: auditor


### PR DESCRIPTION
## Summary

Resolves the remaining open zizmor `github-app` alert on [`release.yml:250`](https://github.com/starhaven-io/pinprick/security/code-scanning/9). The `tap-token` step is already correctly scoped with `repositories: homebrew-tap` and `permission-*` keys — the alert is a false positive caused by a `repository` vs `repositories` typo in zizmor 1.25.0's github-app audit. v0.5.6 of the action pulls in zizmor 1.25.2, where the typo is fixed.

Verified locally with zizmor 1.25.2 (`--persona=auditor`): `No findings to report`.