### PR TITLE
docs: trim verbose comments to their kernel

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -90,8 +90,7 @@ pub async fn run(
         let content = match std::fs::read_to_string(file) {
             Ok(content) => content,
             Err(e) => {
-                // One unreadable or non-UTF-8 workflow must not abort the whole
-                // scan — skip it and keep auditing the rest.
+                // One unreadable/non-UTF-8 workflow shouldn't abort the scan.
                 eprintln!("  {} {display_name}: {e}", "skipped".yellow());
                 continue;
             }
@@ -111,9 +110,8 @@ pub async fn run(
                 }
             }
             Err(e) => {
-                // A workflow GitHub accepts but serde_norway rejects shouldn't
-                // sink the scan; skip its run-block extraction (the regex-based
-                // `uses:` scan below still runs on the same content).
+                // Unparsable YAML shouldn't sink the scan; the `uses:` regex
+                // scan below still runs.
                 eprintln!(
                     "  {} run-block scan of {display_name}: {e}",
                     "skipped".yellow()
@@ -801,11 +799,9 @@ fn check_url_patterns(
         if !pattern.regex.is_match(line) {
             continue;
         }
-        // Examine EVERY URL on the line, not just the first. The line is only
-        // "allowed" if all of its URLs are exempt (versioned, trusted host, or
-        // a data format); the first URL that is unversioned, untrusted, and not
-        // a data format makes it a finding. Checking only the first URL let a
-        // versioned/trusted decoy placed before the real fetch suppress it.
+        // Check EVERY URL, not just the first: a versioned/trusted decoy before
+        // the real fetch must not suppress the finding. Allowed only if all URLs
+        // are exempt; any unexempt one is a finding.
         let mut allowed_reason: Option<&str> = None;
         let mut dangerous = false;
         for url in extract_urls(line) {
@@ -834,8 +830,7 @@ fn check_url_patterns(
                 workflow_line: None,
             });
         } else if let Some(reason) = allowed_reason {
-            // Every URL on the line was exempt; record an allowed match
-            // (visible under --verbose) tagged with the first URL's reason.
+            // All URLs exempt — record an allowed match (shown under --verbose).
             collector.push_allowed(AuditMatch {
                 severity: output::severity_str(&pattern.severity).to_string(),
                 category: category_str(&pattern.category).to_string(),
@@ -846,8 +841,7 @@ fn check_url_patterns(
                 reason: reason.to_string(),
             });
         }
-        // No URL on the line: nothing to record (matches the prior behavior of
-        // skipping when no URL could be extracted).
+        // No URL on the line: nothing to record.
     }
 }
 
@@ -1723,7 +1717,7 @@ more stuff
     #[test]
     fn js_minified_line_splitting() {
         let mut c = AuditCollector::new(false);
-        // Build a line > 500 chars with a fetch call buried in it
+        // A >500-char minified line with a fetch buried inside.
         let padding = "a".repeat(450);
         let minified = format!(
             r#"{}; const r = await fetch("https://example.com/api/data"); {}"#,

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -980,10 +980,8 @@ mod tests {
 
     #[test]
     fn js_exec_spawn_curl_detected() {
-        // exec()/execSync() still match…
         assert!(JS_EXEC_SPAWN_CURL.is_match(r#"exec("curl -L https://example.com")"#));
         assert!(JS_EXEC_SPAWN_CURL.is_match(r#"execSync(`curl ${url}`)"#));
-        // …and spawn()/spawnSync() shelling out to curl/wget now match too.
         assert!(JS_EXEC_SPAWN_CURL.is_match(r#"spawn("curl", ["-L", url])"#));
         assert!(JS_EXEC_SPAWN_CURL.is_match(r#"spawnSync("wget", [url])"#));
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,11 +72,8 @@ impl Config {
     /// Load config from global (~/.config/pinprick/config.toml) and per-repo (.pinprick.toml).
     /// Per-repo overrides global. Missing files are fine — defaults are used.
     pub fn load(repo_root: &Path) -> Self {
-        // Per-repo takes precedence. A malformed per-repo file falls back to
-        // DEFAULTS, not the global config: the author meant to configure THIS
-        // repo, so silently substituting an unrelated global policy is more
-        // surprising than using documented defaults. Global is consulted only
-        // when there is no per-repo file at all.
+        // Per-repo wins; a malformed per-repo file falls back to defaults (not
+        // global) — the author meant to configure THIS repo.
         match load_local(repo_root) {
             ConfigLoad::Loaded(local) => local,
             ConfigLoad::Malformed => Config::default(),
@@ -87,7 +84,6 @@ impl Config {
         }
     }
 
-    /// Returns the minimum severity level as a numeric value for comparison.
     pub fn severity_threshold(&self) -> u8 {
         match self.severity {
             SeverityFilter::High => 2,
@@ -174,19 +170,15 @@ fn ignore_pattern_matches(pattern: &str, action_name: &str) -> bool {
     if pattern.is_empty() {
         return false;
     }
-    // GitHub owner/repo slugs are case-insensitive, and every sibling matcher
-    // (trusted-hosts, trusted-owners, data formats) ignores case — so this one
-    // must too, or an ignore entry silently fails to match a differently-cased
-    // `uses:` line.
+    // GitHub slugs are case-insensitive, so match case-insensitively (like the
+    // sibling matchers) — else an ignore entry silently misses.
     let pattern = pattern.to_ascii_lowercase();
     let action_name = action_name.to_ascii_lowercase();
     action_name == pattern || action_name.starts_with(&format!("{pattern}/"))
 }
 
-/// Outcome of attempting to load a config file: present and valid, present but
-/// unparsable, or absent. The caller distinguishes `Malformed` from `Absent`
-/// because a malformed per-repo file must fall back to defaults, not inherit
-/// the global config.
+/// Load outcome; the caller distinguishes `Malformed` from `Absent` so a bad
+/// per-repo file falls back to defaults rather than inheriting global config.
 enum ConfigLoad {
     Loaded(Config),
     Malformed,
@@ -208,11 +200,9 @@ fn load_local(repo_root: &Path) -> ConfigLoad {
     load_file(&repo_root.join(".pinprick.toml"))
 }
 
-/// Load and parse a config file. A missing or unreadable file is `Absent`
-/// (defaults apply, silently — no config is the normal case). A file that
-/// exists but fails to parse is `Malformed`, and warns to stderr first: a
-/// silently-dropped config would leave the user thinking their `ignore` /
-/// `severity` / `trusted-*` rules are active when they aren't.
+/// Load and parse a config file. Missing/unreadable is `Absent` (the normal
+/// case). Present-but-unparsable is `Malformed` and warns — a silently-dropped
+/// config would leave the user thinking their rules are active when they aren't.
 fn load_file(path: &Path) -> ConfigLoad {
     let content = match std::fs::read_to_string(path) {
         Ok(content) => content,

--- a/src/github.rs
+++ b/src/github.rs
@@ -19,23 +19,18 @@ const MAX_RATE_LIMIT_WAIT: Duration = Duration::from_secs(60);
 /// Delay before retrying a transient 5xx or network error.
 const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-/// Total per-request timeout. Without one, a stalled connection hangs the whole
-/// run forever (the retry logic only fires on a completed response).
+/// Total per-request timeout — without one a stalled connection hangs forever.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Connection-establishment timeout.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Upper bound on a single buffered response body. Action source files and
-/// recursive trees are fetched from arbitrary repositories; a hostile or
-/// compromised endpoint could otherwise stream gigabytes into memory.
+/// Cap on a buffered response body — a hostile endpoint could otherwise stream
+/// gigabytes of "action source" into memory.
 pub(crate) const MAX_RESPONSE_BYTES: usize = 50 * 1024 * 1024;
 
-/// Build the shared HTTP client used for every outbound request: bounded
-/// request/connect timeouts so a stalled endpoint can't hang the run, and an
-/// explicit (bounded) redirect policy. reqwest strips the `Authorization`
-/// header on cross-host redirects, so following GitHub's content redirects is
-/// safe.
+/// Shared HTTP client with request/connect timeouts (a stalled endpoint can't
+/// hang the run) and a bounded redirect policy. reqwest strips `Authorization`
+/// on cross-host redirects, so following GitHub's content redirects is safe.
 pub(crate) fn build_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -45,10 +40,9 @@ pub(crate) fn build_client() -> reqwest::Client {
         .expect("failed to build HTTP client")
 }
 
-/// Read a response body into memory, failing if it exceeds [`MAX_RESPONSE_BYTES`].
-/// Streams chunk-by-chunk so an oversized body is rejected before it is fully
-/// buffered. Use for the unbounded-size fetches (action source, file trees,
-/// the remote catalog); the fixed-shape GitHub API responses don't need it.
+/// Read a response body, rejecting it past [`MAX_RESPONSE_BYTES`] before it is
+/// fully buffered. For the unbounded-size fetches (action source, trees, the
+/// remote catalog).
 pub(crate) async fn read_capped(mut resp: reqwest::Response) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     while let Some(chunk) = resp.chunk().await.context("reading response body")? {
@@ -58,9 +52,8 @@ pub(crate) async fn read_capped(mut resp: reqwest::Response) -> Result<Vec<u8>> 
     Ok(buf)
 }
 
-/// Error if appending `incoming` bytes to a buffer already holding `current`
-/// would exceed `max`. Split out from [`read_capped`] so the boundary logic is
-/// unit-testable without constructing a streaming response.
+/// The cap check, split from [`read_capped`] so it's unit-testable without a
+/// streaming response.
 fn within_cap(current: usize, incoming: usize, max: usize) -> Result<()> {
     if current + incoming > max {
         bail!("response body exceeds {max} bytes — refusing to buffer");
@@ -227,9 +220,8 @@ impl GitHubClient {
                     bail!(GitHubError::RateLimit);
                 }
                 403 | 429 if retry_after(&resp).is_some() => {
-                    // Secondary/abuse rate limit: GitHub returns 403/429 with a
-                    // `Retry-After` header and no zeroed `x-ratelimit-remaining`.
-                    // The concurrent source-fetch fan-out is what trips these.
+                    // Secondary/abuse rate limit: `Retry-After` with no zeroed
+                    // `x-ratelimit-remaining` (the concurrent fan-out trips these).
                     if let Some(wait) = retry_after(&resp)
                         && wait <= MAX_RATE_LIMIT_WAIT
                         && !last_attempt
@@ -264,7 +256,6 @@ impl GitHubClient {
 
         let git_ref: GitRef = resp.json().await.context("parsing tag ref response")?;
 
-        // If it's an annotated tag, follow to the commit
         if git_ref.object.object_type == "tag" {
             let tag_url = format!(
                 "https://api.github.com/repos/{owner}/{repo}/git/tags/{}",

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,16 +3,9 @@ use serde::Serialize;
 
 use crate::audit_patterns::Severity;
 
-/// Neutralize terminal control sequences in untrusted strings before printing.
-///
-/// `audit` and `score` echo data taken from scanned workflows and from action
-/// source code fetched out of arbitrary GitHub repositories (matched lines,
-/// action refs, file paths). Those bytes must never reach the terminal
-/// verbatim: an ANSI/OSC escape embedded in a matched source line could hide or
-/// spoof a finding in the operator's terminal. Every control character (C0, C1,
-/// DEL) except tab is replaced with U+FFFD, which renders visibly and inertly.
-/// JSON and SARIF output are unaffected — serde already escapes these as
-/// `\uXXXX`, so machine consumers still see the true bytes.
+/// Replace control chars (C0/C1/DEL, except tab) with U+FFFD so escape sequences
+/// in fetched action source can't spoof or hide findings in the terminal.
+/// JSON/SARIF are unaffected — serde already escapes control chars.
 pub(crate) fn sanitize_for_terminal(s: &str) -> String {
     s.chars()
         .map(|c| {
@@ -871,15 +864,11 @@ mod audit_summary_tests {
 
     #[test]
     fn sanitize_for_terminal_neutralizes_control_chars() {
-        // Plain text and non-control Unicode pass through untouched.
         assert_eq!(sanitize_for_terminal("plain text"), "plain text");
         assert_eq!(sanitize_for_terminal("café → núñez"), "café → núñez");
-        // Tabs are preserved; every other control char becomes U+FFFD.
+        // Tab is the one control char kept.
         assert_eq!(sanitize_for_terminal("keep\ttab"), "keep\ttab");
-        // An embedded ANSI clear-screen escape is defanged (ESC -> U+FFFD),
-        // leaving the rest inert and printable.
         assert_eq!(sanitize_for_terminal("a\u{1b}[2Jb"), "a\u{fffd}[2Jb");
-        // Carriage return (overwrite), newline, BEL, and DEL are all replaced.
         assert_eq!(
             sanitize_for_terminal("x\ry\nz\u{7}\u{7f}"),
             "x\u{fffd}y\u{fffd}z\u{fffd}\u{fffd}"

--- a/src/score.rs
+++ b/src/score.rs
@@ -286,10 +286,8 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<ScoreReport> {
                 );
             }
             for finding in &collector.findings {
-                // Respect explicit `ignore.patterns` suppressions — an accepted
-                // risk shouldn't be deducted. The `severity` display threshold is
-                // deliberately NOT applied: the posture score reflects every
-                // finding regardless of what `audit` chooses to print.
+                // Honor `ignore.patterns` (an accepted risk shouldn't score) but
+                // not the `severity` display threshold — the score is complete.
                 if config.is_pattern_ignored(&finding.description) {
                     continue;
                 }
@@ -389,10 +387,8 @@ fn recompute_score(report: &mut ScoreReport) {
     report.grade = grade_for(score);
 }
 
-/// A systemic GitHub failure — a rejected/expired token or a rate limit —
-/// as opposed to a per-repo 404 or transient network error. The token-gated
-/// enrichment passes must not silently grade a repo clean on one of these:
-/// it would turn an auth/rate-limit failure into a falsely high score.
+/// A systemic failure (bad token, rate limit) vs. a per-repo 404/network blip —
+/// enrichment must not silently grade a repo clean on one of these.
 fn is_hard_github_error(e: &anyhow::Error) -> bool {
     matches!(
         e.downcast_ref::<GitHubError>(),
@@ -400,9 +396,8 @@ fn is_hard_github_error(e: &anyhow::Error) -> bool {
     )
 }
 
-/// Warn (to stderr, so `--json`/`--html` on stdout stay clean) that a
-/// token-gated rule could not complete. The score is still emitted, but the
-/// user is told it reflects only the rules that actually ran.
+/// Warn (to stderr, so JSON/HTML stdout stays clean) that a token-gated rule
+/// couldn't complete — the score still emits but is incomplete.
 fn warn_enrichment_incomplete(rule: &str, e: &anyhow::Error) {
     eprintln!(
         "warning: {rule} could not be evaluated ({e}); score reflects only the rules that ran"
@@ -688,18 +683,13 @@ fn format_advisory_details(
 fn version_in_range(version: &str, range: &str) -> Option<bool> {
     let v = strip_v_prefix(version);
     let mut ver = semver::Version::parse(v).ok()?;
-    // Advisory ranges describe release versions, and semver's `VersionReq`
-    // refuses to match a pre-release (`2.0.0-rc1`) unless the comparator names
-    // the same pre-release — which would silently miss a vulnerable pre-release
-    // pin. Match on the numeric version by dropping pre-release/build metadata.
+    // semver's VersionReq won't match a pre-release (`2.0.0-rc1`) unless the
+    // comparator names one, so match on the numeric version only.
     ver.pre = semver::Prerelease::EMPTY;
     ver.build = semver::BuildMetadata::EMPTY;
 
-    // GitHub expresses ranges with `or` (a union of clauses) and `and`/comma
-    // (intersection within a clause), e.g. `>= 3.26.11 and <= 3.28.2, or >= 2.x`.
-    // semver has no `or` and uses a comma for `and`, so evaluate each `or` clause
-    // independently and match if any holds. Returns `None` only when NO clause is
-    // parsable, so a truly unparsable range is still treated as "no match".
+    // GitHub uses `or` (union) and `and`/comma (intersection); semver has no
+    // `or`, so match if any `or`-clause holds. None only if nothing parses.
     let mut parsed_any = false;
     for clause in range.split(" or ") {
         let clause = clause
@@ -708,8 +698,7 @@ fn version_in_range(version: &str, range: &str) -> Option<bool> {
             .trim()
             .replace(" and ", ", ");
         let r = normalize_range_string(&clause);
-        // A bare version literal (`1.2.3`) is an exact match, not semver's
-        // default caret (`^1.2.3`), which would both over- and under-match.
+        // A bare version (`1.2.3`) means exact, not semver's caret default.
         let r = if r.trim_start().starts_with(|c: char| c.is_ascii_digit()) {
             format!("={}", r.trim())
         } else {
@@ -725,10 +714,9 @@ fn version_in_range(version: &str, range: &str) -> Option<bool> {
     parsed_any.then_some(false)
 }
 
-/// True if this vulnerability entry describes the action being scored. One
-/// advisory can list several affected packages (e.g. an action *and* a CLI);
-/// matching the action's version against a different package's range is a
-/// false positive. GitHub Actions packages are named `owner/repo`.
+/// True if this vulnerability entry is for the action being scored. An advisory
+/// can list several packages (an action *and* a CLI); matching against another
+/// package's range is a false positive. Actions packages are named `owner/repo`.
 fn vuln_is_for_action(v: &AdvisoryVulnerability, owner: &str, repo: &str) -> bool {
     v.package
         .as_ref()
@@ -793,7 +781,6 @@ fn pin_rule_for(a: &ActionRef) -> Option<RuleId> {
 fn workflow_rules_for(doc: &Value) -> Vec<RuleId> {
     let mut rules = Vec::new();
 
-    // Top-level `permissions: write-all`
     if let Some(Value::String(s)) = doc.get("permissions")
         && s == "write-all"
     {
@@ -807,7 +794,6 @@ fn workflow_rules_for(doc: &Value) -> Vec<RuleId> {
         rules.push(RuleId::WorkflowPullRequestTarget);
     }
 
-    // `on.workflow_run`
     if let Some(on) = doc.get("on")
         && trigger_present(on, "workflow_run")
     {

--- a/src/update.rs
+++ b/src/update.rs
@@ -175,7 +175,6 @@ pub async fn run(
         report.print_human();
     }
 
-    // Exit code 1 if there are pending updates (dry-run mode)
     if has_updates && !apply {
         Ok(ExitCode::from(1))
     } else {
@@ -183,11 +182,9 @@ pub async fn run(
     }
 }
 
-/// Extract the version token a `# comment` leads with. pin/update and the bots
-/// write `# v1.2.3`, but humans annotate (`# v1.2.3 (pinned by renovate)`); the
-/// trailing words would defeat the `latest == current` fast-path and feed the
-/// lossy version parse. Take the leading `v?N…` token (up to the first space or
-/// `(`), falling back to the whole comment when it doesn't start with a version.
+/// The leading `v?N…` version token of a `# comment` (up to the first space or
+/// `(`), so an annotation like `# v1.2.3 (pinned)` doesn't break the comparison.
+/// Falls back to the whole comment when it doesn't start with a version.
 fn leading_version_token(comment: &str) -> String {
     let trimmed = comment.trim();
     let rest = trimmed.strip_prefix('v').unwrap_or(trimmed);
@@ -207,7 +204,6 @@ fn is_newer(current: &str, candidate: &str) -> bool {
     let (cur, cur_pre) = parse_version(current);
     let (cand, cand_pre) = parse_version(candidate);
 
-    // Compare component by component
     for (c, n) in cur.iter().zip(cand.iter()) {
         if n > c {
             return true;

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -12,7 +12,6 @@ pub struct ActionRef {
     pub ref_type: RefType,
     pub tag_comment: Option<String>,
     pub line_number: usize,
-    /// The full original line text
     pub raw_line: String,
 }
 
@@ -52,9 +51,8 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
     let mut ref_string = caps.get(3)?.as_str().to_string();
     let tag_comment = caps.get(5).map(|m| m.as_str().trim().to_string());
 
-    // A quoted `uses:` value (`uses: "owner/repo@v4"`) lands the opening quote
-    // on the action path and the closing quote on the ref; strip a matched pair
-    // so owner/repo and the ref classify correctly.
+    // Strip a matched surrounding quote pair: `uses: "owner/repo@v4"` puts the
+    // quotes on the path and ref, which would break classification.
     for q in ['"', '\''] {
         if action_path.starts_with(q) && ref_string.ends_with(q) {
             action_path = &action_path[1..];
@@ -119,8 +117,8 @@ pub fn build_pinned_line(line: &str, sha: &str, original_tag: &str) -> Option<St
     let action_path = caps.get(2)?.as_str();
     let ref_str = caps.get(3)?.as_str();
 
-    // Preserve a surrounding quote pair so `uses: "owner/repo@v4"` stays quoted
-    // and valid; the resolved-tag comment goes after the closing quote.
+    // Keep a surrounding quote pair so `uses: "owner/repo@v4"` stays valid; the
+    // comment goes after the closing quote.
     if let Some(q) = action_path
         .chars()
         .next()
@@ -220,8 +218,8 @@ pub fn rewrite_actions(
     let content =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
 
-    // Preserve the file's line terminator: `str::lines()` strips `\r`, so a CRLF
-    // workflow would otherwise be silently rewritten as LF across every line.
+    // Preserve CRLF: `str::lines()` strips `\r`, so we'd otherwise rewrite the
+    // whole file to LF.
     let newline = if content.contains("\r\n") {
         "\r\n"
     } else {
@@ -248,7 +246,6 @@ pub fn rewrite_actions(
         }
     }
 
-    // Preserve trailing newline if original had one
     let mut output = lines.join(newline);
     if content.ends_with('\n') {
         output.push_str(newline);


### PR DESCRIPTION
Tightens code comments across the codebase to a leaner bar: cut the ones that just restate the code, and compress multi-line explanations to their kernel — keeping the non-obvious *why* (security rationale, gotchas, invariants) in every case.

Net **−59 comment lines** across 8 files, no behavior change. Verified with `clippy -D warnings`, the full test suite, `fmt`, and `typos`.
