### PR TITLE
feat(audit): verify minisign signatures on the remote audited-actions catalog

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -45,6 +45,30 @@ jobs:
         working-directory: site
         run: npm run build
 
+      # Sign the built audited-actions catalog files so the pinprick binary
+      # can verify them against its embedded public key (fail-closed: an
+      # unsigned or tampered catalog is ignored by clients). Signing the dist
+      # output covers exactly the bytes Cloudflare will serve.
+      - name: Sign audited-actions catalog
+        env:
+          CATALOG_SIGNING_KEY: ${{ secrets.CATALOG_SIGNING_KEY }}
+        run: |
+          if [[ -z "${CATALOG_SIGNING_KEY}" ]]; then
+            echo "::warning::CATALOG_SIGNING_KEY not configured; catalog ships unsigned and clients will ignore the remote layer"
+            exit 0
+          fi
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq minisign
+          KEYFILE="${RUNNER_TEMP}/catalog.key"
+          printf '%s\n' "${CATALOG_SIGNING_KEY}" > "${KEYFILE}"
+          find site/dist -path '*audited-actions*' -name '*.json' -print0 \
+            | while IFS= read -r -d '' f; do
+                minisign -S -s "${KEYFILE}" -m "${f}" -x "${f}.minisig"
+              done
+          rm -f "${KEYFILE}"
+          COUNT=$(find site/dist -name '*.json.minisig' | wc -l)
+          echo "Signed ${COUNT} catalog files"
+
       - name: Deploy to Cloudflare Workers
         working-directory: site
         run: npm run deploy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +193,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -295,6 +314,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +361,17 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -497,6 +552,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,10 +595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -581,6 +648,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -811,6 +887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1048,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aefd422a7a8b5efced01cd7cdf3771e62ebecbc90e3d27695002d3af6af94586"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.4.2",
+ "rpassword",
+ "scrypt",
+]
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1173,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "minisign",
+ "minisign-verify",
  "predicates",
  "regex",
  "reqwest",
@@ -1340,6 +1455,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1591,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1622,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "security-framework"
@@ -1570,6 +1726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1921,6 +2088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2140,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -2187,6 +2366,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "2"
 colored = "3"
 toml = "1"
 semver = "1"
