### PR TITLE
test: cover network paths with a wiremock seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +295,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,12 +409,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -394,6 +438,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -413,8 +485,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -500,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +641,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -810,6 +900,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +989,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,6 +1071,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "wiremock",
 ]
 
 [[package]]
@@ -2236,6 +2343,29 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 assert_cmd = "2"
 predicates = "3"
 tempfile = "3"
+wiremock = "0.6"
 
 [profile.release]
 lto = true

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -47,6 +47,9 @@ pub struct AuditedActions {
     fetch_remote: bool,
     local: HashMap<String, HashSet<String>>,
     remote: HashMap<String, HashSet<String>>,
+    /// Remote catalog origin, [`REMOTE_URL`] in production. Only the in-module
+    /// tests repoint it (at a local mock), so the production host is fixed.
+    remote_url: String,
 }
 
 impl AuditedActions {
@@ -58,6 +61,7 @@ impl AuditedActions {
             fetch_remote,
             local: HashMap::new(),
             remote: HashMap::new(),
+            remote_url: REMOTE_URL.to_string(),
         }
     }
 
@@ -137,7 +141,7 @@ impl AuditedActions {
     }
 
     async fn fetch_remote_list(&self, action_key: &str) -> Option<HashSet<String>> {
-        let url = format!("{REMOTE_URL}/{action_key}.json");
+        let url = format!("{}/{action_key}.json", self.remote_url);
         let resp = self
             .client
             .get(&url)
@@ -214,5 +218,68 @@ mod tests {
         assert_eq!(parsed[0]["tag"], r#"v1 "stable" \ release"#);
         // The reader still recovers the sha.
         assert!(parse_entries(&rendered).contains("abc123"));
+    }
+
+    mod remote {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        #[tokio::test]
+        async fn fetch_remote_list_parses_entries() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/actions/checkout.json"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "sha": "aaa", "tag": "v1" },
+                    { "sha": "bbb", "tag": "v2" }
+                ])))
+                .mount(&server)
+                .await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.remote_url = server.uri();
+            let shas = aa.fetch_remote_list("actions/checkout").await.unwrap();
+            assert!(shas.contains("aaa"));
+            assert!(shas.contains("bbb"));
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_non_success_is_none() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/actions/missing.json"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/missing").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn check_falls_through_to_remote_layer() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/some/action.json"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "sha": "feedface", "tag": "v3" }
+                ])))
+                .mount(&server)
+                .await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.remote_url = server.uri();
+            aa.cache_dir = None; // don't consult the real ~/.cache during the test
+            // Not bundled, no local cache hit → resolved by the remote layer.
+            assert_eq!(
+                aa.check("some", "action", "feedface").await,
+                Some(AuditSource::Remote)
+            );
+            // A SHA the remote list doesn't contain stays unaudited.
+            assert_eq!(aa.check("some", "action", "0000").await, None);
+        }
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -10,7 +10,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub struct GitHubClient {
     client: reqwest::Client,
     token: String,
+    /// API origin, always `https://api.github.com` in production. The
+    /// `#[cfg(test)]` constructor is the only way to point this elsewhere, so
+    /// production code can never be aimed at an attacker-controlled host.
+    base: String,
 }
+
+const GITHUB_API_BASE: &str = "https://api.github.com";
 
 /// Cap on how long we'll sleep waiting for a rate-limit reset. Longer waits
 /// would make `pin` / `update` appear hung from the user's perspective.
@@ -175,6 +181,19 @@ impl GitHubClient {
         Self {
             client: build_client(),
             token,
+            base: GITHUB_API_BASE.to_string(),
+        }
+    }
+
+    /// Build a client pointed at an arbitrary API origin. Test-only: it exists
+    /// to aim the client at a local mock server, and is gated so production
+    /// code keeps the `https://api.github.com` invariant.
+    #[cfg(test)]
+    pub(crate) fn with_base(token: String, base: String) -> Self {
+        Self {
+            client: build_client(),
+            token,
+            base,
         }
     }
 
