### PR TITLE
fix(tests): drop typos-flagged doc key from pubkey parse test

### DIFF
--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -353,9 +353,12 @@ mod tests {
 
     #[test]
     fn real_pubkey_parses() {
-        // Key from the minisign-verify documentation — format-validity only.
+        // The production catalog key in the format minisign writes —
+        // exercises comment-stripping on a literal, independent of the
+        // embedded file. (The minisign-verify docs key would also do, but
+        // its base64 trips the typos linter.)
         let file = "untrusted comment: minisign public key\n\
-                    RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3\n";
+                    RWRwyp1ae8MrgHSws68tQDd94KGWt1cqdTYZOEcIcPh+cQo9rWJIgC0x\n";
         assert!(parse_catalog_key(file).is_some());
     }
 


### PR DESCRIPTION
Main's lint went red after #249: the minisign-verify documentation key used in the `real_pubkey_parses` test contains the letter pair `Iz`, which typos flags. The `_typos.toml` ignore rule I added never reached CI — that filename is globally gitignored on this machine, so the config only ever existed locally. Use the production catalog key for the format test instead; it carries no flagged pairs and CI has already proven it clean.