### PR TITLE
chore: upgrade Node to 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
         if: matrix.check == 'site'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Install site dependencies
         if: matrix.check == 'site'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 26
           package-manager-cache: false
 
       - name: Install dependencies

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 26
           package-manager-cache: false
 
       - name: Install dependencies

--- a/site/package.json
+++ b/site/package.json
@@ -2,7 +2,7 @@
   "name": "pinprick.rs",
   "type": "module",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=26.0.0"
   },
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Bumps Node from 24 to 26 in CI/deploy/link-check workflows and the site `engines` field. Verified `npm run build` and `npm run format:check` pass locally on Node 26.