### PR TITLE
fix(update,pin): atomic rewrites, docker:// refs, smarter tag handling

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -47,9 +47,25 @@ pub async fn run(
             {
                 continue;
             }
-            let current_tag = match &action.tag_comment {
-                Some(t) => leading_version_token(t),
-                None => continue,
+            // Prefer the `# tag` comment; for a bare SHA pin without one (or a
+            // non-version annotation like `# pinned manually`), ask GitHub
+            // which tag points at the SHA instead of silently skipping — or,
+            // worse, comparing against the annotation text.
+            let comment_tag = action
+                .tag_comment
+                .as_deref()
+                .map(leading_version_token)
+                .filter(|t| is_version_like(t));
+            let current_tag = match comment_tag {
+                Some(t) => t,
+                None => match client
+                    .sha_to_tag(&action.owner, &action.repo, &action.ref_string)
+                    .await
+                {
+                    Ok(Some(tag)) => leading_version_token(&tag),
+                    // Unknown SHA or fetch failure — nothing to compare against.
+                    _ => continue,
+                },
             };
 
             if !json {
@@ -139,6 +155,14 @@ pub async fn run(
                 }
             };
 
+            // The "newer" tag can resolve to the commit already pinned (e.g. a
+            // sliding `# v4` comment next to the latest release's SHA) — that
+            // is not an update, just a different name for the same content.
+            if new_sha == action.ref_string {
+                report.up_to_date += 1;
+                continue;
+            }
+
             report.updates.push(UpdateResult {
                 file: workflow::display_path(file, repo_root),
                 action: action.full_name(),
@@ -196,10 +220,15 @@ fn pick_latest_release(releases: &[Release]) -> Option<&Release> {
 }
 
 /// Pick the highest version-like tag name. The release-less fallback path.
+/// Prefers stable tags — unlike releases, tags carry no `prerelease` flag, so
+/// a bare `v2.1.0-rc1` would otherwise win over `v2.0.0` and propose an RC.
 fn pick_latest_tag(tags: &[String]) -> Option<&String> {
-    tags.iter()
-        .filter(|t| is_version_like(t))
-        .reduce(|best, t| if is_newer(best, t) { t } else { best })
+    let pick = |stable_only: bool| {
+        tags.iter()
+            .filter(|t| is_version_like(t) && (!stable_only || !parse_version(t).1))
+            .reduce(|best, t| if is_newer(best, t) { t } else { best })
+    };
+    pick(true).or_else(|| pick(false))
 }
 
 /// Whether a tag looks like a version (`v1.2.3`, `2.0`) rather than a moving
@@ -391,6 +420,18 @@ mod tests {
         let tags = vec!["latest".to_string(), "stable".to_string()];
         assert_eq!(pick_latest_tag(&tags), None);
         assert_eq!(pick_latest_tag(&[]), None);
+    }
+
+    #[test]
+    fn pick_latest_tag_prefers_stable_over_newer_prerelease() {
+        let tags = vec!["v2.0.0".to_string(), "v2.1.0-rc1".to_string()];
+        assert_eq!(pick_latest_tag(&tags).unwrap(), "v2.0.0");
+    }
+
+    #[test]
+    fn pick_latest_tag_falls_back_to_prerelease_when_no_stable() {
+        let tags = vec!["v0.1.0-beta".to_string(), "v0.2.0-rc1".to_string()];
+        assert_eq!(pick_latest_tag(&tags).unwrap(), "v0.2.0-rc1");
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -65,6 +65,13 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
         return None;
     }
 
+    // `docker://image@sha256:…` is a container reference, not a GitHub repo —
+    // parsing it would misread `docker:` as an owner and a digest-pinned image
+    // as an unpinned branch ref.
+    if action_path.contains("://") {
+        return None;
+    }
+
     // Parse owner/repo[/subpath]
     let parts: Vec<&str> = action_path.splitn(3, '/').collect();
     if parts.len() < 2 {
@@ -251,7 +258,18 @@ pub fn rewrite_actions(
         output.push_str(newline);
     }
 
-    std::fs::write(path, &output).with_context(|| format!("writing {}", path.display()))?;
+    // Write to a sibling temp file and rename over the original so a crash or
+    // full disk mid-write can't leave a truncated workflow behind.
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("workflow");
+    let tmp = path.with_file_name(format!(".{file_name}.pinprick-tmp"));
+    std::fs::write(&tmp, &output).with_context(|| format!("writing {}", tmp.display()))?;
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("replacing {}", path.display()));
+    }
     Ok(count)
 }
 
@@ -260,6 +278,14 @@ mod tests {
     use super::*;
 
     // ── parse_uses_line ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_docker_ref_skipped() {
+        // A digest-pinned container reference is not a GitHub action and must
+        // not be misread as owner `docker:` with a branch ref.
+        assert!(parse_uses_line("      - uses: docker://alpine:3.20@sha256:abc123", 1).is_none());
+        assert!(parse_uses_line("      - uses: docker://ghcr.io/owner/image:v1", 1).is_none());
+    }
 
     #[test]
     fn parse_sliding_tag() {


### PR DESCRIPTION
Four robustness fixes from the review. Workflow rewrites now write to a sibling temp file and rename over the original, so a crash or full disk mid-write can't truncate a workflow. `parse_uses_line` returns `None` for container references — a digest-pinned `docker://image@sha256:…` previously parsed as owner `docker:` with a branch ref and was told to pin manually. `update` no longer skips SHA pins lacking a `# tag` comment (or carrying a non-version annotation like `# pinned manually`); it resolves the tag from the SHA via the tags API instead — the non-version case previously compared as text and flagged the action as outdated on every run. Finally, the release-less tag fallback prefers stable tags (a bare `v2.1.0-rc1` used to beat `v2.0.0` and propose an RC), and an update whose resolved SHA equals the pinned one now counts as up to date instead of proposing a comment-only rewrite.