### PR TITLE
fix(audit): flag pip git+URL refs that track a branch

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -2000,4 +2000,21 @@ runs:
         );
         assert!(c.findings.is_empty());
     }
+
+    #[test]
+    fn shell_scan_pip_git_url_branch_ref_is_finding() {
+        // `@main` tracks the branch HEAD — not a pin, so it must still fire.
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "pip install git+https://github.com/owner/repo.git@main",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "medium");
+        assert!(c.findings[0].description.contains("git+URL"));
+    }
 }

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -527,12 +527,10 @@ pub fn ps_install_has_required_version(line: &str) -> bool {
     PS_VERSION.is_match(line)
 }
 
-/// Check if a `pip install git+https://...` line is pinned to an immutable
-/// ref. A full 40-char commit SHA or a version-like tag (`@v1.2.3`) counts as
-/// pinned; a branch ref (`@main`, `@develop`) does not — it tracks the branch
-/// HEAD, which is exactly the risk this rule flags. The greedy `\S+` anchors
-/// the capture at the *last* `@`, so a `user@host` userinfo prefix doesn't
-/// steal the ref. A `#egg=` fragment or trailing flag terminates the ref.
+/// Whether a `pip install git+https://…` line is pinned to an immutable ref: a
+/// full 40-char SHA or a version-like tag (`@v1.2.3`). A branch ref (`@main`) is
+/// not — it tracks HEAD, the risk this rule flags. The greedy `\S+` anchors on
+/// the last `@`, so a `user@host` prefix isn't mistaken for the ref.
 pub fn pip_git_url_has_ref(line: &str) -> bool {
     static GIT_URL_REF: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\bgit\+https?://\S+@([^@#\s]+)").unwrap());

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -527,11 +527,25 @@ pub fn ps_install_has_required_version(line: &str) -> bool {
     PS_VERSION.is_match(line)
 }
 
-/// Check if a `pip install git+https://...` line has a ref (`@<ref>`) on the git URL.
+/// Check if a `pip install git+https://...` line is pinned to an immutable
+/// ref. A full 40-char commit SHA or a version-like tag (`@v1.2.3`) counts as
+/// pinned; a branch ref (`@main`, `@develop`) does not — it tracks the branch
+/// HEAD, which is exactly the risk this rule flags. The greedy `\S+` anchors
+/// the capture at the *last* `@`, so a `user@host` userinfo prefix doesn't
+/// steal the ref. A `#egg=` fragment or trailing flag terminates the ref.
 pub fn pip_git_url_has_ref(line: &str) -> bool {
     static GIT_URL_REF: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\bgit\+https?://\S+@\S+").unwrap());
-    GIT_URL_REF.is_match(line)
+        LazyLock::new(|| Regex::new(r"\bgit\+https?://\S+@([^@#\s]+)").unwrap());
+    let Some(caps) = GIT_URL_REF.captures(line) else {
+        return false;
+    };
+    let git_ref = &caps[1];
+    is_full_sha(git_ref) || ref_looks_versioned(git_ref)
+}
+
+/// True if `s` is a full 40-character hex commit SHA.
+fn is_full_sha(s: &str) -> bool {
+    s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 pub fn category_str(c: &Category) -> &'static str {
@@ -1484,15 +1498,35 @@ mod tests {
     }
 
     #[test]
-    fn pip_install_git_url_with_ref_helper() {
+    fn pip_install_git_url_versioned_or_sha_is_pinned() {
+        // Version-like tag and a full 40-char SHA are immutable pins.
         assert!(pip_git_url_has_ref(
             "pip install git+https://github.com/owner/repo.git@v1.2.3"
         ));
         assert!(pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+        ));
+        // The ref terminates at a `#egg=` fragment.
+        assert!(pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@v1.2.3#egg=foo"
+        ));
+        // A `user@host` userinfo prefix must not be mistaken for the ref.
+        assert!(pip_git_url_has_ref(
+            "pip install git+https://git@github.com/owner/repo.git@v1.2.3"
+        ));
+    }
+
+    #[test]
+    fn pip_install_git_url_branch_ref_is_not_pinned() {
+        // A branch ref tracks HEAD — not a durable pin, so the rule still fires.
+        assert!(!pip_git_url_has_ref(
             "pip install git+https://github.com/owner/repo.git@main"
         ));
-        assert!(pip_git_url_has_ref(
-            "pip install git+https://github.com/owner/repo.git@abc1234567890abcdef1234567890abcdef123456"
+        assert!(!pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@develop"
+        ));
+        assert!(!pip_git_url_has_ref(
+            "pip install git+https://github.com/owner/repo.git@feature/foo"
         ));
     }
 


### PR DESCRIPTION
`pip_git_url_has_ref` previously treated any `@<ref>` on a `pip install git+https://…` line as a pin. A branch ref such as `@main` therefore suppressed the finding, even though it tracks the branch HEAD — the exact runtime supply-chain risk this rule is meant to catch.

The helper now captures the ref and only treats a full 40-char commit SHA or a version-like tag (`@v1.2.3`) as pinned, matching how `git_clone_has_pinned_ref` already distinguishes a version from a branch. The match anchors on the last `@`, so a `user@host` userinfo prefix is not mistaken for the ref, and a `#egg=` fragment terminates it.