### PR TITLE
ci: track git hooks (pre-push + commit-msg DCO)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Enforce DCO sign-off on every local commit.
+# Commit messages must carry a "Signed-off-by:" trailer — add one with `git commit -s`.
+#
+# Enable this hook once per clone with: just install-hooks
+# (sets core.hooksPath to this directory).
+
+msg_file="$1"
+
+if ! grep -qE '^Signed-off-by: .+ <.+@.+>' "$msg_file"; then
+    echo "commit-msg hook: missing DCO sign-off." >&2
+    echo "  Re-run with 'git commit -s' to add a Signed-off-by trailer." >&2
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Runs the same checks as CI before pushing.
+just check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,8 @@ Conventional Commits format: `type(scope): description`
 Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
 
 All commits must:
-- Use `git commit -s` for DCO sign-off
-- Include a `Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>` trailer when authored with Claude (bump the version as newer models ship)
+- Sign off every commit with `git commit -s` for DCO (enforced by the `.githooks/commit-msg` hook — run `just install-hooks` once per clone to enable it).
+- Add a `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer when authored with Claude, placed after `Signed-off-by`. Bump the model version as newer ones ship.
 
 ## Git workflow
 

--- a/README.md
+++ b/README.md
@@ -214,11 +214,12 @@ just fmt            # Format code
 just typos          # Check for typos
 just audit          # Audit GitHub Actions workflows
 just check          # Run all checks (clippy, fmt, typos, zizmor, test, site)
+just install-hooks  # Install git hooks: pre-push check + DCO sign-off (once per clone)
 ```
 
 ## Contributing
 
-Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format and include a DCO sign-off (`git commit -s`).
+Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format and include a DCO sign-off (`git commit -s`). Run `just install-hooks` once per clone to enable the git hooks (a pre-push `just check` and DCO sign-off enforcement).
 
 ## Acknowledgements
 

--- a/justfile
+++ b/justfile
@@ -174,3 +174,7 @@ check:
         failed=1
     fi
     exit $failed
+
+# Install git hooks (DCO sign-off + pre-push checks) — run once per clone
+install-hooks:
+    git config core.hooksPath .githooks


### PR DESCRIPTION
Formalizes pinprick's previously machine-local pre-push hook into a tracked `.githooks/` enabled with `just install-hooks`: `pre-push` runs `just check` and `commit-msg` enforces DCO sign-off, with README/CLAUDE.md notes. Nothing machine-local remains, and the commit-trailer convention is aligned to the fleet-wide standard.