### PR TITLE
fix(ci): grant workflows:write to bump-cargo-tools token

### DIFF
--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -91,6 +91,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
The Update job mints an app token with `contents:write` + `pull-requests:write`, then commits to `.github/workflows/ci.yml`. GitHub blocks workflow-file mutations without `workflows:write`, so `createCommitOnBranch` returns `FORBIDDEN` / `Resource not accessible by integration`. Adds the missing permission. Requires that the `starhaven-bot` App registration has been granted the *Workflows* repository permission and the install upgrade accepted; without that, the token mint itself will fail.

See failing run: https://github.com/starhaven-io/pinprick/actions/runs/26398440794/job/77704603792