### PR TITLE
chore(site): allowlist npm install scripts ahead of npm v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,8 @@ jobs:
       - name: Install site dependencies
         if: matrix.check == 'site'
         working-directory: site
-        run: npm ci
+        # Fail closed on unreviewed install scripts (npm v12 default; see allowScripts in package.json).
+        run: npm ci --strict-allow-scripts
 
       - name: Check formatting
         if: matrix.check == 'site'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -39,7 +39,8 @@ jobs:
 
       - name: Install dependencies
         working-directory: site
-        run: npm ci
+        # Fail closed on unreviewed install scripts (npm v12 default; see allowScripts in package.json).
+        run: npm ci --strict-allow-scripts
 
       - name: Build site
         working-directory: site

--- a/site/package.json
+++ b/site/package.json
@@ -24,5 +24,11 @@
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "wrangler": "^4.95.0"
+  },
+  "allowScripts": {
+    "sharp": true,
+    "esbuild": true,
+    "fsevents": true,
+    "workerd": true
   }
 }


### PR DESCRIPTION
npm v12 (estimated July 2026) stops executing dependency install scripts unless they're allowlisted in `package.json`. This adds an `allowScripts` entry covering the site's build-critical native packages — esbuild, sharp, and workerd — plus fsevents for local macOS dev. They're recorded by name rather than version-pinned, so routine transitive bumps don't leave stale entries (Dependabot doesn't manage this field), while a genuinely new script-bearing dependency still gets gated for review. The CI and deploy `npm ci` steps gain `--strict-allow-scripts` so a missing approval fails closed at install time rather than silently skipping the script and shipping a broken build.