### PR TITLE
fix(pin): exit 1 in dry-run for branch refs and failed resolutions

### DIFF
--- a/src/pin.rs
+++ b/src/pin.rs
@@ -21,6 +21,12 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
 
     let mut resolve_cache: HashMap<String, (String, String)> = HashMap::new();
 
+    // Actions that remain unpinned after the run: branch refs (which need a
+    // manual pin) and refs whose resolution failed. A dry run must exit 1 for
+    // these too — they are exactly what a CI gate exists to catch. Sliding-tag
+    // skips are excluded: those are warnings attached to a successful pin.
+    let mut unpinnable = 0usize;
+
     for file in &files {
         let display_name = workflow::display_path(file, repo_root);
         if !json {
@@ -34,6 +40,7 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
             match action.ref_type {
                 RefType::Sha => {}
                 RefType::Branch => {
+                    unpinnable += 1;
                     report.skipped.push(PinSkip {
                         file: workflow::display_path(file, repo_root),
                         action: format!("{}@{}", action.full_name(), action.ref_string),
@@ -112,6 +119,7 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
                             }
                         }
                         Err(e) => {
+                            unpinnable += 1;
                             report.skipped.push(PinSkip {
                                 file: workflow::display_path(file, repo_root),
                                 action: format!("{}@{}", action.full_name(), action.ref_string),
@@ -135,7 +143,7 @@ pub async fn run(repo_root: &Path, json: bool, apply: bool) -> Result<ExitCode> 
         report.print_human();
     }
 
-    if !apply && !report.pinned.is_empty() {
+    if !apply && (!report.pinned.is_empty() || unpinnable > 0) {
         Ok(ExitCode::from(1))
     } else {
         Ok(ExitCode::SUCCESS)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -186,3 +186,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: git clone --depth 1 --branch v1.2.3 https://github.com/org/repo
 ";
+
+/// One branch-ref action next to a SHA-pinned one. `pin` skips the branch ref
+/// without any network call, so this is usable with a dummy token.
+pub const WORKFLOW_BRANCH_REF: &str = "\
+name: branch-ref
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: owner/repo@main
+      - run: echo \"Hello World\"
+";

--- a/tests/pin.rs
+++ b/tests/pin.rs
@@ -25,6 +25,32 @@ fn no_token_human_error() {
 }
 
 #[test]
+fn branch_ref_dry_run_exits_one() {
+    // A branch ref is an unpinned action `pin` can't fix automatically; a CI
+    // gate must still fail on it. No network: the branch arm short-circuits
+    // before any API call, so a dummy token is enough.
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_BRANCH_REF);
+    common::pinprick_cmd()
+        .env("GITHUB_TOKEN", "dummy")
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("branch ref"));
+}
+
+#[test]
+fn all_pinned_dry_run_exits_zero() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .env("GITHUB_TOKEN", "dummy")
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(0);
+}
+
+#[test]
 fn no_token_json_error() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
     let output = common::pinprick_cmd()


### PR DESCRIPTION
The dry-run exit code only reflected resolvable tag refs: a repo whose unpinned actions were all branch refs (`@main`), or whose resolutions all errored, exited 0 and passed a CI gate — exactly the actions the gate exists to catch, and contrary to the documented contract. Branch-ref and resolution-failure skips now count as unpinnable and trigger exit 1 in dry-run. Sliding-tag skips stay excluded since they're warnings attached to a successful pin. Covered by two new network-free integration tests (branch ref → 1, all-pinned → 0).