### PR TITLE
fix(audit): don't flag multi-stage FROM <stage> or FROM scratch

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -667,6 +667,14 @@ fn scan_dockerfile_content(
 ) {
     let lines: Vec<&str> = content.lines().collect();
 
+    // Multi-stage builds name stages via `FROM … AS <name>`. Collect those
+    // names so a later `FROM <name>` is recognized as a stage reference, not an
+    // image pull — otherwise it false-positives as an untagged image.
+    let stage_names: HashSet<String> = lines
+        .iter()
+        .filter_map(|line| audit_patterns::dockerfile_stage_alias(line))
+        .collect();
+
     // Escalate `RUN curl ... | sh` from medium (DOCKER_RUN_CURL) to high.
     let mut pipe_shell_lines: HashSet<usize> = HashSet::new();
     for (i, line) in lines.iter().enumerate() {
@@ -692,6 +700,13 @@ fn scan_dockerfile_content(
             continue;
         }
         if pipe_shell_lines.contains(&line_num) {
+            continue;
+        }
+        // `FROM <stage>` (an earlier build stage) and `FROM scratch` (the empty
+        // base) are not unpinned image pulls — there's nothing to pin.
+        if let Some(base) = audit_patterns::dockerfile_from_base(line)
+            && (base == "scratch" || stage_names.contains(&base))
+        {
             continue;
         }
 
@@ -1678,6 +1693,85 @@ more stuff
             &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn dockerfile_from_named_stage_not_flagged() {
+        // `FROM builder` references the stage defined above, not an image pull.
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM golang:1.21 AS builder\nRUN echo build\nFROM builder\nRUN echo package\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(
+            c.findings.is_empty(),
+            "findings: {:?}",
+            c.findings
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dockerfile_from_scratch_not_flagged() {
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM golang:1.21 AS builder\nFROM scratch\nCOPY --from=builder /app /app\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(
+            c.findings.is_empty(),
+            "findings: {:?}",
+            c.findings
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dockerfile_stage_alias_collected_with_platform_flag() {
+        // The stage is declared with a --platform flag; the later `FROM builder`
+        // must still be recognized as a stage reference.
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM --platform=$BUILDPLATFORM golang:1.21 AS builder\nFROM builder\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(
+            c.findings.is_empty(),
+            "findings: {:?}",
+            c.findings
+                .iter()
+                .map(|f| &f.description)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dockerfile_untagged_base_with_stage_name_still_flagged() {
+        // `FROM ubuntu AS builder` pulls untagged ubuntu (implicitly :latest);
+        // naming the stage must not suppress the finding on the real base.
+        let mut c = AuditCollector::new(false);
+        scan_dockerfile_content(
+            "FROM ubuntu AS builder\nRUN echo hi\n",
+            "Dockerfile",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert!(c.findings[0].description.contains("FROM without tag"));
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -482,6 +482,22 @@ pub fn has_git_checkout_sha(line: &str) -> bool {
     GIT_CHECKOUT_SHA.is_match(line)
 }
 
+/// The stage name a `FROM … AS <name>` line declares, lowercased. Tolerates a
+/// leading `--platform=…` flag by matching the trailing `AS <name>` rather than
+/// a fixed position. Returns `None` when the line declares no stage alias.
+pub fn dockerfile_stage_alias(line: &str) -> Option<String> {
+    static FROM_AS: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)^FROM\b.*\bAS\s+(\S+)\s*$").unwrap());
+    FROM_AS.captures(line).map(|c| c[1].to_ascii_lowercase())
+}
+
+/// The base image/stage a `FROM <base>` line references, lowercased. Returns
+/// `None` when the line is not a `FROM` instruction.
+pub fn dockerfile_from_base(line: &str) -> Option<String> {
+    static FROM_BASE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^FROM\s+(\S+)").unwrap());
+    FROM_BASE.captures(line).map(|c| c[1].to_ascii_lowercase())
+}
+
 /// Check if a `pip install` line has a version specifier or uses `-r`.
 pub fn pip_install_has_version(line: &str) -> bool {
     static PIP_VERSION: LazyLock<Regex> = LazyLock::new(|| {
@@ -979,6 +995,49 @@ mod tests {
     #[test]
     fn docker_add_case_insensitive() {
         assert!(DOCKER_ADD_URL.is_match("add https://example.com/tool.tgz /opt/"));
+    }
+
+    // ── Dockerfile stage helpers ───────────────────────────────────────
+
+    #[test]
+    fn dockerfile_stage_alias_extracts_lowercased_name() {
+        assert_eq!(
+            dockerfile_stage_alias("FROM golang:1.21 AS builder").as_deref(),
+            Some("builder")
+        );
+        // Case-insensitive keyword, lowercased result.
+        assert_eq!(
+            dockerfile_stage_alias("from node:20 as Builder").as_deref(),
+            Some("builder")
+        );
+        // Tolerates a leading --platform flag.
+        assert_eq!(
+            dockerfile_stage_alias("FROM --platform=$BUILDPLATFORM golang:1.21 AS web").as_deref(),
+            Some("web")
+        );
+    }
+
+    #[test]
+    fn dockerfile_stage_alias_none_without_as() {
+        assert_eq!(dockerfile_stage_alias("FROM ubuntu:22.04"), None);
+        assert_eq!(dockerfile_stage_alias("RUN echo hello"), None);
+    }
+
+    #[test]
+    fn dockerfile_from_base_extracts_lowercased_base() {
+        assert_eq!(
+            dockerfile_from_base("FROM ubuntu:22.04").as_deref(),
+            Some("ubuntu:22.04")
+        );
+        assert_eq!(
+            dockerfile_from_base("FROM scratch").as_deref(),
+            Some("scratch")
+        );
+        assert_eq!(
+            dockerfile_from_base("FROM builder AS final").as_deref(),
+            Some("builder")
+        );
+        assert_eq!(dockerfile_from_base("RUN echo hello"), None);
     }
 
     // ── PowerShell patterns ────────────────────────────────────────────


### PR DESCRIPTION
`scan_dockerfile_content` flagged `FROM <stage>` — a build stage named earlier via `AS <name>` — and `FROM scratch` (the empty base) as `FROM without tag — implicitly pulls :latest`. Both are false positives: a stage reference is not an image pull, and `scratch` cannot be pinned. Multi-stage builds and `scratch` bases are common in the Docker-based actions pinprick scans, so this was a recurring source of noise.

The scanner now collects stage aliases declared via `FROM … AS <name>` (tolerating a leading `--platform` flag) and skips a later `FROM <name>` or `FROM scratch`, mirroring the existing digest-pinned skip. A real untagged base that also names a stage (`FROM ubuntu AS builder`) still fires.