### PR TITLE
docs: update Claude co-author trailer to Opus 4.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
 
 All commits must:
 - Use `git commit -s` for DCO sign-off
-- Include a `Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>` trailer when authored with Claude
+- Include a `Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>` trailer when authored with Claude (bump the version as newer models ship)
 
 ## Git workflow
 


### PR DESCRIPTION
The contributor convention in `CLAUDE.md` named `Claude Opus 4.7` in the co-author trailer. The trailer should track whatever model is actually doing the work, so this bumps it to `4.8` and notes that it should be updated as newer models ship.