### PR TITLE
ci: guard release dispatch to main and validate crates.io versions

### DIFF
--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -42,6 +42,13 @@ jobs:
               echo "::warning::Could not resolve latest version for ${TOOL}, skipping"
               continue
             fi
+            # The version flows into the sed replacements below — reject anything
+            # that isn't plain X.Y.Z so a hostile registry response can't inject
+            # arbitrary content into ci.yml.
+            if [[ ! "${LATEST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::warning::Unexpected version format for ${TOOL}: ${LATEST}, skipping"
+              continue
+            fi
 
             # Extract the currently pinned version, if any.
             CURRENT=$(grep -oE "cargo install ${TOOL} --locked --version [0-9]+\.[0-9]+\.[0-9]+" .github/workflows/ci.yml | awk '{print $NF}' | head -1 || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ permissions: {}
 jobs:
   build:
     name: Build (${{ matrix.target }})
+    # Releases come from main only — a dispatch from any other branch would
+    # tag and publish whatever that branch contains. Guarding the entry job
+    # skips the whole chain via `needs`.
+    if: github.ref == 'refs/heads/main'
     environment:
       name: release
       deployment: false


### PR DESCRIPTION
Two small hardening fixes from the CI review. release.yml's `workflow_dispatch` could be run from any branch, and the job chain would tag `github.sha` and publish a GitHub release (and the crate) from whatever branch was selected — the entry job is now gated on `refs/heads/main`, and the rest of the chain skips via `needs`. bump-cargo-tools.yml interpolated the crates.io `max_stable_version` string into `sed` replacements against ci.yml, so a hostile registry response containing sed metacharacters could inject arbitrary content into the workflow that the app token then commits as a PR; versions that aren't plain X.Y.Z are now rejected.