@@ -243,7 +262,7 @@ impl GitHubClient {
 
     /// Resolve a tag to its commit SHA, following annotated tag objects.
     pub async fn resolve_tag(&self, owner: &str, repo: &str, tag: &str) -> Result<String> {
-        let url = format!("https://api.github.com/repos/{owner}/{repo}/git/ref/tags/{tag}");
+        let url = format!("{}/repos/{owner}/{repo}/git/ref/tags/{tag}", self.base);
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -258,8 +277,8 @@ impl GitHubClient {
 
         if git_ref.object.object_type == "tag" {
             let tag_url = format!(
-                "https://api.github.com/repos/{owner}/{repo}/git/tags/{}",
-                git_ref.object.sha
+                "{}/repos/{owner}/{repo}/git/tags/{}",
+                self.base, git_ref.object.sha
             );
             let tag_resp = self.get(&tag_url).await?;
             let tag_obj: TagObject = tag_resp.json().await.context("parsing tag object")?;
@@ -279,7 +298,8 @@ impl GitHubClient {
         original_tag: &str,
     ) -> String {
         let url = format!(
-            "https://api.github.com/repos/{owner}/{repo}/git/matching-refs/tags/{original_tag}"
+            "{}/repos/{owner}/{repo}/git/matching-refs/tags/{original_tag}",
+            self.base
         );
         let Ok(resp) = self.get(&url).await else {
             return original_tag.to_string();
@@ -306,7 +326,7 @@ impl GitHubClient {
     }
 
     async fn resolve_annotated_tag(&self, owner: &str, repo: &str, tag_sha: &str) -> String {
-        let url = format!("https://api.github.com/repos/{owner}/{repo}/git/tags/{tag_sha}");
+        let url = format!("{}/repos/{owner}/{repo}/git/tags/{tag_sha}", self.base);
         let Ok(resp) = self.get(&url).await else {
             return String::new();
         };
@@ -318,7 +338,7 @@ impl GitHubClient {
 
     /// List releases for a repo (first page, most recent first).
     pub async fn list_releases(&self, owner: &str, repo: &str) -> Result<Vec<Release>> {
-        let url = format!("https://api.github.com/repos/{owner}/{repo}/releases?per_page=30");
+        let url = format!("{}/repos/{owner}/{repo}/releases?per_page=30", self.base);
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -336,7 +356,7 @@ impl GitHubClient {
     /// the first 100 tags only — pinned actions are virtually always on a
     /// recent release tag, and paginating further isn't worth the latency.
     pub async fn sha_to_tag(&self, owner: &str, repo: &str, sha: &str) -> Result<Option<String>> {
-        let url = format!("https://api.github.com/repos/{owner}/{repo}/tags?per_page=100");
+        let url = format!("{}/repos/{owner}/{repo}/tags?per_page=100", self.base);
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
             bail!(GitHubError::RepoNotFound {
@@ -359,7 +379,8 @@ impl GitHubClient {
         repo: &str,
     ) -> Result<Vec<SecurityAdvisory>> {
         let url = format!(
-            "https://api.github.com/repos/{owner}/{repo}/security-advisories?state=published&per_page=100"
+            "{}/repos/{owner}/{repo}/security-advisories?state=published&per_page=100",
+            self.base
         );
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
@@ -373,7 +394,7 @@ impl GitHubClient {
 
     /// Return `true` if the repo is archived on GitHub.
     pub async fn is_archived(&self, owner: &str, repo: &str) -> Result<bool> {
-        let url = format!("https://api.github.com/repos/{owner}/{repo}");
+        let url = format!("{}/repos/{owner}/{repo}", self.base);
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -389,8 +410,10 @@ impl GitHubClient {
 
     /// Fetch the file tree for a repo at a given SHA.
     pub async fn fetch_tree(&self, owner: &str, repo: &str, sha: &str) -> Result<Vec<TreeEntry>> {
-        let url =
-            format!("https://api.github.com/repos/{owner}/{repo}/git/trees/{sha}?recursive=1");
+        let url = format!(
+            "{}/repos/{owner}/{repo}/git/trees/{sha}?recursive=1",
+            self.base
+        );
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
             bail!(GitHubError::RepoNotFound {
@@ -411,8 +434,10 @@ impl GitHubClient {
         path: &str,
         git_ref: &str,
     ) -> Result<String> {
-        let url =
-            format!("https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}");
+        let url = format!(
+            "{}/repos/{owner}/{repo}/contents/{path}?ref={git_ref}",
+            self.base
+        );
         let resp = self
             .client
             .get(&url)
@@ -504,5 +529,254 @@ mod tests {
     #[test]
     fn build_client_does_not_panic() {
         let _ = build_client();
+    }
+
+    mod network {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        async fn client_for(server: &MockServer) -> GitHubClient {
+            GitHubClient::with_base("test-token".into(), server.uri())
+        }
+
+        #[tokio::test]
+        async fn resolve_tag_lightweight() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/v1"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "object": { "sha": "deadbeef", "type": "commit" }
+                })))
+                .mount(&server)
+                .await;
+
+            let sha = client_for(&server)
+                .await
+                .resolve_tag("o", "r", "v1")
+                .await
+                .unwrap();
+            assert_eq!(sha, "deadbeef");
+        }
+
+        #[tokio::test]
+        async fn resolve_tag_follows_annotated_object() {
+            let server = MockServer::start().await;
+            // A `tag` object type means the ref points at an annotated tag; the
+            // commit lives behind a second dereference.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/v1"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "object": { "sha": "tagobjsha", "type": "tag" }
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/tags/tagobjsha"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "object": { "sha": "commitsha" }
+                })))
+                .mount(&server)
+                .await;
+
+            let sha = client_for(&server)
+                .await
+                .resolve_tag("o", "r", "v1")
+                .await
+                .unwrap();
+            assert_eq!(sha, "commitsha");
+        }
+
+        #[tokio::test]
+        async fn resolve_tag_missing_is_tag_not_found() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/nope"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+
+            let err = client_for(&server)
+                .await
+                .resolve_tag("o", "r", "nope")
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err.downcast_ref::<GitHubError>(),
+                Some(GitHubError::TagNotFound { .. })
+            ));
+        }
+
+        #[tokio::test]
+        async fn list_releases_parses_and_404_is_repo_not_found() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/releases"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "tag_name": "v2", "draft": false, "prerelease": false, "html_url": "u2" },
+                    { "tag_name": "v1", "draft": false, "prerelease": false, "html_url": null }
+                ])))
+                .mount(&server)
+                .await;
+            let releases = client_for(&server)
+                .await
+                .list_releases("o", "r")
+                .await
+                .unwrap();
+            assert_eq!(releases.len(), 2);
+            assert_eq!(releases[0].tag_name, "v2");
+
+            let missing = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/releases"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&missing)
+                .await;
+            let err = client_for(&missing)
+                .await
+                .list_releases("o", "r")
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err.downcast_ref::<GitHubError>(),
+                Some(GitHubError::RepoNotFound { .. })
+            ));
+        }
+
+        #[tokio::test]
+        async fn sha_to_tag_finds_match_or_none() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/tags"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "name": "v1", "commit": { "sha": "aaa" } },
+                    { "name": "v2", "commit": { "sha": "bbb" } }
+                ])))
+                .mount(&server)
+                .await;
+            let c = client_for(&server).await;
+            assert_eq!(
+                c.sha_to_tag("o", "r", "bbb").await.unwrap().as_deref(),
+                Some("v2")
+            );
+            assert_eq!(c.sha_to_tag("o", "r", "zzz").await.unwrap(), None);
+        }
+
+        #[tokio::test]
+        async fn is_archived_reads_repo_metadata() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "archived": true })))
+                .mount(&server)
+                .await;
+            assert!(
+                client_for(&server)
+                    .await
+                    .is_archived("o", "r")
+                    .await
+                    .unwrap()
+            );
+        }
+
+        #[tokio::test]
+        async fn list_security_advisories_404_is_empty() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/security-advisories"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            let advs = client_for(&server)
+                .await
+                .list_security_advisories("o", "r")
+                .await
+                .unwrap();
+            assert!(advs.is_empty());
+        }
+
+        #[tokio::test]
+        async fn fetch_tree_and_file() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/trees/sha"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "tree": [ { "path": "action.yml", "type": "blob" } ]
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/contents/action.yml"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_string("runs:\n  using: node20\n"),
+                )
+                .mount(&server)
+                .await;
+
+            let c = client_for(&server).await;
+            let tree = c.fetch_tree("o", "r", "sha").await.unwrap();
+            assert_eq!(tree[0].path, "action.yml");
+            let body = c.fetch_file("o", "r", "action.yml", "sha").await.unwrap();
+            assert!(body.contains("using: node20"));
+        }
+
+        #[tokio::test]
+        async fn primary_rate_limit_bails_when_reset_is_far_off() {
+            let server = MockServer::start().await;
+            // remaining=0 with a reset well beyond MAX_RATE_LIMIT_WAIT: the
+            // client must surface RateLimit immediately rather than sleep.
+            let reset = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 9_999;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/v1"))
+                .respond_with(
+                    ResponseTemplate::new(403)
+                        .insert_header("x-ratelimit-remaining", "0")
+                        .insert_header("x-ratelimit-reset", reset.to_string().as_str()),
+                )
+                .mount(&server)
+                .await;
+            let err = client_for(&server)
+                .await
+                .resolve_tag("o", "r", "v1")
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err.downcast_ref::<GitHubError>(),
+                Some(GitHubError::RateLimit)
+            ));
+        }
+
+        #[tokio::test]
+        async fn transient_5xx_is_retried_then_succeeds() {
+            let server = MockServer::start().await;
+            // First attempt 500 (higher priority, single-use), second 200.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/v1"))
+                .respond_with(ResponseTemplate::new(500))
+                .up_to_n_times(1)
+                .with_priority(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/git/ref/tags/v1"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "object": { "sha": "recovered", "type": "commit" }
+                })))
+                .with_priority(2)
+                .mount(&server)
+                .await;
+
+            let sha = client_for(&server)
+                .await
+                .resolve_tag("o", "r", "v1")
+                .await
+                .unwrap();
+            assert_eq!(sha, "recovered");
+        }
     }
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -2124,4 +2124,127 @@ jobs:
         let _ = severity_label(Severity::Medium);
         let _ = severity_label(Severity::High);
     }
