### PR TITLE
fix(deploy): correct wrangler config path and dry-run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,13 @@ jobs:
         working-directory: site
         run: npm run build
 
+      - name: Deploy dry-run
+        if: matrix.check == 'site'
+        working-directory: site
+        run: npm run deploy:dry
+        env:
+          WRANGLER_SEND_METRICS: 'false'
+
       # --- Verify Audited Actions ---
 
       - name: Check sort order

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "deploy": "wrangler deploy --config dist/server/wrangler.json",
+    "deploy": "wrangler deploy --config dist/client/wrangler.json",
+    "deploy:dry": "npm run deploy -- --dry-run",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
The npm-dependencies bump in #236 took `@astrojs/cloudflare` to 13.6.0, which emits the generated Worker config at `dist/client/wrangler.json` for fully-static builds instead of `dist/server/wrangler.json`. The site's `deploy` script still pointed at the old path, so `wrangler deploy` failed with ENOENT after a green build — that's the broken Deploy Site run on main.

This points the deploy script at the new path and adds a `deploy:dry` script that reuses `deploy` (keeping the config path in one place so the two can't drift). The Site check runs it right after the build, so a stale config path fails PR CI instead of slipping through to production. `wrangler deploy --dry-run` validates the path, assets directory, and bindings without needing Cloudflare credentials.
