### PR TITLE
chore: release 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Version bump for 0.12.0. This release rolls up the June review work: closed detection gaps in the audit engine (backslash-continuation scanning, multi-stage pipe-to-shell, PowerShell word-boundary fix, execution-context requirement for command substitution, flag-first installs, `FROM --platform`, smarter versioned-URL heuristics), `pin` now exits 1 in dry-run for branch refs and failed resolutions, atomic workflow rewrites, `docker://` ref handling, SHA→tag fallback in `update`, repo-local config transparency (stderr notice + `--no-repo-config`), and minisign signature verification for the remote audited-actions catalog. Merge after #250 (lint hotfix), then dispatch release.yml from main.