### PR TITLE
chore: release 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Release 0.15.0 — bumps the crate version for the checksum-verified-fetch suppression in #263 (rubric `0.7.0`). `Cargo.toml` + `Cargo.lock` only.
