### PR TITLE
test: isolate per-test HOME and make clean tests deterministic

### DIFF
--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -3,15 +3,34 @@ mod common;
 use predicates::prelude::*;
 
 #[test]
-fn human_output() {
+fn reports_nothing_to_clean_when_cache_absent() {
+    // A fresh per-test HOME has no cache directory, so this is deterministic.
     common::pinprick_cmd()
         .arg("clean")
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("Cache cleaned.")
-                .or(predicate::str::contains("Nothing to clean.")),
-        );
+        .stdout(predicate::str::contains("Nothing to clean."));
+}
+
+#[test]
+fn reports_cache_cleaned_when_present() {
+    // Seed a cache directory under an isolated HOME, then clean it.
+    let home = tempfile::TempDir::new().unwrap();
+    let cache = home.path().join(".cache/pinprick/audited");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(cache.join("actions.json"), "[]").unwrap();
+
+    assert_cmd::Command::cargo_bin("pinprick")
+        .unwrap()
+        .env("GITHUB_TOKEN", "")
+        .env("GH_TOKEN", "")
+        .env("HOME", home.path())
+        .arg("--color")
+        .arg("never")
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cache cleaned."));
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::fs;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
 /// Create a temporary repo directory with one workflow file.
@@ -30,14 +31,19 @@ pub fn repo_with_config(filename: &str, workflow: &str, config: &str) -> TempDir
     dir
 }
 
-/// Build an `assert_cmd::Command` for pinprick with token stripped, colors off,
-/// and HOME pointed at a temp location to avoid global config interference.
+/// Build an `assert_cmd::Command` for pinprick with the token stripped, colors
+/// off, and HOME pointed at a unique temp path per invocation. The per-call HOME
+/// isolates the audit cache (`~/.cache/pinprick`) and global config
+/// (`~/.config/pinprick`) so parallel test processes can't race on, or poison,
+/// a shared directory.
 pub fn pinprick_cmd() -> assert_cmd::Command {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let mut cmd = assert_cmd::Command::cargo_bin("pinprick").unwrap();
     cmd.env("GITHUB_TOKEN", "");
     cmd.env("GH_TOKEN", "");
-    cmd.env("HOME", "/tmp/pinprick-test-home");
-    cmd.env("XDG_CONFIG_HOME", "/tmp/pinprick-test-config");
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let home = std::env::temp_dir().join(format!("pinprick-test-{}-{n}", std::process::id()));
+    cmd.env("HOME", &home);
     cmd.arg("--color").arg("never");
     cmd
 }


### PR DESCRIPTION
Test-suite hygiene from the review:

- **Per-test isolated HOME.** The harness pinned `HOME=/tmp/pinprick-test-home` for every test, so the audit cache and global-config lookup were shared mutable state across parallel test processes — a race, and poisonable by a stray real file on the dev/CI box. Each `pinprick_cmd()` invocation now gets a unique temp HOME.
- **Drop the dead `XDG_CONFIG_HOME`.** The global-config loader reads `$HOME/.config`, never `XDG_CONFIG_HOME`, so that override did nothing.
- **Deterministic `clean` tests.** With isolated HOMEs the output is predictable, so the either/or assertion (which passed on both branches and verified nothing) is split into two real tests: "Nothing to clean." on an empty cache and "Cache cleaned." on a seeded one.

This is the final test-hardening chunk of the review. The remaining network-path coverage (a mock-server seam) was deliberately deferred — it would add a dev-dependency and a base-URL seam through the security-critical GitHub URL code for advisory-only coverage.
