### PR TITLE
chore: fail cargo-deny on yanked crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -28,9 +28,10 @@ confidence-threshold = 0.95
 unused-allowed-license = "allow"
 
 [advisories]
-# Flag unmaintained crates anywhere in the tree, not just workspace members
-# (cargo-deny's default for this check is "workspace").
+# Scan the whole dep tree for unmaintained crates, not just workspace members (default: workspace).
 unmaintained = "all"
+# A yank usually signals a release pulled for a security or correctness problem (default: warn).
+yanked = "deny"
 
 [sources]
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
pinprick and midden each carried a different cargo-deny advisories hardening — pinprick had `unmaintained = "all"`, midden had `yanked = "deny"`. This brings pinprick up to the union so both repos share an identical `[advisories]` block: yanked crates now fail the check (a yank usually signals a release pulled for a security or correctness problem; the default only warns). Verified locally with `cargo deny check advisories` (clean). Comments trimmed to one line each.