### PR TITLE
fix(audit): cover local actions and config-shaped fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/starhaven-io/pinprick/actions/workflows/ci.yml/badge.svg)](https://github.com/starhaven-io/pinprick/actions/workflows/ci.yml)
 [![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-blue.svg)](LICENSE)
 
-A CLI tool for GitHub Actions supply chain security. Pins action references to full SHAs, checks for updates, and audits pinned actions for runtime fetch patterns that bypass pinning.
+A CLI tool for GitHub Actions supply chain security. Pins action references to full SHAs, checks for updates, audits runtime fetch patterns that bypass pinning, and scores repository posture.
 
 The name: **pin** (SHA pinning) + **prick** (a small, sharp probe finding tiny holes in your supply chain).
 
@@ -11,7 +11,7 @@ The name: **pin** (SHA pinning) + **prick** (a small, sharp probe finding tiny h
 
 For static analysis of your workflow files — template injection, excessive permissions, credential leaks — use [zizmor](https://github.com/zizmorcore/zizmor). It's excellent.
 
-pinprick picks up where static analysis leaves off. SHA-pinning actions is table stakes, but even a pinned action can `curl` down `releases/latest` at runtime. pinprick pins your actions, keeps them updated, and audits their source code for unversioned runtime fetches in shell scripts, JavaScript, Python, and Dockerfiles.
+pinprick picks up where static analysis leaves off. SHA-pinning actions is table stakes, but even a pinned action can `curl` down `releases/latest` at runtime. pinprick pins your actions, keeps them updated, audits source code for unversioned runtime fetches in shell scripts, JavaScript, Python, and Dockerfiles, and gives you a single score to track over time.
 
 ## Installation
 
@@ -71,6 +71,13 @@ pinprick audit --verbose
 # Emit SARIF 2.1.0 for GitHub code scanning
 pinprick audit --sarif > pinprick.sarif
 
+# Score a repository's Actions supply chain posture
+pinprick score
+
+# Emit the full score report as JSON or a self-contained HTML report
+pinprick --json score
+pinprick score --html > report.html
+
 # Clear locally cached audit results
 pinprick clean
 
@@ -123,9 +130,29 @@ HIGH  .github/workflows/ci.yml:42
 1 finding (1 high, 0 medium, 0 low)
 ```
 
-Without a GitHub token, audit scans local `run:` blocks only. With a token (via `GITHUB_TOKEN` or `gh auth`), it also fetches and scans action source code — JavaScript, Python, Dockerfiles, and composite action steps.
+Without a GitHub token, audit scans local workflow `run:` blocks and local actions referenced with `uses: ./...`. With a token (via `GITHUB_TOKEN` or `gh auth`), it also fetches and scans external action source code — JavaScript, Python, Dockerfiles, and composite action steps.
 
 Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, jq-pipe, or checksum rules.
+
+### Score
+
+Compute a posture grade against the public, versioned rubric in [`docs/scoring.md`](docs/scoring.md):
+
+```
+$ pinprick score
+pinprick score  v0.7.0 rubric
+
+  Grade:  A   (95 / 100)
+
+  Findings (1 unique, 1 occurrences):
+    medium  -5    pin.sliding                       actions/checkout@v4
+
+  3 workflows scanned, 8 unique actions.
+
+  Run with --json for the full report.
+```
+
+`source.unverified` is informational: it inventories publishers outside the baseline trusted set (`actions`, `github`) and your configured `trusted-owners`, but it deducts zero points and does not fail CI. `score` exits 1 only when at least one finding deducts points. Use `pinprick score --html > report.html` for a shareable static report.
 
 ### Configuration
 
@@ -142,6 +169,9 @@ fetch-remote = false
 # Hosts whose unversioned URL fetches are downgraded to allowed matches.
 # Case-insensitive exact match. Only applies to the unversioned-URL rules.
 trusted-hosts = ["crates.io"]
+
+# Additional GitHub owners trusted for the source.unverified scoring note.
+trusted-owners = ["my-org"]
 
 # Extra file extensions (beyond .json/.yaml/.toml/.csv/.tsv/.xml/.md/.rst/.txt)
 # to treat as data formats for the unversioned-URL exemption.
@@ -198,7 +228,7 @@ Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) w
 | Code | Meaning |
 |------|---------|
 | 0 | Clean — no findings, no pending updates |
-| 1 | Findings present (audit) or updates available (update dry-run) |
+| 1 | Findings present (audit), score deductions present, or updates available (update dry-run) |
 | 2 | Error |
 
 ## Building

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -85,7 +85,7 @@ These reuse findings from the existing `pinprick audit` pipeline applied to each
 Notes:
 
 - The audit pipeline already suppresses `data format URL` and checksum-verified fetches to allowed matches and applies the trusted-host exemption before `runtime.*` scoring runs, so those never deduct points and there's no double-counting. (Checksum-verified fetches are suppressed as of rubric 0.7.0; they were downgraded one severity level through 0.6.0.)
-- Through v0.5.0 the runtime scan is limited to `run:` blocks in local workflow files (no GitHub token required). Runtime findings in the source of fetched actions themselves — where `pinprick audit` looks when a token is present — are not yet scored; that integration lands in a later rubric version.
+- As of v0.7.0 the runtime score scan is limited to `run:` blocks in local workflow files (no GitHub token required). Runtime findings in the source of fetched actions themselves — where `pinprick audit` looks when a token is present — are not yet scored; that integration lands in a later rubric version.
 - Runtime findings are not deduplicated. Each pattern match emits one finding keyed to its `(workflow, line)` — each is a distinct fix in a distinct place.
 - Config interaction: `runtime.*` scoring honors `ignore.patterns` from `.pinprick.toml` (an explicitly accepted risk is not deducted), but **not** the `severity` display threshold — the posture score reflects every finding regardless of what `pinprick audit` is configured to print.
 
@@ -99,7 +99,7 @@ These fire once per workflow, not per action use.
 | `workflow.pull_request_target` | Workflow uses the `pull_request_target` trigger     | high     |    5   | live   | Validate the checkout ref; avoid running PR code with elevated tokens |
 | `workflow.workflow_run`     | Workflow uses the `workflow_run` trigger              | medium   |    3   | live   | Explicitly validate trigger provenance                |
 
-The `pull_request_target` and `workflow_run` rules fire on trigger *presence* as of v0.5.0. A future release may narrow to "without explicit guardrails" once the parser can recognize common safe patterns (e.g., validating the checkout ref).
+The `pull_request_target` and `workflow_run` rules fire on trigger *presence* as of v0.7.0. A future release may narrow to "without explicit guardrails" once the parser can recognize common safe patterns (e.g., validating the checkout ref).
 
 ### Future categories (not in v1)
 
@@ -119,7 +119,6 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 {
   "rubric_version": "0.7.0",
   "pinprick_version": "…",
-  "scanned_at": "2026-04-22T20:00:00Z",
   "target": { "kind": "repo", "path": "./" },
   "score": 72,
   "grade": "C",
@@ -157,17 +156,14 @@ pinprick score  v0.7.0 rubric
   Grade:  C   (72 / 100)
 
   Findings (11 unique, 24 occurrences):
-    high    2  pin.branch           actions/foo@main
-    high    1  source.archived      bar/baz@abc1234
-    medium  6  pin.sliding          7 actions
-    low     2  pin.full_tag         2 actions
+    high    -15   pin.branch                        actions/foo@main
+    high    -10   source.archived                   bar/baz@abc1234
+    medium  -5    pin.sliding                       actions/checkout@v4
+    low     -2    pin.full_tag                      actions/setup-node@v4.2.1
 
-  Top remediations:
-    1. Pin actions/foo@main to a full SHA             (-15)
-    2. Replace bar/baz (archived) with a maintained action (-10)
-    …
+  4 workflows scanned, 17 unique actions.
 
-  Run `pinprick score --json` for the full report.
+  Run with --json for the full report.
 ```
 
 ### HTML report
@@ -175,9 +171,8 @@ pinprick score  v0.7.0 rubric
 A single self-contained HTML file with:
 
 - Score + grade banner
-- Per-category breakdown with expandable finding lists
-- Per-workflow drill-down
-- Prioritized remediation list (sorted by points recovered)
+- Prioritized finding list (sorted by points recovered)
+- Remediation text and occurrence locations for each finding
 
 No JavaScript frameworks; plain HTML + a little CSS. The HTML report is shareable as a static artifact.
 

--- a/site/src/content/docs/commands/score.md
+++ b/site/src/content/docs/commands/score.md
@@ -16,12 +16,12 @@ pinprick score --html > report.html
 
 - Scans `.github/workflows/*.yml` and emits findings across four categories: `pin.*`, `workflow.*`, `source.*`, `runtime.*`
 - Each finding has a fixed point deduction; the score is `max(0, 100 - sum(points))`
-- Exits 1 when any findings exist (matches [audit](/commands/audit) for CI gating)
+- Exits 1 when any finding deducts points. Zero-point informational findings do not fail CI
 - Runs fully offline by default. `source.archived` and `source.advisory` activate only when a GitHub token is available
 
 ## Output formats
 
-- Default: a compact human-readable summary with grade, finding counts by severity, and top remediations
+- Default: a compact human-readable summary with grade, finding count, prioritized rules, and targets
 - `--json`: the full finding list as JSON for CI integration or downstream processing
 - `--html`: a self-contained HTML report (mutually exclusive with `--json`)
 - `--no-repo-config`: ignore the scanned repository's `.pinprick.toml` and use the global config (or defaults)
@@ -37,7 +37,7 @@ The full catalog lives in [`docs/scoring.md`](https://github.com/starhaven-io/pi
 | `pin`      | `pin.full_tag` (e.g. `@v4.2.1`)     | low      | 2      |
 | `source`   | `source.archived`                   | high     | 10     |
 | `source`   | `source.advisory` (GHSA match)      | high     | 15     |
-| `source`   | `source.unverified` (untrusted org) | low      | 1      |
+| `source`   | `source.unverified` (untrusted org) | low      | 0      |
 | `runtime`  | `runtime.pipe_to_shell`             | high     | 20     |
 | `runtime`  | `runtime.fetch.high`                | high     | 15     |
 | `runtime`  | `runtime.fetch.medium`              | medium   | 8      |
@@ -50,7 +50,7 @@ Grade bands: **A** 90–100, **B** 80–89, **C** 70–79, **D** 60–69, **F** 
 
 ## Trusted publishers
 
-`source.unverified` fires when an action's `owner` is not in the baseline trusted set (`actions`, `github`). Extend the allowlist in `.pinprick.toml`:
+`source.unverified` fires when an action's `owner` is not in the baseline trusted set (`actions`, `github`). It is informational: it deducts zero points and never fails the score gate. Extend the allowlist in `.pinprick.toml`:
 
 ```toml
 trusted-owners = ["my-org", "vendor"]
@@ -58,30 +58,24 @@ trusted-owners = ["my-org", "vendor"]
 
 Matching is exact owner, case-insensitive. See [Config File](/configuration/config-file) for the full set of options.
 
-Because the scanned repository's own `.pinprick.toml` applies, a third-party repo can shape its own grade (`trusted-owners`, `ignore` rules). Whenever a repo-local config changes the score, pinprick prints a note to stderr saying what it changed; pass `--no-repo-config` to ignore the file entirely.
+Because the scanned repository's own `.pinprick.toml` applies, a third-party repo can shape its own grade (`trusted-owners`, `trusted-hosts`, `extra-data-formats`, `ignore` rules). Whenever a repo-local config changes the score, pinprick prints a note to stderr saying what it changed; pass `--no-repo-config` to ignore the file entirely.
 
 ## Example
 
 ```
 $ pinprick score
-pinprick score  v0.5.0 rubric
+pinprick score  v0.7.0 rubric
 
-  Grade:  C   (72 / 100)
+  Grade:  A   (95 / 100)
 
-  Findings (11 unique, 24 occurrences):
-    high    2  pin.branch           actions/foo@main
-    high    1  source.archived      bar/baz@abc1234
-    medium  6  pin.sliding          7 actions
-    low     2  pin.full_tag         2 actions
+  Findings (1 unique, 1 occurrences):
+    medium  -5    pin.sliding                       actions/checkout@v4
 
-  Top remediations:
-    1. Pin actions/foo@main to a full SHA             (-15)
-    2. Replace bar/baz (archived) with a maintained action (-10)
-    ...
+  3 workflows scanned, 8 unique actions.
 
-  Run `pinprick score --json` for the full report.
+  Run with --json for the full report.
 ```
 
 ## Versioning
 
-The rubric is independently versioned from the pinprick binary (currently `v0.5.0`). Every scan records the rubric version so historical scores remain interpretable as the rubric evolves. Re-scoring against a newer rubric is always explicit — pinprick never silently re-grades a past scan.
+The rubric is independently versioned from the pinprick binary (currently `v0.7.0`). Every scan records the rubric version so historical scores remain interpretable as the rubric evolves. Re-scoring against a newer rubric is always explicit — pinprick never silently re-grades a past scan.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde_norway::Value;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -22,12 +22,14 @@ use crate::auth;
 use crate::config::Config;
 use crate::github::GitHubClient;
 use crate::output::{self, AuditFinding, AuditMatch, AuditReport};
-use crate::workflow::{self, ActionRef};
+use crate::workflow::{self, ActionRef, LocalActionRef};
 use colored::Colorize;
 
 /// Reason string for matches allowed via the `trusted-hosts` config list.
 /// Shared between the allow site and the repo-config notice that counts them.
 pub(crate) const REASON_TRUSTED_HOST: &str = "trusted host";
+/// Reason string for matches allowed via `extra-data-formats` config entries.
+pub(crate) const REASON_EXTRA_DATA_FORMAT: &str = "extra data format URL";
 
 /// Accumulates findings and (when verbose) allowed matches during a scan.
 ///
@@ -40,6 +42,9 @@ pub struct AuditCollector {
     /// Matches allowed via `trusted-hosts` — counted regardless of verbosity
     /// so the repo-config notice doesn't depend on `--verbose`.
     pub trusted_host_allowed: usize,
+    /// Matches allowed via `extra-data-formats` — counted regardless of
+    /// verbosity so repo-config notices surface score shaping.
+    pub extra_data_format_allowed: usize,
 }
 
 impl AuditCollector {
@@ -49,6 +54,7 @@ impl AuditCollector {
             allowed: Vec::new(),
             verbose,
             trusted_host_allowed: 0,
+            extra_data_format_allowed: 0,
         }
     }
 
@@ -59,6 +65,9 @@ impl AuditCollector {
     pub fn push_allowed(&mut self, allowed: AuditMatch) {
         if allowed.reason == REASON_TRUSTED_HOST {
             self.trusted_host_allowed += 1;
+        }
+        if allowed.reason == REASON_EXTRA_DATA_FORMAT {
+            self.extra_data_format_allowed += 1;
         }
         if self.verbose {
             self.allowed.push(allowed);
@@ -127,6 +136,32 @@ pub async fn run(
                     "  {} run-block scan of {display_name}: {e}",
                     "skipped".yellow()
                 );
+            }
+        }
+
+        for action in workflow::scan_local_actions(&content) {
+            let key = format!("local:{}", action.path);
+            if !scanned_actions.insert(key) {
+                continue;
+            }
+
+            if !quiet {
+                eprintln!("  {} {}", "Scanning local".blue(), action.path);
+            }
+
+            let findings_before = collector.findings.len();
+            match scan_local_action_source(repo_root, &action, &mut collector, config) {
+                Ok(ActionScanStatus::Complete) => {}
+                Ok(ActionScanStatus::Incomplete) => {
+                    eprintln!("warning: incomplete scan of local action {}", action.path);
+                }
+                Err(e) => {
+                    eprintln!("warning: could not scan local action {}: {e}", action.path);
+                }
+            }
+            for finding in collector.findings.iter_mut().skip(findings_before) {
+                finding.workflow_file = Some(display_name.clone());
+                finding.workflow_line = Some(action.line_number);
             }
         }
 
@@ -269,6 +304,12 @@ pub async fn run(
         }
         if trusted_host_allowed > 0 {
             parts.push(format!("trusted-host fetches: {trusted_host_allowed}"));
+        }
+        if collector.extra_data_format_allowed > 0 {
+            parts.push(format!(
+                "extra-data-format fetches: {}",
+                collector.extra_data_format_allowed
+            ));
         }
         if !parts.is_empty() {
             eprintln!(
@@ -881,6 +922,8 @@ fn check_url_patterns(
                 allowed_reason.get_or_insert("versioned URL");
             } else if config.is_host_trusted(url) {
                 allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
+            } else if config.is_extra_data_format_exempt(url) {
+                allowed_reason.get_or_insert(REASON_EXTRA_DATA_FORMAT);
             } else if config.is_data_format_exempt(url) {
                 allowed_reason.get_or_insert("data format URL");
             } else if audit_patterns::fetch_piped_to_jq(line) {
@@ -1025,6 +1068,131 @@ fn select_source_files(
         targets.push((path.clone(), kind));
     }
     targets
+}
+
+fn collect_local_source_files(action_dir: &Path) -> Result<Vec<(PathBuf, SourceFileKind)>> {
+    fn visit(dir: &Path, base: &Path, targets: &mut Vec<(PathBuf, SourceFileKind)>) -> Result<()> {
+        let mut entries = Vec::new();
+        for entry in std::fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+            entries.push(entry?);
+        }
+        entries.sort_by_key(|e| e.path());
+
+        for entry in entries {
+            let path = entry.path();
+            let relative = path
+                .strip_prefix(base)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+
+            if is_vendored_path(&relative) {
+                continue;
+            }
+
+            // `file_type()` does not follow symlinks, so a symlinked entry is
+            // neither file nor dir here and is skipped. Deliberate: it keeps
+            // traversal inside the action directory (a symlink can't redirect
+            // the scan outside it) at the cost of not scanning symlinked source
+            // — an acceptable trade-off since local actions are first-party.
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                visit(&path, base, targets)?;
+            } else if file_type.is_file()
+                && let Some(kind) = source_file_kind(&relative)
+            {
+                targets.push((path, kind));
+            }
+        }
+        Ok(())
+    }
+
+    let mut targets = Vec::new();
+    visit(action_dir, action_dir, &mut targets)?;
+    Ok(targets)
+}
+
+fn source_file_kind(relative: &str) -> Option<SourceFileKind> {
+    if relative == "action.yml" || relative == "action.yaml" {
+        Some(SourceFileKind::ActionYml)
+    } else if relative.ends_with(".js") || relative.ends_with(".ts") {
+        Some(SourceFileKind::JavaScript)
+    } else if relative.ends_with(".py") {
+        Some(SourceFileKind::Python)
+    } else if relative == "Dockerfile" || relative.ends_with(".dockerfile") {
+        Some(SourceFileKind::Dockerfile)
+    } else {
+        None
+    }
+}
+
+fn local_action_dir(repo_root: &Path, action: &LocalActionRef) -> Result<PathBuf> {
+    let Some(rel) = action.path.strip_prefix("./") else {
+        anyhow::bail!("local action path must start with ./");
+    };
+    if rel.is_empty()
+        || !Path::new(rel)
+            .components()
+            .all(|c| matches!(c, Component::Normal(_)))
+    {
+        anyhow::bail!("local action path escapes the repository");
+    }
+    Ok(repo_root.join(rel))
+}
+
+fn scan_local_action_source(
+    repo_root: &Path,
+    action: &LocalActionRef,
+    collector: &mut AuditCollector,
+    config: &Config,
+) -> Result<ActionScanStatus> {
+    let action_dir = local_action_dir(repo_root, action)?;
+    if !action_dir.is_dir() {
+        anyhow::bail!("{} is not a directory", action_dir.display());
+    }
+
+    let targets = collect_local_source_files(&action_dir)?;
+    if targets.is_empty() {
+        return Ok(ActionScanStatus::Complete);
+    }
+
+    let mut complete = true;
+    for (path, kind) in targets {
+        let content = match std::fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(_) => {
+                complete = false;
+                continue;
+            }
+        };
+        let relative = path
+            .strip_prefix(&action_dir)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let source_label = format!("{} ({relative})", action.path);
+        match kind {
+            SourceFileKind::ActionYml => match serde_norway::from_str::<Value>(&content) {
+                Ok(yaml) => {
+                    scan_action_yml_runs(&yaml, &source_label, &action.path, collector, config);
+                }
+                Err(_) => {
+                    complete = false;
+                }
+            },
+            SourceFileKind::JavaScript => {
+                scan_js_content(&content, &source_label, &action.path, collector, config);
+            }
+            SourceFileKind::Python => {
+                scan_py_content(&content, &source_label, &action.path, collector, config);
+            }
+            SourceFileKind::Dockerfile => {
+                scan_dockerfile_content(&content, &source_label, &action.path, collector, config);
+            }
+        }
+    }
+
+    Ok(ActionScanStatus::from_complete(complete))
 }
 
 async fn scan_action_source(
@@ -1598,6 +1766,7 @@ more stuff
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "data format URL");
+        assert_eq!(c.extra_data_format_allowed, 0);
     }
 
     #[test]
@@ -1628,6 +1797,7 @@ more stuff
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "data format URL");
+        assert_eq!(c.extra_data_format_allowed, 0);
     }
 
     #[test]
@@ -1707,6 +1877,7 @@ more stuff
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "data format URL");
+        assert_eq!(c.extra_data_format_allowed, 0);
     }
 
     #[test]
@@ -1722,6 +1893,7 @@ more stuff
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "data format URL");
+        assert_eq!(c.extra_data_format_allowed, 0);
     }
 
     #[test]
@@ -1741,7 +1913,8 @@ more stuff
         );
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
-        assert_eq!(c.allowed[0].reason, "data format URL");
+        assert_eq!(c.allowed[0].reason, REASON_EXTRA_DATA_FORMAT);
+        assert_eq!(c.extra_data_format_allowed, 1);
     }
 
     #[test]
@@ -1780,6 +1953,7 @@ more stuff
         assert!(c.findings.is_empty());
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "trusted host");
+        assert_eq!(c.trusted_host_allowed, 1);
     }
 
     #[test]
@@ -2170,6 +2344,82 @@ runs:
             tree_entry("node_modules/x/index.js", "blob"),
         ];
         assert!(select_source_files(&tree, "").is_empty());
+    }
+
+    #[test]
+    fn collect_local_source_files_filters_vendored_dirs() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let action_dir = dir.path().join(".github/actions/local");
+        std::fs::create_dir_all(action_dir.join("node_modules/dep")).unwrap();
+        std::fs::create_dir_all(action_dir.join("dist")).unwrap();
+        std::fs::write(action_dir.join("action.yml"), "name: local\n").unwrap();
+        std::fs::write(
+            action_dir.join("dist/index.js"),
+            "fetch('https://example.com/x')",
+        )
+        .unwrap();
+        std::fs::write(
+            action_dir.join("node_modules/dep/index.js"),
+            "fetch('https://evil.example/x')",
+        )
+        .unwrap();
+
+        let got = collect_local_source_files(&action_dir).unwrap();
+        let paths: Vec<_> = got
+            .iter()
+            .map(|(path, _)| {
+                path.strip_prefix(&action_dir)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert_eq!(paths, vec!["action.yml", "dist/index.js"]);
+    }
+
+    #[test]
+    fn scan_local_action_source_finds_composite_fetches() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let action_dir = dir.path().join(".github/actions/local");
+        std::fs::create_dir_all(&action_dir).unwrap();
+        std::fs::write(
+            action_dir.join("action.yml"),
+            r#"
+runs:
+  using: composite
+  steps:
+    - run: curl -fsSL https://example.com/install.sh | bash
+"#,
+        )
+        .unwrap();
+
+        let action = LocalActionRef {
+            path: "./.github/actions/local".to_string(),
+            line_number: 12,
+        };
+        let mut collector = AuditCollector::new(false);
+        let status =
+            scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).unwrap();
+        assert_eq!(status, ActionScanStatus::Complete);
+        assert_eq!(collector.findings.len(), 1);
+        assert!(collector.findings[0].description.contains("piped to shell"));
+        assert_eq!(
+            collector.findings[0].source_file,
+            "./.github/actions/local (action.yml)"
+        );
+    }
+
+    #[test]
+    fn scan_local_action_source_rejects_parent_escape() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let action = LocalActionRef {
+            path: "./../outside".to_string(),
+            line_number: 1,
+        };
+        let mut collector = AuditCollector::new(false);
+        assert!(
+            scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).is_err()
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,12 @@ impl Config {
         if audit_patterns::url_is_data_format(url) {
             return true;
         }
+        self.is_extra_data_format_exempt(url)
+    }
+
+    /// Check whether a URL is exempt only because of `extra-data-formats`
+    /// from the active config file. Built-in data formats are not counted.
+    pub fn is_extra_data_format_exempt(&self, url: &str) -> bool {
         let Some(ext) = audit_patterns::url_extension(url) else {
             return false;
         };

--- a/src/score.rs
+++ b/src/score.rs
@@ -230,6 +230,10 @@ pub struct ConfigImpact {
     /// Unique action refs exempted from `source.unverified` via the
     /// configured `trusted-owners` list (baseline owners not counted).
     pub actions_exempted: usize,
+    /// Runtime fetches exempted via the configured `trusted-hosts` list.
+    pub trusted_host_fetches: usize,
+    /// Runtime fetches exempted via the configured `extra-data-formats` list.
+    pub extra_data_format_fetches: usize,
 }
 
 /// Collect findings across all workflows, dedupe by rule + target, and roll
@@ -306,6 +310,8 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<(ScoreReport, Con
                     config,
                 );
             }
+            impact.trusted_host_fetches += collector.trusted_host_allowed;
+            impact.extra_data_format_fetches += collector.extra_data_format_allowed;
             for finding in &collector.findings {
                 // Honor `ignore.patterns` (an accepted risk shouldn't score) but
                 // not the `severity` display threshold — the score is complete.
@@ -871,6 +877,18 @@ pub async fn run(
                 impact.actions_exempted
             ));
         }
+        if impact.trusted_host_fetches > 0 {
+            parts.push(format!(
+                "trusted-host fetches: {}",
+                impact.trusted_host_fetches
+            ));
+        }
+        if impact.extra_data_format_fetches > 0 {
+            parts.push(format!(
+                "extra-data-format fetches: {}",
+                impact.extra_data_format_fetches
+            ));
+        }
         if !parts.is_empty() {
             eprintln!(
                 "note: the scanned repo's .pinprick.toml affected the score ({}) — rerun with --no-repo-config to ignore it",
@@ -1416,6 +1434,58 @@ jobs:
         assert_eq!(report.totals.points_deducted, 46);
         assert_eq!(report.score, 54);
         assert_eq!(report.grade, "F");
+    }
+
+    #[test]
+    fn runtime_trusted_host_impact_is_reported() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: trusted-host
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL https://artifacts.example.com/install.sh -o install.sh
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let cfg = Config {
+            trusted_hosts: vec!["artifacts.example.com".to_string()],
+            ..Config::default()
+        };
+        let (report, impact) = score_repo(dir.path(), &cfg).unwrap();
+        assert!(report.findings.is_empty());
+        assert_eq!(report.score, 100);
+        assert_eq!(impact.trusted_host_fetches, 1);
+    }
+
+    #[test]
+    fn runtime_extra_data_format_impact_is_reported() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wfdir = dir.path().join(".github").join("workflows");
+        std::fs::create_dir_all(&wfdir).unwrap();
+        let yaml = r#"
+name: extra-data
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL https://example.com/schema.proto -o schema.proto
+"#;
+        std::fs::write(wfdir.join("ci.yml"), yaml).unwrap();
+
+        let cfg = Config {
+            extra_data_formats: vec!["proto".to_string()],
+            ..Config::default()
+        };
+        let (report, impact) = score_repo(dir.path(), &cfg).unwrap();
+        assert!(report.findings.is_empty());
+        assert_eq!(report.score, 100);
+        assert_eq!(impact.extra_data_format_fetches, 1);
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 
 #[derive(Debug, Clone)]
@@ -40,9 +40,22 @@ static USES_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(\s*-?\s*uses:\s*)([^\s@]+)@(\S+?)(\s*#\s*(.+?))?\s*$").unwrap()
 });
 
-// `run: |` / `run: >` openers, including indent/chomping indicators (`|2-`, `>+`).
-static RUN_BLOCK_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*)(?:-\s+)?run\s*:\s*[|>][0-9+\-]*\s*$").unwrap());
+static LOCAL_USES_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*-?\s*uses:\s*(?:"([^"]+)"|'([^']+)'|([^#\s]+))\s*(?:#.*)?$"#).unwrap()
+});
+
+// YAML block scalar openers (`run: |`, `script: >`, etc.), including
+// indent/chomping indicators (`|2-`, `>+`). Every block body is skipped so
+// literal docs or scripts cannot false-match on `uses:` text.
+static BLOCK_SCALAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(\s*)(?:-\s+)?[A-Za-z0-9_-]+\s*:\s*[|>][0-9+\-]*\s*(?:#.*)?$").unwrap()
+});
+
+#[derive(Debug, Clone)]
+pub struct LocalActionRef {
+    pub path: String,
+    pub line_number: usize,
+}
 
 /// Parse a single line into an ActionRef, if it's a `uses:` line with an external action.
 pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
@@ -100,6 +113,35 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
     })
 }
 
+/// Parse a single line into a local action reference (`uses: ./path`), if any.
+pub fn parse_local_uses_line(line: &str, line_number: usize) -> Option<LocalActionRef> {
+    let caps = LOCAL_USES_RE.captures(line)?;
+    let path = caps
+        .get(1)
+        .or_else(|| caps.get(2))
+        .or_else(|| caps.get(3))?
+        .as_str();
+
+    if !path.starts_with("./") || !is_safe_local_action_path(path) {
+        return None;
+    }
+
+    Some(LocalActionRef {
+        path: path.to_string(),
+        line_number,
+    })
+}
+
+fn is_safe_local_action_path(path: &str) -> bool {
+    let Some(rel) = path.strip_prefix("./") else {
+        return false;
+    };
+    !rel.is_empty()
+        && Path::new(rel)
+            .components()
+            .all(|c| matches!(c, Component::Normal(_)))
+}
+
 fn classify_ref(r: &str) -> RefType {
     if r.len() == 40 && r.chars().all(|c| c.is_ascii_hexdigit()) {
         return RefType::Sha;
@@ -140,9 +182,8 @@ pub fn build_pinned_line(line: &str, sha: &str, original_tag: &str) -> Option<St
 
 /// Scan workflow YAML text and return all external action references.
 ///
-/// Lines inside `run:` block scalars are skipped so that shell heredocs and
-/// inline scripts can't false-match on literal `- uses:` text (e.g. a workflow
-/// that generates a test workflow on the fly).
+/// Lines inside block scalars are skipped so that shell heredocs, inline docs,
+/// and `with: script: |` snippets can't false-match on literal `- uses:` text.
 pub fn scan_content(content: &str) -> Vec<ActionRef> {
     let mut refs = Vec::new();
     let mut block_parent_col: Option<usize> = None;
@@ -158,12 +199,45 @@ pub fn scan_content(content: &str) -> Vec<ActionRef> {
             block_parent_col = None;
         }
 
-        if let Some(caps) = RUN_BLOCK_RE.captures(line) {
+        if let Some(caps) = BLOCK_SCALAR_RE.captures(line) {
             block_parent_col = Some(caps.get(1).unwrap().as_str().len());
             continue;
         }
 
         if let Some(r) = parse_uses_line(line, line_num) {
+            refs.push(r);
+        }
+    }
+
+    refs
+}
+
+/// Scan workflow YAML text and return local action references (`uses: ./path`).
+///
+/// Only references in the workflow itself are returned. A composite action that
+/// references another local action from its own `action.yml` is not followed —
+/// such a nested action is scanned only if a workflow also uses it directly.
+pub fn scan_local_actions(content: &str) -> Vec<LocalActionRef> {
+    let mut refs = Vec::new();
+    let mut block_parent_col: Option<usize> = None;
+
+    for (i, line) in content.lines().enumerate() {
+        let line_num = i + 1;
+
+        if let Some(start_col) = block_parent_col {
+            let indent = line.chars().take_while(|c| *c == ' ').count();
+            if line.trim().is_empty() || indent > start_col {
+                continue;
+            }
+            block_parent_col = None;
+        }
+
+        if let Some(caps) = BLOCK_SCALAR_RE.captures(line) {
+            block_parent_col = Some(caps.get(1).unwrap().as_str().len());
+            continue;
+        }
+
+        if let Some(r) = parse_local_uses_line(line, line_num) {
             refs.push(r);
         }
     }
@@ -370,6 +444,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_local_action() {
+        let r = parse_local_uses_line("      - uses: ./.github/actions/my-action", 7).unwrap();
+        assert_eq!(r.path, "./.github/actions/my-action");
+        assert_eq!(r.line_number, 7);
+    }
+
+    #[test]
+    fn parse_quoted_local_action_with_comment() {
+        let r = parse_local_uses_line("      - uses: \"./.github/actions/my-action\" # local", 7)
+            .unwrap();
+        assert_eq!(r.path, "./.github/actions/my-action");
+    }
+
+    #[test]
+    fn local_action_rejects_parent_escape() {
+        assert!(parse_local_uses_line("      - uses: ../actions/my-action", 1).is_none());
+        assert!(parse_local_uses_line("      - uses: ./../actions/my-action", 1).is_none());
+    }
+
+    #[test]
     fn skip_non_uses_line() {
         assert!(parse_uses_line("      - run: echo hello", 1).is_none());
         assert!(parse_uses_line("name: CI", 1).is_none());
@@ -478,6 +572,43 @@ jobs:
             );
             assert_eq!(refs[0].full_name(), "good/action");
         }
+    }
+
+    #[test]
+    fn scan_skips_uses_inside_non_run_block_scalar() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with:
+          script: |
+            const text = `
+            - uses: bad/action@v1
+            `;
+      - uses: good/action@v2
+"#;
+        let refs = scan_content(yaml);
+        assert_eq!(refs.len(), 2);
+        assert_eq!(refs[0].full_name(), "actions/github-script");
+        assert_eq!(refs[1].full_name(), "good/action");
+    }
+
+    #[test]
+    fn scan_local_actions_skips_block_scalars() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          - uses: ./.github/actions/fake
+      - uses: ./.github/actions/real
+"#;
+        let refs = scan_local_actions(yaml);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].path, "./.github/actions/real");
     }
 
     #[test]


### PR DESCRIPTION
Extends `pinprick audit` to cover locally-referenced actions. Without a GitHub token, audit now walks the source of local actions (`action.yml`, JS/TS, Python, Dockerfile) for the same runtime-fetch patterns it applies to remote action source, closing the gap where only remote source and inline `run:` blocks were scanned — paths are validated against traversal before any disk read, and symlinks and nested local actions are deliberately not followed (documented inline). Block-scalar skipping is generalized from `run:` to any YAML block scalar, so literal `- uses:` text inside an `actions/github-script` snippet no longer false-matches as a real action. Config-driven `extra-data-formats` exemptions are now tracked and surfaced in the repo-config notice for both `audit` and `score`. README and scoring docs are aligned to match.
