### PR TITLE
feat(audit): suppress checksum-verified fetches instead of downgrading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Data-format exemption: unversioned-URL rules (shell, JS, Python) do **not** fire
 
 Piped-to-jq exemption: an unversioned-URL fetch whose line pipes into `jq` is recorded as allowed with reason `piped to jq` — the same data-not-code rationale as the data-format exemption, but for JSON API endpoints that carry no file extension (e.g. `curl …/api/v1/crates/<x> | jq …`). The `jq\b` match keeps `jqfoo` from qualifying. Pipe-to-shell matches and pre-empts the URL rules, so `curl … | jq … | bash` is flagged high, never exempted.
 
-Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are downgraded one severity level. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
+Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are suppressed and recorded as allowed matches (visible under `--verbose`) — the checksum deterministically detects a tampered download, mirroring the SHA-checkout suppression. Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
 
 Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name (main, develop, feature/foo) is flagged medium severity. `--branch v1.2.3` (version-like ref) suppresses the finding. A `git checkout <40-char-SHA>` within 3 lines fully suppresses the finding (recorded as allowed, visible under `--verbose`), since the SHA checkout deterministically pins the repo content.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ HIGH  .github/workflows/ci.yml:42
 
 Without a GitHub token, audit scans local `run:` blocks only. With a token (via `GITHUB_TOKEN` or `gh auth`), it also fetches and scans action source code — JavaScript, Python, Dockerfiles, and composite action steps.
 
-Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, or jq-pipe rules.
+Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, jq-pipe, or checksum rules.
 
 ### Configuration
 
@@ -191,7 +191,7 @@ Pipe-to-shell is flagged even when the URL is versioned — a piped payload is n
 
 Unversioned-URL rules don't fire when the URL's path ends in a data-format extension (`.json`, `.yaml`, `.toml`, `.csv`, etc.), or when the fetch is piped into `jq` — the payload is consumed as data, not executed. These matches are only visible under `--verbose`. (Pipe-to-shell takes precedence, so `curl … | jq … | bash` is still flagged.)
 
-Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are downgraded one severity level. Pipe-to-shell findings are exempt.
+Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) within 3 lines are suppressed and recorded as allowed matches (shown under `--verbose`) — the checksum deterministically detects tampering, so the download is pinned by content. Pipe-to-shell findings are exempt; the piped payload is never written to disk for a checksum to verify.
 
 ## Exit codes
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,6 +1,6 @@
 # pinprick scoring rubric
 
-**Status:** draft (rubric version `0.6.0`)
+**Status:** draft (rubric version `0.7.0`)
 
 This document defines how pinprick computes a single score for a GitHub repository's Actions supply chain posture. It is the public specification that the `pinprick score` CLI subcommand implements against, and that any downstream tool wrapping the engine (dashboards, CI plugins, reporting pipelines) should implement against so scores stay portable and comparable.
 
@@ -84,7 +84,7 @@ These reuse findings from the existing `pinprick audit` pipeline applied to each
 
 Notes:
 
-- The audit pipeline already applies the `data format URL` and nearby-checksum adjustments. `runtime.*` scoring uses the post-adjustment severity, so double-counting doesn't happen.
+- The audit pipeline already suppresses `data format URL` and checksum-verified fetches to allowed matches and applies the trusted-host exemption before `runtime.*` scoring runs, so those never deduct points and there's no double-counting. (Checksum-verified fetches are suppressed as of rubric 0.7.0; they were downgraded one severity level through 0.6.0.)
 - Through v0.5.0 the runtime scan is limited to `run:` blocks in local workflow files (no GitHub token required). Runtime findings in the source of fetched actions themselves — where `pinprick audit` looks when a token is present — are not yet scored; that integration lands in a later rubric version.
 - Runtime findings are not deduplicated. Each pattern match emits one finding keyed to its `(workflow, line)` — each is a distinct fix in a distinct place.
 - Config interaction: `runtime.*` scoring honors `ignore.patterns` from `.pinprick.toml` (an explicitly accepted risk is not deducted), but **not** the `severity` display threshold — the posture score reflects every finding regardless of what `pinprick audit` is configured to print.