+
+    mod enrichment {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        /// Write a single workflow pinning `o/r` at a 40-char SHA tagged v1.0.0,
+        /// then produce the offline base report the enrichers extend.
+        fn base_report(dir: &std::path::Path) -> ScoreReport {
+            let wfdir = dir.join(".github").join("workflows");
+            std::fs::create_dir_all(&wfdir).unwrap();
+            let sha = "a".repeat(40);
+            let yaml = format!(
+                "name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: o/r@{sha} # v1.0.0\n"
+            );
+            std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+            score_repo(dir, &Config::default()).unwrap()
+        }
+
+        #[tokio::test]
+        async fn source_archived_fires_when_repo_is_archived() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut report = base_report(dir.path());
+
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "archived": true })))
+                .mount(&server)
+                .await;
+            let client = GitHubClient::with_base("t".into(), server.uri());
+
+            enrich_with_source_archived(&mut report, dir.path(), &client)
+                .await
+                .unwrap();
+            assert!(report.findings.iter().any(|f| f.id == "source.archived"));
+        }
+
+        #[tokio::test]
+        async fn source_advisory_fires_when_pin_is_in_vulnerable_range() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut report = base_report(dir.path());
+
+            let server = MockServer::start().await;
+            // The SHA pin resolves to v1.0.0 via the tags endpoint...
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/tags"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "name": "v1.0.0", "commit": { "sha": "a".repeat(40) } }
+                ])))
+                .mount(&server)
+                .await;
+            // ...which falls inside this advisory's vulnerable range.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/security-advisories"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    {
+                        "ghsa_id": "GHSA-test",
+                        "html_url": "https://github.com/advisories/GHSA-test",
+                        "severity": "high",
+                        "summary": "vulnerable",
+                        "vulnerabilities": [
+                            {
+                                "package": { "name": "o/r" },
+                                "vulnerable_version_range": "< 1.1.0",
+                                "patched_versions": "1.1.0"
+                            }
+                        ]
+                    }
+                ])))
+                .mount(&server)
+                .await;
+            let client = GitHubClient::with_base("t".into(), server.uri());
+
+            enrich_with_source_advisory(&mut report, dir.path(), &client)
+                .await
+                .unwrap();
+            assert!(report.findings.iter().any(|f| f.id == "source.advisory"));
+        }
+
+        #[tokio::test]
+        async fn source_advisory_skips_when_package_does_not_match() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut report = base_report(dir.path());
+
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/tags"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "name": "v1.0.0", "commit": { "sha": "a".repeat(40) } }
+                ])))
+                .mount(&server)
+                .await;
+            // Advisory range covers v1.0.0 but is for a *co-listed* package, not
+            // the action — the #216 false-match guard must keep this silent.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/security-advisories"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    {
+                        "ghsa_id": "GHSA-other",
+                        "html_url": "https://github.com/advisories/GHSA-other",
+                        "severity": "high",
+                        "summary": "different package",
+                        "vulnerabilities": [
+                            {
+                                "package": { "name": "o/some-cli" },
+                                "vulnerable_version_range": "< 1.1.0",
+                                "patched_versions": "1.1.0"
+                            }
+                        ]
+                    }
+                ])))
+                .mount(&server)
+                .await;
+            let client = GitHubClient::with_base("t".into(), server.uri());
+
+            enrich_with_source_advisory(&mut report, dir.path(), &client)
+                .await
+                .unwrap();
+            assert!(!report.findings.iter().any(|f| f.id == "source.advisory"));
+        }
+    }
 }


### PR DESCRIPTION
Adds a `#[cfg(test)]`-only `with_base` constructor on `GitHubClient` and a matching `remote_url` field on `AuditedActions`, so the GitHub API client and the remote audited-actions catalog can be aimed at a local `wiremock` mock server in tests. The production origin stays fixed to `https://api.github.com` — the seam is gated out of non-test builds, so the host-pinning invariant is fully preserved.

New wiremock coverage:
- `github.rs`: tag resolution (lightweight + annotated two-hop), releases, sha→tag, archived, advisories, tree/file fetch, the primary-rate-limit bail path, and the 5xx retry-then-succeed path.
- `audited_actions.rs`: the remote catalog layer (`fetch_remote_list` parse/404 and `check` falling through to `Remote`).
- `score.rs`: the `source.archived` and `source.advisory` network enrichers end-to-end, including the #216 co-listed-package false-match guard.

Adds `wiremock` as a dev-dependency only (passes `cargo deny check`).