### PR TITLE
fix: harden audit caching and scoring/CI checks

### DIFF
--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -62,6 +62,7 @@ jobs:
           set +e
           ./target/debug/pinprick audit --sarif . > pinprick.sarif
           EXIT=$?
+          echo "PINPRICK_AUDIT_EXIT=${EXIT}" >> "${GITHUB_ENV}"
           # 0 = clean, 1 = findings (still upload), 2+ = real error
           if [[ "${EXIT}" -gt 1 ]]; then
             echo "::error::pinprick audit errored with exit code ${EXIT}"
@@ -69,7 +70,14 @@ jobs:
           fi
 
       - name: Upload SARIF
+        if: always() && (env.PINPRICK_AUDIT_EXIT == '0' || env.PINPRICK_AUDIT_EXIT == '1')
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: pinprick.sarif
           category: pinprick
+
+      - name: Fail on findings
+        if: always() && env.PINPRICK_AUDIT_EXIT == '1'
+        run: |
+          echo "::error::pinprick audit found runtime fetch risks"
+          exit 1

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -198,17 +198,24 @@ pub async fn run(
 
                 let findings_before = collector.findings.len();
                 match scan_action_source(client, action, &mut collector, config).await {
-                    Ok(()) => {
-                        match action.ref_type {
-                            workflow::RefType::Sha | workflow::RefType::Tag => {
-                                scanned_fresh += 1;
+                    Ok(scan_status) => {
+                        if scan_status == ActionScanStatus::Complete {
+                            match action.ref_type {
+                                workflow::RefType::Sha | workflow::RefType::Tag => {
+                                    scanned_fresh += 1;
+                                }
+                                workflow::RefType::SlidingTag => {
+                                    scanned_unpinned_sliding += 1;
+                                }
+                                workflow::RefType::Branch => {
+                                    scanned_unpinned_branch += 1;
+                                }
                             }
-                            workflow::RefType::SlidingTag => {
-                                scanned_unpinned_sliding += 1;
-                            }
-                            workflow::RefType::Branch => {
-                                scanned_unpinned_branch += 1;
-                            }
+                        } else {
+                            eprintln!(
+                                "warning: incomplete scan of {}; clean verdict not cached",
+                                action.full_name()
+                            );
                         }
                         // Anchor remote-scan findings to the loading `uses:` line
                         // so SARIF results land inside the scanning repo.
@@ -218,7 +225,8 @@ pub async fn run(
                         }
                         // Only cache clean verdicts for SHA refs — tag and branch
                         // contents can move after the verdict.
-                        if collector.findings.len() == findings_before
+                        if scan_status == ActionScanStatus::Complete
+                            && collector.findings.len() == findings_before
                             && action.ref_type == workflow::RefType::Sha
                         {
                             let tag = action.tag_comment.as_deref().unwrap_or(&action.ref_string);
@@ -949,6 +957,24 @@ enum SourceFileKind {
     Dockerfile,
 }
 
+/// Whether all selected action source files were fetched and parsed well
+/// enough to support a durable "clean" verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionScanStatus {
+    Complete,
+    Incomplete,
+}
+
+impl ActionScanStatus {
+    fn from_complete(complete: bool) -> Self {
+        if complete {
+            Self::Complete
+        } else {
+            Self::Incomplete
+        }
+    }
+}
+
 /// Select the files in a fetched action tree worth scanning, each paired with
 /// its scanner, in tree order. Pure (no I/O) so the filtering is unit testable.
 fn select_source_files(
@@ -964,7 +990,7 @@ fn select_source_files(
         if is_vendored_path(path) {
             continue;
         }
-        if !base.is_empty() && !path.starts_with(base) {
+        if !base.is_empty() && path != base && !path.starts_with(&format!("{base}/")) {
             continue;
         }
         let relative = if base.is_empty() {
@@ -995,7 +1021,7 @@ async fn scan_action_source(
     action: &ActionRef,
     collector: &mut AuditCollector,
     config: &Config,
-) -> Result<()> {
+) -> Result<ActionScanStatus> {
     let action_name = format!("{}@{}", action.full_name(), short_sha(&action.ref_string));
     let tree = client
         .fetch_tree(&action.owner, &action.repo, &action.ref_string)
@@ -1004,12 +1030,12 @@ async fn scan_action_source(
     let base = action.subpath.as_deref().unwrap_or("");
     let targets = select_source_files(&tree, base);
     if targets.is_empty() {
-        return Ok(());
+        return Ok(ActionScanStatus::Complete);
     }
 
     // Fetch concurrently, then scan in tree order so findings are
-    // deterministic regardless of which fetch lands first; a failed fetch is
-    // skipped.
+    // deterministic regardless of which fetch lands first. A failed fetch
+    // makes the scan incomplete, so the caller will not cache a clean verdict.
     let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_FILE_FETCHES));
     let mut fetches = tokio::task::JoinSet::new();
     for (index, (path, _)) in targets.iter().enumerate() {
@@ -1021,29 +1047,42 @@ async fn scan_action_source(
         let semaphore = Arc::clone(&semaphore);
         fetches.spawn(async move {
             let _permit = semaphore.acquire_owned().await.ok();
-            let content = client.fetch_file(&owner, &repo, &path, &git_ref).await.ok();
+            let content = client.fetch_file(&owner, &repo, &path, &git_ref).await;
             (index, content)
         });
     }
 
-    let mut contents: Vec<Option<String>> = vec![None; targets.len()];
+    let mut contents: Vec<Option<Result<String>>> = (0..targets.len()).map(|_| None).collect();
+    let mut complete = true;
     while let Some(joined) = fetches.join_next().await {
-        if let Ok((index, content)) = joined {
-            contents[index] = content;
+        match joined {
+            Ok((index, content)) => {
+                if content.is_err() {
+                    complete = false;
+                }
+                contents[index] = Some(content);
+            }
+            Err(_) => {
+                complete = false;
+            }
         }
     }
 
     for ((path, kind), content) in targets.iter().zip(contents) {
-        let Some(content) = content else {
-            continue;
+        let content = match content {
+            Some(Ok(content)) => content,
+            _ => continue,
         };
         let source_label = format!("{} ({path})", action.full_name());
         match kind {
-            SourceFileKind::ActionYml => {
-                if let Ok(yaml) = serde_norway::from_str::<Value>(&content) {
+            SourceFileKind::ActionYml => match serde_norway::from_str::<Value>(&content) {
+                Ok(yaml) => {
                     scan_action_yml_runs(&yaml, &source_label, &action_name, collector, config);
                 }
-            }
+                Err(_) => {
+                    complete = false;
+                }
+            },
             SourceFileKind::JavaScript => {
                 scan_js_content(&content, &source_label, &action_name, collector, config);
             }
@@ -1056,7 +1095,7 @@ async fn scan_action_source(
         }
     }
 
-    Ok(())
+    Ok(ActionScanStatus::from_complete(complete))
 }
 
 fn scan_action_yml_runs(
@@ -2072,6 +2111,24 @@ runs:
     }
 
     #[test]
+    fn select_source_files_subpath_base_requires_path_boundary() {
+        let tree = vec![
+            tree_entry("action-a/action.yml", "blob"),
+            tree_entry("action-a/index.js", "blob"),
+            tree_entry("action-abcd/action.yml", "blob"),
+            tree_entry("action-abcd/index.js", "blob"),
+        ];
+        let got = select_source_files(&tree, "action-a");
+        assert_eq!(
+            got,
+            vec![
+                ("action-a/action.yml".to_string(), SourceFileKind::ActionYml),
+                ("action-a/index.js".to_string(), SourceFileKind::JavaScript),
+            ]
+        );
+    }
+
+    #[test]
     fn select_source_files_empty_when_nothing_scannable() {
         let tree = vec![
             tree_entry("README.md", "blob"),
@@ -2113,6 +2170,63 @@ runs:
         );
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].action, "actions/checkout@abc1234");
+    }
+
+    #[tokio::test]
+    async fn scan_action_source_reports_incomplete_when_any_file_fetch_fails() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/o/r/git/trees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tree": [
+                    { "path": "action.yml", "type": "blob" },
+                    { "path": "dist/index.js", "type": "blob" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/contents/action.yml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("runs:\n  using: node20\n  main: dist/index.js\n"),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/contents/dist/index.js"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base("t".into(), server.uri());
+        let action = ActionRef {
+            owner: "o".into(),
+            repo: "r".into(),
+            subpath: None,
+            ref_string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            ref_type: workflow::RefType::Sha,
+            tag_comment: Some("v1.0.0".into()),
+            line_number: 1,
+            raw_line: String::new(),
+        };
+        let mut collector = AuditCollector::new(false);
+
+        let status = scan_action_source(&client, &action, &mut collector, &DEFAULT_CONFIG)
+            .await
+            .unwrap();
+
+        assert_eq!(status, ActionScanStatus::Incomplete);
+        assert!(
+            collector.findings.is_empty(),
+            "failed fetch should not invent findings, only block clean caching"
+        );
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -469,6 +469,12 @@ impl GitHubClient {
         if resp.status().as_u16() == 404 {
             bail!("File {path} not found in {owner}/{repo} at {git_ref}");
         }
+        if !resp.status().is_success() {
+            bail!(
+                "GitHub API returned {} while fetching {path} in {owner}/{repo} at {git_ref}",
+                resp.status()
+            );
+        }
 
         let bytes = read_capped(resp).await?;
         Ok(String::from_utf8_lossy(&bytes).into_owned())
@@ -810,6 +816,23 @@ mod tests {
                 .await
                 .unwrap();
             assert!(body.contains("using: node20"));
+        }
+
+        #[tokio::test]
+        async fn fetch_file_non_success_is_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/contents/action.yml"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("oops"))
+                .mount(&server)
+                .await;
+
+            let err = client_for(&server)
+                .await
+                .fetch_file("o", "r", "action.yml", "sha")
+                .await
+                .unwrap_err();
+            assert!(err.to_string().contains("GitHub API returned 500"));
         }
 
         #[tokio::test]

--- a/src/score.rs
+++ b/src/score.rs
@@ -797,9 +797,7 @@ fn pin_rule_for(a: &ActionRef) -> Option<RuleId> {
 fn workflow_rules_for(doc: &Value) -> Vec<RuleId> {
     let mut rules = Vec::new();
 
-    if let Some(Value::String(s)) = doc.get("permissions")
-        && s == "write-all"
-    {
+    if permissions_write_all(doc) {
         rules.push(RuleId::WorkflowPermissionsWriteAll);
     }
 
@@ -817,6 +815,20 @@ fn workflow_rules_for(doc: &Value) -> Vec<RuleId> {
     }
 
     rules
+}
+
+fn permissions_write_all(doc: &Value) -> bool {
+    if matches!(doc.get("permissions"), Some(Value::String(s)) if s == "write-all") {
+        return true;
+    }
+
+    doc.get("jobs")
+        .and_then(|jobs| jobs.as_mapping())
+        .is_some_and(|jobs| {
+            jobs.values().any(
+                |job| matches!(job.get("permissions"), Some(Value::String(s)) if s == "write-all"),
+            )
+        })
 }
 
 fn trigger_present(on: &Value, name: &str) -> bool {
@@ -1132,6 +1144,15 @@ mod tests {
     }
 
     #[test]
+    fn workflow_rules_job_permissions_write_all() {
+        let yaml =
+            "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    permissions: write-all\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(rules.contains(&RuleId::WorkflowPermissionsWriteAll));
+    }
+
+    #[test]
     fn workflow_rules_no_permissions_block() {
         let yaml = "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
         let doc: Value = serde_norway::from_str(yaml).unwrap();
@@ -1143,6 +1164,14 @@ mod tests {
     fn workflow_rules_permissions_map_is_fine() {
         let yaml =
             "on: push\npermissions:\n  contents: read\njobs:\n  a:\n    runs-on: ubuntu-latest\n";
+        let doc: Value = serde_norway::from_str(yaml).unwrap();
+        let rules = workflow_rules_for(&doc);
+        assert!(!rules.contains(&RuleId::WorkflowPermissionsWriteAll));
+    }
+
+    #[test]
+    fn workflow_rules_job_permissions_map_is_fine() {
+        let yaml = "on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n";
         let doc: Value = serde_norway::from_str(yaml).unwrap();
         let rules = workflow_rules_for(&doc);
         assert!(!rules.contains(&RuleId::WorkflowPermissionsWriteAll));
@@ -1330,6 +1359,30 @@ jobs:
         assert_eq!(report.totals.points_deducted, 8);
         assert_eq!(report.score, 92);
         assert_eq!(report.grade, "A");
+    }
+
+    #[test]
+    fn job_permissions_write_all_scores_end_to_end() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: x
+on: push
+jobs:
+  a:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let (report, _) = score_repo(dir.path(), &Config::default()).unwrap();
+        let ids: Vec<_> = report.findings.iter().map(|f| f.id).collect();
+        assert!(ids.contains(&"workflow.permissions_write_all"));
+        assert_eq!(report.totals.points_deducted, 10);
+        assert_eq!(report.score, 90);
     }
 
     #[test]


### PR DESCRIPTION
Three fail-closed hardening fixes to the audit and score paths.

The audit no longer caches a clean verdict for an action it didn't fully read. `fetch_file` now errors on any non-success status rather than only 404, and `scan_action_source` tracks whether every selected source file was fetched and parsed; a failed fetch or unparseable `action.yml` marks the scan incomplete, which blocks both the scanned-fresh count and the cached clean verdict. Previously a transient or hostile fetch failure could whitelist an action's SHA in the local cache without its source ever being read. Incomplete scans still never invent findings — they only withhold the clean cache. This also tightens `select_source_files` so a subpath base like `action-a` no longer matches sibling directories such as `action-abcd/`.

Scoring now flags a job-level `permissions: write-all`, not just the top-level key. And the self-audit workflow now fails on findings (exit 1) instead of uploading SARIF and passing, uploading SARIF only on exit 0 or 1 — note this flips that workflow from report-only to gating.
