### PR TITLE
ci: bound the cargo-debug cache to stop unbounded growth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  CARGO_INCREMENTAL: 0
+
 defaults:
   run:
     shell: bash -xeuo pipefail {0}
@@ -115,7 +118,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Restore coverage tools cache
         id: cov-tools-cache


### PR DESCRIPTION
The cargo-debug cache paired a whole-`target/` cache with `restore-keys`, so every Cargo.lock change restored the previous already-bloated `target/`, built on top of it, and saved a bigger one — an unbounded ladder that had reached 1.3 GB across four generations. Dropping the restore-keys makes each Cargo.lock state build clean once and then freeze (an exact-key hit skips the re-save), with superseded generations aging out on their own. `CARGO_INCREMENTAL=0` drops incremental-compilation artifacts that don't help in CI and only inflate the cache. This matches the cache shape macOSdb already uses. Tradeoff: a Cargo.lock change triggers one cold dependency rebuild instead of warm-starting from the prior lock's `target/`.
