### PR TITLE
feat(config): surface repo-local config impact and add --no-repo-config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Rate-limit handling: `github::get` retries once on network/5xx errors and sleeps
 
 ### Configuration
 
-A `.pinprick.toml` at the repo root (or `~/.config/pinprick/config.toml`) customizes behavior. Keys are all optional: `severity`, `fetch-remote`, `trusted-hosts`, `extra-data-formats`, `ignore.actions`, `ignore.patterns`. Per-repo wholly overrides global (no field-level merge).
+A `.pinprick.toml` at the repo root (or `~/.config/pinprick/config.toml`) customizes behavior. Keys are all optional: `severity`, `fetch-remote`, `trusted-hosts`, `trusted-owners`, `extra-data-formats`, `ignore.actions`, `ignore.patterns`. Per-repo wholly overrides global (no field-level merge). Because the scanned repo's own config applies, `audit`/`score` print a stderr notice whenever a repo-local config suppressed findings or extended trust, and accept `--no-repo-config` to ignore the repo's file (for scanning repositories you don't control).
 
 ### Audit patterns
 

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -39,6 +39,11 @@ When no GitHub token is available, audit scans only workflow `run:` blocks. Acti
 - `--json`: machine-readable JSON for CI integration
 - `--sarif`: SARIF 2.1.0 for upload to GitHub code scanning
 - `--verbose`: also report _allowed_ matches (fetches that fired a rule but were dropped because the URL is versioned)
+- `--no-repo-config`: ignore the scanned repository's `.pinprick.toml` and use the global config (or defaults)
+
+## Auditing repositories you don't control
+
+The scanned repository's own `.pinprick.toml` applies during an audit — `ignore` rules, `trusted-hosts`, and `severity` can all suppress findings. That's the right behavior for your own CI, but when auditing a third-party repository it means the target sets its own audit policy. Whenever a repo-local config changes the results, pinprick prints a note to stderr saying what it suppressed; pass `--no-repo-config` to ignore the file entirely.
 
 ## Example
 

--- a/site/src/content/docs/commands/score.md
+++ b/site/src/content/docs/commands/score.md
@@ -24,6 +24,7 @@ pinprick score --html > report.html
 - Default: a compact human-readable summary with grade, finding counts by severity, and top remediations
 - `--json`: the full finding list as JSON for CI integration or downstream processing
 - `--html`: a self-contained HTML report (mutually exclusive with `--json`)
+- `--no-repo-config`: ignore the scanned repository's `.pinprick.toml` and use the global config (or defaults)
 
 ## Rule catalog
 
@@ -56,6 +57,8 @@ trusted-owners = ["my-org", "vendor"]
 ```
 
 Matching is exact owner, case-insensitive. See [Config File](/configuration/config-file) for the full set of options.
+
+Because the scanned repository's own `.pinprick.toml` applies, a third-party repo can shape its own grade (`trusted-owners`, `ignore` rules). Whenever a repo-local config changes the score, pinprick prints a note to stderr saying what it changed; pass `--no-repo-config` to ignore the file entirely.
 
 ## Example
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -25,6 +25,10 @@ use crate::output::{self, AuditFinding, AuditMatch, AuditReport};
 use crate::workflow::{self, ActionRef};
 use colored::Colorize;
 
+/// Reason string for matches allowed via the `trusted-hosts` config list.
+/// Shared between the allow site and the repo-config notice that counts them.
+pub(crate) const REASON_TRUSTED_HOST: &str = "trusted host";
+
 /// Accumulates findings and (when verbose) allowed matches during a scan.
 ///
 /// `push_allowed` is a no-op when `verbose` is false, so callers can record
@@ -33,6 +37,9 @@ pub struct AuditCollector {
     pub findings: Vec<AuditFinding>,
     pub allowed: Vec<AuditMatch>,
     pub verbose: bool,
+    /// Matches allowed via `trusted-hosts` — counted regardless of verbosity
+    /// so the repo-config notice doesn't depend on `--verbose`.
+    pub trusted_host_allowed: usize,
 }
 
 impl AuditCollector {
@@ -41,6 +48,7 @@ impl AuditCollector {
             findings: Vec::new(),
             allowed: Vec::new(),
             verbose,
+            trusted_host_allowed: 0,
         }
     }
 
@@ -49,6 +57,9 @@ impl AuditCollector {
     }
 
     pub fn push_allowed(&mut self, allowed: AuditMatch) {
+        if allowed.reason == REASON_TRUSTED_HOST {
+            self.trusted_host_allowed += 1;
+        }
         if self.verbose {
             self.allowed.push(allowed);
         }
@@ -231,9 +242,33 @@ pub async fn run(
         eprintln!();
     }
 
+    let before_filters = collector.findings.len();
     collector.findings.retain(|f| {
         config.meets_severity(&f.severity) && !config.is_pattern_ignored(&f.description)
     });
+    let suppressed = before_filters - collector.findings.len();
+
+    // When auditing a repo you don't control, its own .pinprick.toml must not
+    // silently set audit policy — say what it changed and how to opt out.
+    if config.is_repo_local() {
+        let trusted_host_allowed = collector.trusted_host_allowed;
+        let mut parts = Vec::new();
+        if suppressed > 0 {
+            parts.push(format!("findings suppressed: {suppressed}"));
+        }
+        if ignored > 0 {
+            parts.push(format!("actions skipped: {ignored}"));
+        }
+        if trusted_host_allowed > 0 {
+            parts.push(format!("trusted-host fetches: {trusted_host_allowed}"));
+        }
+        if !parts.is_empty() {
+            eprintln!(
+                "note: the scanned repo's .pinprick.toml affected results ({}) — rerun with --no-repo-config to ignore it",
+                parts.join(", ")
+            );
+        }
+    }
 
     collector
         .findings
@@ -826,7 +861,7 @@ fn check_url_patterns(
             if url_has_version(url) {
                 allowed_reason.get_or_insert("versioned URL");
             } else if config.is_host_trusted(url) {
-                allowed_reason.get_or_insert("trusted host");
+                allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
             } else if config.is_data_format_exempt(url) {
                 allowed_reason.get_or_insert("data format URL");
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,21 @@ pub struct Config {
     /// to the built-in baseline (`actions`, `github`). Case-insensitive.
     #[serde(default)]
     pub trusted_owners: Vec<String>,
+
+    /// Where this configuration was loaded from. Not part of the file format —
+    /// used to attribute suppressions to the scanned repo's own config, which
+    /// matters when auditing a repository you don't control.
+    #[serde(skip)]
+    pub source: ConfigSource,
+}
+
+/// Where the active configuration was loaded from.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ConfigSource {
+    #[default]
+    Default,
+    Global,
+    RepoLocal,
 }
 
 /// Baseline list of trusted action publishers. GitHub's own orgs are
@@ -71,17 +86,35 @@ pub struct IgnoreConfig {
 impl Config {
     /// Load config from global (~/.config/pinprick/config.toml) and per-repo (.pinprick.toml).
     /// Per-repo overrides global. Missing files are fine — defaults are used.
-    pub fn load(repo_root: &Path) -> Self {
+    /// With `use_repo_config` false the per-repo file is ignored entirely —
+    /// the right mode when scanning a repository you don't control, whose
+    /// config would otherwise set its own audit policy.
+    pub fn load(repo_root: &Path, use_repo_config: bool) -> Self {
         // Per-repo wins; a malformed per-repo file falls back to defaults (not
         // global) — the author meant to configure THIS repo.
-        match load_local(repo_root) {
-            ConfigLoad::Loaded(local) => local,
-            ConfigLoad::Malformed => Config::default(),
-            ConfigLoad::Absent => match load_global() {
-                ConfigLoad::Loaded(global) => global,
-                ConfigLoad::Malformed | ConfigLoad::Absent => Config::default(),
-            },
+        if use_repo_config {
+            match load_local(repo_root) {
+                ConfigLoad::Loaded(mut local) => {
+                    local.source = ConfigSource::RepoLocal;
+                    return local;
+                }
+                ConfigLoad::Malformed => return Config::default(),
+                ConfigLoad::Absent => {}
+            }
         }
+        match load_global() {
+            ConfigLoad::Loaded(mut global) => {
+                global.source = ConfigSource::Global;
+                global
+            }
+            ConfigLoad::Malformed | ConfigLoad::Absent => Config::default(),
+        }
+    }
+
+    /// Whether the active config came from the scanned repo's own
+    /// `.pinprick.toml`.
+    pub fn is_repo_local(&self) -> bool {
+        self.source == ConfigSource::RepoLocal
     }
 
     pub fn severity_threshold(&self) -> u8 {
@@ -155,10 +188,16 @@ impl Config {
         BASELINE_TRUSTED_OWNERS
             .iter()
             .any(|b| b.eq_ignore_ascii_case(owner))
-            || self
-                .trusted_owners
-                .iter()
-                .any(|o| o.eq_ignore_ascii_case(owner))
+            || self.is_owner_trusted_by_config(owner)
+    }
+
+    /// Whether `owner` is trusted via the configured `trusted-owners` list
+    /// specifically (not the built-in baseline). Used to attribute
+    /// `source.unverified` exemptions to the active config file.
+    pub fn is_owner_trusted_by_config(&self, owner: &str) -> bool {
+        self.trusted_owners
+            .iter()
+            .any(|o| o.eq_ignore_ascii_case(owner))
     }
 }
 
@@ -223,6 +262,24 @@ fn load_file(path: &Path) -> ConfigLoad {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn load_without_repo_config_ignores_local_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".pinprick.toml"),
+            "trusted-hosts = [\"x.example\"]\n",
+        )
+        .unwrap();
+
+        let with = Config::load(dir.path(), true);
+        assert!(with.is_repo_local());
+        assert!(with.is_host_trusted("https://x.example/tool"));
+
+        let without = Config::load(dir.path(), false);
+        assert!(!without.is_repo_local());
+        assert!(!without.is_host_trusted("https://x.example/tool"));
+    }
 
     #[test]
     fn is_data_format_exempt_built_in() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,11 @@ enum Command {
         /// Output findings as SARIF 2.1.0 (for github/codeql-action/upload-sarif)
         #[arg(long, conflicts_with = "json")]
         sarif: bool,
+
+        /// Ignore the scanned repository's .pinprick.toml and use the global
+        /// config (or defaults) — for auditing repositories you don't control
+        #[arg(long)]
+        no_repo_config: bool,
     },
     /// Remove locally cached audit results
     Clean,
@@ -88,6 +93,11 @@ enum Command {
         /// If `--json` is also set, JSON wins (global flags take precedence).
         #[arg(long)]
         html: bool,
+
+        /// Ignore the scanned repository's .pinprick.toml and use the global
+        /// config (or defaults) — for scoring repositories you don't control
+        #[arg(long)]
+        no_repo_config: bool,
     },
     /// Check for updates to pinned actions
     Update {
@@ -121,8 +131,9 @@ async fn main() -> ExitCode {
             path,
             verbose,
             sarif,
+            no_repo_config,
         } => {
-            let config = config::Config::load(path);
+            let config = config::Config::load(path, !no_repo_config);
             audit::run(path, cli.json, *sarif, *verbose, &config).await
         }
         Command::Clean => {
@@ -151,7 +162,11 @@ async fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
         Command::Pin { path, apply } => pin::run(path, cli.json, *apply).await,
-        Command::Score { path, html } => score::run(path, cli.json, *html).await,
+        Command::Score {
+            path,
+            html,
+            no_repo_config,
+        } => score::run(path, cli.json, *html, *no_repo_config).await,
         Command::Update { path, apply, only } => {
             update::run(path, *apply, cli.json, only.as_deref()).await
         }

--- a/src/score.rs
+++ b/src/score.rs
@@ -216,9 +216,22 @@ pub fn grade_for(score: u32) -> &'static str {
     }
 }
 
+/// What the active config file changed about the score — used to surface a
+/// notice when the scanned repo's own `.pinprick.toml` shaped its own grade.
+#[derive(Default)]
+pub struct ConfigImpact {
+    /// Runtime findings dropped via `ignore.patterns`.
+    pub findings_suppressed: usize,
+    /// Unique action refs exempted from `source.unverified` via the
+    /// configured `trusted-owners` list (baseline owners not counted).
+    pub actions_exempted: usize,
+}
+
 /// Collect findings across all workflows, dedupe by rule + target, and roll
-/// up into a single report.
-pub fn score_repo(repo_root: &Path, config: &Config) -> Result<ScoreReport> {
+/// up into a single report, alongside what the config changed about it.
+pub fn score_repo(repo_root: &Path, config: &Config) -> Result<(ScoreReport, ConfigImpact)> {
+    let mut impact = ConfigImpact::default();
+    let mut exempted_refs: std::collections::BTreeSet<String> = Default::default();
     let files = workflow::find_workflows(repo_root)?;
 
     // Accumulate action-level findings keyed by (rule, action_ref).
@@ -254,6 +267,9 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<ScoreReport> {
                     workflow: display.clone(),
                     line: a.line_number,
                 });
+            } else if config.is_owner_trusted_by_config(&a.owner) {
+                // Trusted via the config file, not the baseline — attributable.
+                exempted_refs.insert(action_ref.clone());
             }
         }
 
@@ -289,6 +305,7 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<ScoreReport> {
                 // Honor `ignore.patterns` (an accepted risk shouldn't score) but
                 // not the `severity` display threshold — the score is complete.
                 if config.is_pattern_ignored(&finding.description) {
+                    impact.findings_suppressed += 1;
                     continue;
                 }
                 let rule = runtime_rule_for(finding);
@@ -358,7 +375,8 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<ScoreReport> {
         findings,
     };
     recompute_score(&mut report);
-    Ok(report)
+    impact.actions_exempted = exempted_refs.len();
+    Ok((report, impact))
 }
 
 /// Sort findings (highest deduction first, then by rule id, then by action ref)
@@ -818,9 +836,38 @@ fn trigger_present(on: &Value, name: &str) -> bool {
 
 // ── CLI entry point ─────────────────────────────────────────────────────────
 
-pub async fn run(repo_root: &Path, json: bool, html: bool) -> Result<ExitCode> {
-    let config = Config::load(repo_root);
-    let mut report = score_repo(repo_root, &config)?;
+pub async fn run(
+    repo_root: &Path,
+    json: bool,
+    html: bool,
+    no_repo_config: bool,
+) -> Result<ExitCode> {
+    let config = Config::load(repo_root, !no_repo_config);
+    let (mut report, impact) = score_repo(repo_root, &config)?;
+
+    // When scoring a repo you don't control, its own .pinprick.toml must not
+    // silently inflate its own grade — say what it changed and how to opt out.
+    if config.is_repo_local() {
+        let mut parts = Vec::new();
+        if impact.findings_suppressed > 0 {
+            parts.push(format!(
+                "runtime findings suppressed: {}",
+                impact.findings_suppressed
+            ));
+        }
+        if impact.actions_exempted > 0 {
+            parts.push(format!(
+                "actions exempted via trusted-owners: {}",
+                impact.actions_exempted
+            ));
+        }
+        if !parts.is_empty() {
+            eprintln!(
+                "note: the scanned repo's .pinprick.toml affected the score ({}) — rerun with --no-repo-config to ignore it",
+                parts.join(", ")
+            );
+        }
+    }
 
     // Rules that need the GitHub API run after the offline scan. Without a
     // token we silently skip them — same behavior as `audit`.
@@ -1149,7 +1196,7 @@ jobs:
 "#;
         std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         // pin.sliding (5) + pin.full_tag (2) + pin.branch (15)
         //   + workflow.permissions_write_all (10)
         //   + source.unverified for some-org/custom-action (1)
@@ -1177,7 +1224,7 @@ jobs:
 "#;
         std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         assert_eq!(report.score, 100);
         assert_eq!(report.grade, "A");
         assert!(report.findings.is_empty());
@@ -1192,7 +1239,7 @@ jobs:
         std::fs::write(wfdir.join("a.yml"), yaml).unwrap();
         std::fs::write(wfdir.join("b.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         // Two workflows, same sliding-tag action -> ONE finding with 2 occurrences.
         let pin_findings: Vec<_> = report
             .findings
@@ -1259,7 +1306,7 @@ jobs:
 "#;
         std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         let ids: Vec<_> = report.findings.iter().map(|f| f.id).collect();
         assert!(ids.contains(&"workflow.pull_request_target"));
         assert!(ids.contains(&"workflow.workflow_run"));
@@ -1290,7 +1337,7 @@ jobs:
 "#;
         std::fs::write(wfdir.join("risky.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         let ids: Vec<_> = report.findings.iter().map(|f| f.id).collect();
         assert!(ids.contains(&"runtime.pipe_to_shell"), "ids: {ids:?}");
         assert!(ids.contains(&"runtime.fetch.high"), "ids: {ids:?}");
@@ -1337,7 +1384,7 @@ jobs:
         let yaml = "name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: random-vendor/tool@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v1\n";
         std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         let ids: Vec<_> = report.findings.iter().map(|f| f.id).collect();
         assert_eq!(ids, vec!["source.unverified"]);
         assert_eq!(report.score, 99);
@@ -1352,7 +1399,7 @@ jobs:
         let yaml = "name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6\n      - uses: github/codeql-action/init@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v3\n";
         std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
 
-        let report = score_repo(dir.path(), &Config::default()).unwrap();
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
         assert!(report.findings.is_empty());
         assert_eq!(report.score, 100);
     }
@@ -1369,8 +1416,11 @@ jobs:
             trusted_owners: vec!["my-vendor".to_string()],
             ..Config::default()
         };
-        let report = score_repo(dir.path(), &cfg).unwrap();
+        let (report, impact) = score_repo(dir.path(), &cfg).unwrap();
         assert!(report.findings.is_empty());
+        // The exemption is attributed to the config, not the baseline.
+        assert_eq!(impact.actions_exempted, 1);
+        assert_eq!(impact.findings_suppressed, 0);
     }
 
     fn make_adv(
@@ -2141,7 +2191,7 @@ jobs:
                 "name: x\non: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: o/r@{sha} # v1.0.0\n"
             );
             std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
-            score_repo(dir, &Config::default()).unwrap()
+            score_repo(dir, &Config::default()).unwrap().0
         }
 
         #[tokio::test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -576,6 +576,95 @@ fn config_ignore_patterns() {
 }
 
 #[test]
+fn repo_config_suppression_prints_notice() {
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_PIPE_TO_SHELL,
+        "[ignore]\npatterns = [\"piped to shell\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("note: the scanned repo's .pinprick.toml affected results"),
+        "expected a repo-config notice on stderr, got: {stderr}"
+    );
+    assert!(stderr.contains("findings suppressed: 1"));
+    assert!(stderr.contains("--no-repo-config"));
+}
+
+#[test]
+fn no_repo_config_ignores_local_file() {
+    // Same suppressing config, but --no-repo-config must restore the finding
+    // (exit 1) and print no notice.
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_PIPE_TO_SHELL,
+        "[ignore]\npatterns = [\"piped to shell\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .arg("--no-repo-config")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("note: the scanned repo's .pinprick.toml"));
+}
+
+#[test]
+fn repo_config_trusted_host_notice_without_verbose() {
+    // The trusted-host count must not depend on --verbose.
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_TRUSTED_HOST,
+        "trusted-hosts = [\"artifacts.internal.example.com\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("trusted-host fetches: 1"),
+        "expected a trusted-host notice on stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn repo_config_clean_repo_prints_no_notice() {
+    // A repo-local config that changes nothing must stay silent.
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_CLEAN,
+        "[ignore]\npatterns = [\"piped to shell\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("note:"));
+}
+
+#[test]
 fn config_trusted_hosts() {
     let dir = common::repo_with_config(
         "ci.yml",

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -196,6 +196,76 @@ jobs:
 }
 
 #[test]
+fn repo_config_suppression_prints_notice_and_flag_restores() {
+    let workflow = "\
+name: risky
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: curl -fsSL https://example.com/install.sh | bash
+";
+    let dir = common::repo_with_config(
+        "ci.yml",
+        workflow,
+        "[ignore]\npatterns = [\"piped to shell\"]\n",
+    );
+
+    // The scanned repo's own config shaped the score — a notice must say so.
+    let output = common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("note: the scanned repo's .pinprick.toml affected the score"),
+        "expected a repo-config notice on stderr, got: {stderr}"
+    );
+    assert!(stderr.contains("runtime findings suppressed: 1"));
+
+    // --no-repo-config ignores the local file: finding returns, no notice.
+    let output = common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .arg("--no-repo-config")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stderr.contains("note: the scanned repo's .pinprick.toml"));
+}
+
+#[test]
+fn repo_config_trusted_owners_notice() {
+    let workflow = "\
+name: vendor
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: my-vendor/tool@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v1.0.0
+      - run: echo ok
+";
+    let dir = common::repo_with_config("ci.yml", workflow, "trusted-owners = [\"my-vendor\"]\n");
+
+    let output = common::pinprick_cmd()
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("actions exempted via trusted-owners: 1"),
+        "expected a trusted-owners notice on stderr, got: {stderr}"
+    );
+}
+
+#[test]
 fn html_output_contains_expected_markers() {
     let dir = common::repo_with_workflow("ci.yml", WORKFLOW_UNPINNED_SLIDING);
     let output = common::pinprick_cmd()


### PR DESCRIPTION
The scanned repository's own `.pinprick.toml` applies during `audit` and `score`, which means a third-party repo can silently set its own audit policy — `ignore` rules, `trusted-hosts`, `severity`, and `trusted-owners` all suppress findings or extend trust. Two changes make that visible and optional. Both commands now print a stderr notice whenever a repo-local config changed the results, with counts per mechanism (findings suppressed, actions skipped, trusted-host fetches, trusted-owner exemptions); the trusted-host count is tracked on the collector independently of `--verbose`, which previously gated the allowed-match list. And both commands accept `--no-repo-config` to ignore the scanned repo's file entirely, falling back to the global config or defaults. `Config::load` records where the active config came from so the notice only fires for repo-local files — a user's own global config stays silent. Docs updated; covered by six new integration tests plus unit tests for source attribution and impact counting.