### PR TITLE
fix(deploy): pin the SESSION KV namespace id

### DIFF
--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -8,4 +8,6 @@
     "binding": "ASSETS",
     "directory": "./dist/client",
   },
+  // Astro sessions KV: pin the id so the SESSION binding is explicit, not inherited from the live Worker.
+  "kv_namespaces": [{ "binding": "SESSION", "id": "8053289ef6d64c7786e52ce98720cf49" }],
 }


### PR DESCRIPTION
Pins the `SESSION` KV namespace id in `site/wrangler.jsonc`. The `@astrojs/cloudflare` adapter injects this binding without an id, so deploys currently inherit the namespace from the live Worker — pinning it makes the binding explicit and deterministic, matching the starhaven setup and removing any reliance on inheritance (or the experimental provisioning path that broke starhaven's re-deploys).

Verified with `npm run build && npm run deploy:dry`: the dry-run now reports `env.SESSION (8053289e…)` bound to the id instead of `(inherited)`.
