### PR TITLE
chore: correct audit-actions gating and refresh stale docs

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      updated: ${{ steps.scan.outputs.updated }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -185,7 +187,7 @@ jobs:
   update:
     name: Update
     needs: scan
-    if: needs.scan.result == 'success'
+    if: needs.scan.outputs.updated == '1'
     runs-on: ubuntu-slim
     environment:
       name: starhaven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pinprick/
 - `pinprick pin [PATH] [--write]` — Scan `.github/workflows/*.yml`, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
 - `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
 - `pinprick audit [PATH] [--verbose] [--sarif]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans only local `run:` blocks. With a token, also fetches and scans action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning.
-- `pinprick score [PATH] [--html]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md`. v0.3.0 emits `pin.*`, `workflow.*`, `source.unverified`, and `runtime.*` findings (all offline, no token required). `runtime.*` rules reuse the `audit` shell pipeline against each workflow's `run:` blocks, distinguishing pipe-to-shell (-20) from severity-graded fetches (-15/-8/-3). `source.unverified` uses a baseline of trusted publishers (`actions`, `github`) extended by `trusted-owners` in `.pinprick.toml`. Exits 1 when any findings exist (matches `audit` for CI gating); outputs JSON with `--json` or a self-contained HTML report with `--html` (mutually exclusive with `--json`).
+- `pinprick score [PATH] [--html]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md` (rubric v0.5.0). The offline rules (`pin.*`, `workflow.*`, `source.unverified`, `runtime.*`) need no token; with a token it additionally emits the token-gated `source.archived` and `source.advisory` rules. `runtime.*` rules reuse the `audit` shell pipeline against each workflow's `run:` blocks, distinguishing pipe-to-shell (-20) from severity-graded fetches (-15/-8/-3). `source.unverified` uses a baseline of trusted publishers (`actions`, `github`) extended by `trusted-owners` in `.pinprick.toml`. Exits 1 when any findings exist (matches `audit` for CI gating); outputs JSON with `--json` or a self-contained HTML report with `--html` (mutually exclusive with `--json`).
 - `pinprick clean` — Remove locally cached audit results (`~/.cache/pinprick/audited/`).
 - `pinprick completions <SHELL>` — Generate shell completions for bash, zsh, fish, etc.
 
@@ -112,11 +112,14 @@ Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name
 ## CI workflows (.github/workflows/)
 
 - **audit-actions.yml** — Weekly scan of tracked actions for new releases, automated PRs for clean entries
-- **ci.yml** — Dynamic matrix PR checks: conventional commits, clippy + rustfmt + typos, cargo test, site format + build, audited-actions verification, zizmor
-- **codeql.yml** — CodeQL security analysis on push to main
+- **bump-cargo-tools.yml** — Weekly check for newer versions of the cargo-installed CI lint tools (typos, cargo-deny, cargo-nextest, cargo-llvm-cov); opens a PR bumping the pins in ci.yml
+- **ci.yml** — Dynamic matrix PR checks: conventional commits, clippy + rustfmt + typos, cargo test, coverage, site format + build, audited-actions verification, zizmor
+- **codeql.yml** — CodeQL security analysis (actions queries) on push to main
 - **deploy-site.yml** — Build and deploy Astro site to Cloudflare Workers
-- **release.yml** — Manual dispatch: build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io
+- **link-check.yml** — Weekly lychee broken-link check across the built site and README
 - **pinprick-audit.yml** — Run pinprick audit on its own workflows with SARIF upload
+- **refresh-cargo-lockfile.yml** — Weekly `cargo update` to pick up transitive dependency bumps Dependabot does not file PRs for; opens a PR
+- **release.yml** — Manual dispatch: build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io, bump the Homebrew cask
 - **zizmor.yml** — GitHub Actions security audit on push to main
 
 ## Commit conventions

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,9 @@ confidence-threshold = 0.95
 unused-allowed-license = "allow"
 
 [advisories]
+# Flag unmaintained crates anywhere in the tree, not just workspace members
+# (cargo-deny's default for this check is "workspace").
+unmaintained = "all"
 
 [sources]
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -96,7 +96,7 @@ These fire once per workflow, not per action use.
 | `workflow.pull_request_target` | Workflow uses the `pull_request_target` trigger     | high     |    5   | live   | Validate the checkout ref; avoid running PR code with elevated tokens |
 | `workflow.workflow_run`     | Workflow uses the `workflow_run` trigger              | medium   |    3   | live   | Explicitly validate trigger provenance                |
 
-The `pull_request_target` and `workflow_run` rules fire on trigger *presence* in v0.1.0. A future release may narrow to "without explicit guardrails" once the parser can recognize common safe patterns (e.g., validating the checkout ref).
+The `pull_request_target` and `workflow_run` rules fire on trigger *presence* as of v0.5.0. A future release may narrow to "without explicit guardrails" once the parser can recognize common safe patterns (e.g., validating the checkout ref).
 
 ### Future categories (not in v1)
 
@@ -114,7 +114,7 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 
 ```jsonc
 {
-  "rubric_version": "0.1.0",
+  "rubric_version": "0.5.0",
   "pinprick_version": "…",
   "scanned_at": "2026-04-22T20:00:00Z",
   "target": { "kind": "repo", "path": "./" },
@@ -149,7 +149,7 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 A compact summary:
 
 ```
-pinprick score  v0.1.0 rubric
+pinprick score  v0.5.0 rubric
 
   Grade:  C   (72 / 100)
 


### PR DESCRIPTION
The weekly audit-actions `update` job ran whenever `scan` succeeded, but `scan` exposed no job-level output and uploaded its results artifact only when it found changes. On a week with no new releases the `update` job therefore failed at `download-artifact`. Gate it on a new `scan.outputs.updated`, matching the `bump-cargo-tools` and `refresh-cargo-lockfile` bots.

Also refreshes stale docs: syncs the scoring spec examples and the CLAUDE.md score-command description to rubric 0.5.0, completes the CI workflow list, and sets cargo-deny's `unmaintained` check to `all` so unmaintained transitive dependencies are flagged.