+minisign-verify = "0.2.5"
 
 [build-dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -36,6 +37,7 @@ serde_json = "1"
 
 [dev-dependencies]
 assert_cmd = "2"
+minisign = "0.9.1"
 predicates = "3"
 tempfile = "3"
 wiremock = "0.6"

--- a/audited-actions/README.md
+++ b/audited-actions/README.md
@@ -47,6 +47,13 @@ Each file is named `{owner}/{repo}.json` and contains an array of audited SHAs w
 [{ "sha": "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "tag": "v6.0.2" }]
 ```
 
+## Trust model
+
+These files reach users two ways with different trust anchors:
+
+- **Bundled**: compiled into the pinprick binary at build time — same trust as the binary itself (which ships with build provenance attestations).
+- **Remote** (`https://pinprick.rs/audited-actions/`, opt-in): each served file is signed with [minisign](https://jedisct1.github.io/minisign/) during deploy, and the binary verifies the signature against a public key (`catalog-minisign.pub` at the repo root) embedded at build time. Verification is fail-closed: a missing or invalid signature means the remote entry is ignored and the action is scanned normally. TLS alone is deliberately not trusted — a catalog entry suppresses scanning, so a compromised CDN must not be able to forge one.
+
 ## Contributing
 
 To add a new entry:

--- a/catalog-minisign.pub
+++ b/catalog-minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key for the pinprick audited-actions catalog
+RWRwyp1ae8MrgHSws68tQDd94KGWt1cqdTYZOEcIcPh+cQo9rWJIgC0x

--- a/site/src/content/docs/configuration/audited-actions.md
+++ b/site/src/content/docs/configuration/audited-actions.md
@@ -12,6 +12,12 @@ pinprick maintains a list of GitHub Actions that have been scanned and confirmed
 3. **Remote** — `https://pinprick.rs/audited-actions/`. Opt-in via `fetch-remote = true` in your [config file](/configuration/config-file).
 4. **GitHub API** — full source fetch and scan as last resort.
 
+## Remote catalog signing
+
+A remote catalog entry tells pinprick to _skip scanning_ a SHA, so its integrity matters more than TLS alone can guarantee — a compromised CDN must not be able to mark malicious SHAs as audited. Every catalog file is therefore signed with [minisign](https://jedisct1.github.io/minisign/): the signature is served next to the file (`….json.minisig`), and the pinprick binary verifies it against a public key embedded at build time before honoring any entry.
+
+Verification is fail-closed. A missing or invalid signature — or a binary built without the public key — disables the remote layer entirely, and pinprick falls back to scanning via the GitHub API. Nothing is silently trusted.
+
 ## What "audited" means
 
 Each SHA was scanned for **unversioned runtime fetch patterns**. Specifically:

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -1,9 +1,17 @@
+use minisign_verify::{PublicKey, Signature};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 const BUNDLED_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/bundled_audited_actions.json"));
 const REMOTE_URL: &str = "https://pinprick.rs/audited-actions";
+
+/// Minisign public key for the remote catalog, committed at the repo root and
+/// embedded at compile time. The remote layer is fail-closed: without a valid
+/// key in the build (or a valid signature on the fetched catalog), remote
+/// entries are never honored — a compromised CDN must not be able to mark
+/// malicious SHAs as audited.
+const CATALOG_PUBKEY_FILE: &str = include_str!("../catalog-minisign.pub");
 
 #[derive(Deserialize)]
 struct AuditedEntry {
@@ -39,10 +47,16 @@ impl AuditSource {
 /// 2. **Local cache** — `~/.cache/pinprick/audited/{owner}/{repo}.json`
 /// 3. **Remote** — `https://pinprick.rs/audited-actions/{owner}/{repo}.json` (opt-in)
 ///
-/// All failures are silent — a miss means "not audited, scan it via GitHub".
+/// Misses are silent — "not audited" just means the action is scanned via
+/// GitHub. The exception is a remote catalog that fails signature
+/// verification, which warns: that is either misconfigured serving
+/// infrastructure or tampering, and should not pass unnoticed.
 pub struct AuditedActions {
     bundled: HashMap<String, HashSet<String>>,
     cache_dir: Option<PathBuf>,
+    /// Key used to verify remote catalog signatures. `None` (a build without
+    /// a real public key) disables the remote layer entirely.
+    catalog_key: Option<PublicKey>,
     client: reqwest::Client,
     fetch_remote: bool,
     local: HashMap<String, HashSet<String>>,
@@ -54,9 +68,16 @@ pub struct AuditedActions {
 
 impl AuditedActions {
     pub fn new(fetch_remote: bool) -> Self {
+        let catalog_key = parse_catalog_key(CATALOG_PUBKEY_FILE);
+        if fetch_remote && catalog_key.is_none() {
+            eprintln!(
+                "warning: remote audited-actions catalog disabled — this build carries no catalog public key"
+            );
+        }
         Self {
             bundled: load_bundled(),
             cache_dir: cache_dir(),
+            catalog_key,
             client: crate::github::build_client(),
             fetch_remote,
             local: HashMap::new(),
@@ -144,10 +165,42 @@ impl AuditedActions {
     }
 
     async fn fetch_remote_list(&self, action_key: &str) -> Option<HashSet<String>> {
+        // No public key in this build → the remote layer stays dark.
+        let key = self.catalog_key.as_ref()?;
+
         let url = format!("{}/{action_key}.json", self.remote_url);
+        let bytes = self.fetch_url(&url).await?;
+
+        // The signature is served next to the catalog file (minisign's `.minisig`
+        // convention). A catalog without a valid signature is not honored — a
+        // 404 on the catalog itself above is a normal miss, but a present
+        // catalog with a missing or bad signature is worth a warning: it means
+        // either serving infra is misconfigured or someone tampered with it.
+        let sig_bytes = match self.fetch_url(&format!("{url}.minisig")).await {
+            Some(b) => b,
+            None => {
+                eprintln!(
+                    "warning: remote catalog for {action_key} has no signature — ignoring it"
+                );
+                return None;
+            }
+        };
+        let sig_text = String::from_utf8_lossy(&sig_bytes);
+        if !verify_catalog_signature(key, &bytes, &sig_text) {
+            eprintln!(
+                "warning: remote catalog for {action_key} failed signature verification — ignoring it"
+            );
+            return None;
+        }
+
+        Some(parse_entries(&String::from_utf8_lossy(&bytes)))
+    }
+
+    /// GET a URL and return the (size-capped) body, or `None` on any failure.
+    async fn fetch_url(&self, url: &str) -> Option<Vec<u8>> {
         let resp = self
             .client
-            .get(&url)
+            .get(url)
             .header("User-Agent", "pinprick")
             .send()
             .await
@@ -157,8 +210,25 @@ impl AuditedActions {
             return None;
         }
 
-        let bytes = crate::github::read_capped(resp).await.ok()?;
-        Some(parse_entries(&String::from_utf8_lossy(&bytes)))
+        crate::github::read_capped(resp).await.ok()
+    }
+}
+
+/// Parse the embedded `.pub` file into a verification key. Comment lines (and
+/// the placeholder file, which is all comments) yield `None`.
+fn parse_catalog_key(content: &str) -> Option<PublicKey> {
+    let line = content
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with("untrusted comment:"))?;
+    PublicKey::from_base64(line).ok()
+}
+
+/// True when `sig_text` is a valid minisign signature over `data` by `key`.
+fn verify_catalog_signature(key: &PublicKey, data: &[u8], sig_text: &str) -> bool {
+    match Signature::decode(sig_text) {
+        Ok(sig) => key.verify(data, &sig, true).is_ok(),
+        Err(_) => false,
     }
 }
 
@@ -266,25 +336,80 @@ mod tests {
         assert!(parse_entries(&rendered).contains("abc123"));
     }
 
+    #[test]
+    fn embedded_pubkey_parses() {
+        // The committed catalog key must parse, or every release silently
+        // ships with the remote layer disabled.
+        assert!(parse_catalog_key(CATALOG_PUBKEY_FILE).is_some());
+    }
+
+    #[test]
+    fn comment_only_pubkey_yields_no_key() {
+        // A placeholder file (all comment lines) must not parse — it keeps
+        // the remote layer disabled rather than panicking.
+        assert!(parse_catalog_key("untrusted comment: nothing here\n").is_none());
+        assert!(parse_catalog_key("").is_none());
+    }
+
+    #[test]
+    fn real_pubkey_parses() {
+        // Key from the minisign-verify documentation — format-validity only.
+        let file = "untrusted comment: minisign public key\n\
+                    RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3\n";
+        assert!(parse_catalog_key(file).is_some());
+    }
+
     mod remote {
         use super::*;
         use serde_json::json;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        #[tokio::test]
-        async fn fetch_remote_list_parses_entries() {
-            let server = MockServer::start().await;
+        /// Ephemeral signing identity for tests: the verification key (as
+        /// parsed from a real `.pub` rendering) and a signer closure.
+        fn test_identity() -> (PublicKey, impl Fn(&[u8]) -> String) {
+            let minisign::KeyPair { pk, sk } =
+                minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+            let verify_key = parse_catalog_key(&pk.to_box().unwrap().to_string())
+                .expect("generated public key must parse");
+            let signer = move |data: &[u8]| {
+                minisign::sign(None, &sk, std::io::Cursor::new(data), None, None)
+                    .unwrap()
+                    .to_string()
+            };
+            (verify_key, signer)
+        }
+
+        /// Mount a catalog body and its signature at `{key}.json[.minisig]`.
+        async fn mount_signed(server: &MockServer, action_key: &str, body: &str, sig: &str) {
             Mock::given(method("GET"))
-                .and(path("/actions/checkout.json"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                    { "sha": "aaa", "tag": "v1" },
-                    { "sha": "bbb", "tag": "v2" }
-                ])))
-                .mount(&server)
+                .and(path(format!("/{action_key}.json")))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_raw(body.to_string(), "application/json"),
+                )
+                .mount(server)
                 .await;
+            Mock::given(method("GET"))
+                .and(path(format!("/{action_key}.json.minisig")))
+                .respond_with(ResponseTemplate::new(200).set_body_string(sig.to_string()))
+                .mount(server)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_parses_signed_entries() {
+            let (key, sign) = test_identity();
+            let body = serde_json::to_string(&json!([
+                { "sha": "aaa", "tag": "v1" },
+                { "sha": "bbb", "tag": "v2" }
+            ]))
+            .unwrap();
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/checkout", &body, &sign(body.as_bytes())).await;
 
             let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
             aa.remote_url = server.uri();
             let shas = aa.fetch_remote_list("actions/checkout").await.unwrap();
             assert!(shas.contains("aaa"));
@@ -293,6 +418,7 @@ mod tests {
 
         #[tokio::test]
         async fn fetch_remote_list_non_success_is_none() {
+            let (key, _) = test_identity();
             let server = MockServer::start().await;
             Mock::given(method("GET"))
                 .and(path("/actions/missing.json"))
@@ -301,22 +427,96 @@ mod tests {
                 .await;
 
             let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
             aa.remote_url = server.uri();
             assert!(aa.fetch_remote_list("actions/missing").await.is_none());
         }
 
         #[tokio::test]
-        async fn check_falls_through_to_remote_layer() {
+        async fn fetch_remote_list_missing_signature_is_none() {
+            let (key, _) = test_identity();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+
             let server = MockServer::start().await;
             Mock::given(method("GET"))
-                .and(path("/some/action.json"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                    { "sha": "feedface", "tag": "v3" }
-                ])))
+                .and(path("/actions/unsigned.json"))
+                .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
                 .mount(&server)
                 .await;
+            // No .minisig mock → 404 on the signature.
 
             let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/unsigned").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_tampered_body_is_none() {
+            let (key, sign) = test_identity();
+            let signed_body =
+                serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+            let tampered_body =
+                serde_json::to_string(&json!([{ "sha": "evil", "tag": "v1" }])).unwrap();
+
+            let server = MockServer::start().await;
+            // Signature is over the original body; the server returns a
+            // different one — verification must reject it.
+            mount_signed(
+                &server,
+                "actions/tampered",
+                &tampered_body,
+                &sign(signed_body.as_bytes()),
+            )
+            .await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/tampered").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_wrong_key_is_none() {
+            let (_, sign) = test_identity();
+            let (other_key, _) = test_identity();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/wrongkey", &body, &sign(body.as_bytes())).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(other_key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/wrongkey").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn keyless_build_never_fetches() {
+            // Even with a perfectly signed catalog available, a build without
+            // a public key must not honor remote entries.
+            let (_, sign) = test_identity();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/keyless", &body, &sign(body.as_bytes())).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = None;
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/keyless").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn check_falls_through_to_remote_layer() {
+            let (key, sign) = test_identity();
+            let body = serde_json::to_string(&json!([{ "sha": "feedface", "tag": "v3" }])).unwrap();
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "some/action", &body, &sign(body.as_bytes())).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
             aa.remote_url = server.uri();
             aa.cache_dir = None; // don't consult the real ~/.cache during the test
             // Not bundled, no local cache hit → resolved by the remote layer.


### PR DESCRIPTION
A remote catalog entry tells pinprick to *skip scanning* a SHA, so its integrity matters more than TLS alone can guarantee — a compromised CDN must not be able to mark malicious SHAs as audited. Catalog files served from pinprick.rs are now signed with minisign during site deploy (signing the built `dist` output, so the signature covers exactly the bytes Cloudflare serves), with each signature next to its file as `….json.minisig`. The binary embeds the catalog public key (`catalog-minisign.pub` at the repo root) at build time and verifies every fetched catalog before honoring it. Fail-closed throughout: a missing or invalid signature, or a build without a valid public key, disables the remote layer and the action is scanned normally; verification failures warn on stderr since they indicate misconfigured infrastructure or tampering. The production public key is committed and the signing key is in place as the `CATALOG_SIGNING_KEY` repo secret, so signing goes live on the first site deploy after merge. Tests cover the verified path end to end with an ephemeral keypair (`minisign` as a dev-dependency): signed, unsigned, tampered, wrong-key, and keyless-build cases, plus a guard that the committed public key always parses.