### PR TITLE
chore: release 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the version to 0.10.1 to cut a patch release. The 34 commits since 0.10.0 are bug fixes, hardening, and CI/test improvements — notably closing several audit runtime-fetch detection bypasses, correcting score advisory matching against GitHub range syntax, and hardening the GitHub HTTP client with timeouts, a body cap, and secondary rate-limit handling. No new features or breaking changes.