@@ -117,7 +117,7 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 
 ```jsonc
 {
-  "rubric_version": "0.6.0",
+  "rubric_version": "0.7.0",
   "pinprick_version": "…",
   "scanned_at": "2026-04-22T20:00:00Z",
   "target": { "kind": "repo", "path": "./" },
@@ -152,7 +152,7 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 A compact summary:
 
 ```
-pinprick score  v0.6.0 rubric
+pinprick score  v0.7.0 rubric
 
   Grade:  C   (72 / 100)
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -19,9 +19,9 @@ pinprick scans line by line. Each rule is an anchored regex, compiled once at st
 - **Versioned-URL downgrade.** Non-pipe shell, JavaScript, and Python fetch rules only fire if the URL is _unversioned_. A URL is versioned if any path segment matches `v?\d+(\.\d+)+` — e.g. `/v1.2.3/`, `/0.55.8/`. See [Versioned URL heuristic](#versioned-url-heuristic).
 - **Trusted hosts exemption.** Unversioned-URL rules are downgraded to allowed matches when the URL host matches an entry in the user's [`trusted-hosts`](#trusted-hosts-exemption) list.
 - **Data-format exemption.** If a fetch targets a URL whose path ends in a known data-format extension (`.json`, `.yaml`, `.toml`, etc.), it is treated as a data fetch, not a code fetch, and downgraded to an allowed match instead of a finding. See [Data-format exemption](#data-format-exemption).
-- **Checksum downgrade.** A non-pipe finding followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` is downgraded one severity level (high → medium → low). The fetch is still reported.
+- **Checksum suppression.** A non-pipe finding followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` is suppressed and recorded as an allowed match — the checksum deterministically detects a tampered download, so the fetch is pinned by content rather than merely flagged.
 
-:::caution[Pipe-to-shell is never downgraded]
+:::caution[Pipe-to-shell is never suppressed]
 A piped payload is never written to disk, so no checksum command can verify it. Trusted-host and data-format exemptions also do not apply — the risk is the execution model, not the source.
 :::
 
@@ -519,7 +519,7 @@ RUN curl -L https://example.com/install.sh -o /usr/local/bin/install
 RUN wget https://example.com/tool
 ```
 
-Not flagged: a `curl` line followed within 3 lines by a checksum command, which is downgraded to low.
+Not flagged: a `curl` line followed within 3 lines by a checksum command, which is suppressed (recorded as an allowed match).
 
 ### ADD with a URL source
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -619,31 +619,40 @@ pub fn scan_shell_content(
         }
     }
 
-    // Downgrade severity for findings followed by checksum verification.
-    // Pipe-shell findings sit below `findings_before`, so they are exempt.
-    // Offset 0 covers a one-liner `curl -o f … && sha256sum -c …`.
-    for finding in collector.findings.iter_mut().skip(findings_before) {
-        if let Some(finding_line) = finding.line {
+    // Suppress findings immediately followed by checksum verification: a
+    // sha256sum / gpg --verify check deterministically detects a tampered
+    // download, so the fetch is mitigated, not merely less severe. Recorded as
+    // an allowed match (visible under --verbose), mirroring the SHA-checkout
+    // suppression above. Pipe-shell findings sit below `findings_before` and are
+    // exempt — the piped payload is never written to disk for a checksum to
+    // verify. Offset 0 covers a one-liner `curl -o f … && sha256sum -c …`.
+    let mut idx = findings_before;
+    while idx < collector.findings.len() {
+        let verified = collector.findings[idx].line.is_some_and(|finding_line| {
             let rel = finding_line.saturating_sub(base_line);
-            let Some(li) = logical.iter().position(|(start, _)| *start == rel) else {
-                continue;
-            };
-            for offset in 0..=3 {
-                if li + offset < logical.len() && has_checksum_verify(&logical[li + offset].1) {
-                    finding.severity = downgrade_severity(&finding.severity);
-                    finding.description = format!("{} (checksum verified)", finding.description);
-                    break;
-                }
-            }
+            logical
+                .iter()
+                .position(|(start, _)| *start == rel)
+                .is_some_and(|li| {
+                    (0..=3).any(|offset| {
+                        li + offset < logical.len() && has_checksum_verify(&logical[li + offset].1)
+                    })
+                })
+        });
+        if verified {
+            let finding = collector.findings.remove(idx);
+            collector.push_allowed(AuditMatch {
+                severity: finding.severity,
+                category: finding.category,
+                action: finding.action,
+                source_file: finding.source_file,
+                line: finding.line,
+                pattern_matched: finding.pattern_matched,
+                reason: "followed by checksum verification".to_string(),
+            });
+        } else {
+            idx += 1;
         }
-    }
-}
-
-fn downgrade_severity(severity: &str) -> String {
-    match severity {
-        "high" => "medium".to_string(),
-        "medium" => "low".to_string(),
-        _ => severity.to_string(),
     }
 }
 
@@ -1175,7 +1184,7 @@ mod tests {
     #[test]
     fn find_run_line_advances_past_earlier_match() {
         // Two `run:` blocks both start with `echo hello`. The second one must
-        // map to its own line, not the first occurrence, so severity-downgrade
+        // map to its own line, not the first occurrence, so checksum-suppression
         // windows and SARIF locations stay anchored correctly.
         let yaml = "\
 jobs:
@@ -1452,7 +1461,7 @@ more stuff
     }
 
     #[test]
-    fn shell_scan_pipe_to_sh_not_downgraded_by_checksum() {
+    fn shell_scan_pipe_to_sh_not_suppressed_by_checksum() {
         let mut c = AuditCollector::new(false);
         scan_shell_content(
             "curl -sSL https://example.com/install.sh | sh\nsha256sum -c checksums.txt",
@@ -1462,12 +1471,10 @@ more stuff
             &mut c,
             &DEFAULT_CONFIG,
         );
+        // Pipe-to-shell is exempt: the payload is never written to disk, so a
+        // nearby checksum cannot verify it. The finding stands at high severity.
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
-        assert!(
-            !c.findings[0].description.contains("checksum verified"),
-            "pipe-shell must not be downgraded by a nearby checksum"
-        );
     }
 
     #[test]
@@ -2044,16 +2051,6 @@ runs:
     }
 
     #[test]
-    fn downgrade_low_stays_low() {
-        assert_eq!(downgrade_severity("low"), "low");
-    }
-
-    #[test]
-    fn downgrade_unknown_unchanged() {
-        assert_eq!(downgrade_severity("info"), "info");
-    }
-
-    #[test]
     fn short_sha_full() {
         assert_eq!(
             short_sha("abcdef1234567890abcdef1234567890abcdef12"),
@@ -2267,8 +2264,8 @@ runs:
     }
 
     #[test]
-    fn checksum_at_boundary_of_three_lines() {
-        let mut c = AuditCollector::new(false);
+    fn checksum_at_boundary_of_three_lines_suppresses() {
+        let mut c = AuditCollector::new(true);
         scan_shell_content(
             "curl -L https://example.com/releases/latest/download/tool -o tool\necho step1\necho step2\nsha256sum --check tool.sha256",
             "test.sh",
@@ -2277,13 +2274,15 @@ runs:
             &mut c,
             &DEFAULT_CONFIG,
         );
-        assert_eq!(c.findings.len(), 1);
-        assert_eq!(c.findings[0].severity, "medium");
-        assert!(c.findings[0].description.contains("checksum verified"));
+        // Checksum on the third line after the fetch still lands inside the
+        // window, so the finding is suppressed and recorded as allowed.
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "followed by checksum verification");
     }
 
     #[test]
-    fn checksum_beyond_three_lines_no_downgrade() {
+    fn checksum_beyond_three_lines_not_suppressed() {
         let mut c = AuditCollector::new(false);
         scan_shell_content(
             "curl -L https://example.com/releases/latest/download/tool -o tool\necho 1\necho 2\necho 3\nsha256sum --check tool.sha256",
@@ -2293,6 +2292,8 @@ runs:
             &mut c,
             &DEFAULT_CONFIG,
         );
+        // Checksum is on the fourth line — beyond the window — so the fetch is
+        // still flagged at full severity.
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
     }
@@ -2455,8 +2456,8 @@ runs:
     }
 
     #[test]
-    fn shell_scan_same_line_checksum_downgrades() {
-        let mut c = AuditCollector::new(false);
+    fn shell_scan_same_line_checksum_suppressed() {
+        let mut c = AuditCollector::new(true);
         scan_shell_content(
             "curl -o tool.tgz https://example.com/tool.tgz && sha256sum -c tool.tgz.sha256",
             "test.sh",
@@ -2465,9 +2466,10 @@ runs:
             &mut c,
             &DEFAULT_CONFIG,
         );
-        assert_eq!(c.findings.len(), 1);
-        assert_eq!(c.findings[0].severity, "low");
-        assert!(c.findings[0].description.contains("checksum verified"));
+        // One-liner fetch-then-verify (offset 0) is suppressed.
+        assert!(c.findings.is_empty());
+        assert_eq!(c.allowed.len(), 1);
+        assert_eq!(c.allowed[0].reason, "followed by checksum verification");
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -167,7 +167,7 @@ pub static SHELL_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
 });
 
 // Scanned before (and pre-empt) the regular shell patterns so `curl ... | sh`
-// produces a single high-severity finding. Not subject to checksum downgrade —
+// produces a single high-severity finding. Not subject to checksum suppression —
 // a piped payload is never written to disk and cannot be verified.
 pub static SHELL_PIPE_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![

--- a/src/score.rs
+++ b/src/score.rs
@@ -19,7 +19,7 @@ use crate::github::{AdvisoryVulnerability, GitHubClient, GitHubError, SecurityAd
 use crate::output::AuditFinding;
 use crate::workflow::{self, ActionRef, RefType};
 
-pub const RUBRIC_VERSION: &str = "0.6.0";
+pub const RUBRIC_VERSION: &str = "0.7.0";
 
 // ── Rule catalog ────────────────────────────────────────────────────────────
 

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -226,7 +226,7 @@ fn data_format_exempt() {
 }
 
 #[test]
-fn checksum_downgrade() {
+fn checksum_suppressed() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CHECKSUM);
     let output = common::pinprick_cmd()
         .arg("--json")
@@ -235,18 +235,12 @@ fn checksum_downgrade() {
         .output()
         .unwrap();
 
-    // Still a finding, but severity should be downgraded from high to medium.
-    assert_eq!(output.status.code(), Some(1));
+    // The fetch is verified by sha256sum on the next line, so it is suppressed
+    // (recorded as an allowed match) rather than flagged — the run is clean.
+    assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let findings = json["findings"].as_array().unwrap();
-    assert_eq!(findings.len(), 1);
-    assert_eq!(findings[0]["severity"], "medium");
-    assert!(
-        findings[0]["description"]
-            .as_str()
-            .unwrap()
-            .contains("checksum verified")
-    );
+    assert!(findings.is_empty());
 }
 
 #[test]

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -119,7 +119,7 @@ fn json_output_shape() {
     assert_eq!(output.status.code(), Some(1));
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
 
-    assert_eq!(json["rubric_version"], "0.6.0");
+    assert_eq!(json["rubric_version"], "0.7.0");
     assert_eq!(json["grade"], "A");
     assert_eq!(json["score"], 95);
     assert_eq!(json["totals"]["findings"], 1);


### PR DESCRIPTION
Checksum-verified fetches are now suppressed — recorded as allowed matches, visible under `--verbose` — instead of downgraded one severity level. A `sha256sum` / `gpg --verify` within 3 lines pins a download by content just as deterministically as a SHA-pinned `git checkout`, so the fetch is fully mitigated rather than merely less risky; reporting it even at reduced severity was a false positive.

The change applies to both `audit` (the finding leaves the SARIF output) and `score` (a verified fetch no longer deducts under `runtime.*`), and the `downgrade_severity` helper is removed. Pipe-to-shell stays exempt — its payload is never written to disk for a checksum to verify. Docs and tests are updated to match.

Because this refines `runtime.*` scoring, you may want to bump the draft rubric version in `docs/scoring.md`.
