### PR TITLE
chore: release 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the crate to 0.16.0, releasing the work merged since 0.15.0: `pinprick audit` now scans local `uses: ./...` actions without a token (#277), the local audit cache is versioned and re-warms after an upgrade (#278), and GitHub API non-success responses are rejected with a clear error before parsing (#279) — alongside the CI/site hardening (#280), the agent-docs consolidation (#281), and the dependency updates since 0.15.0. `Cargo.toml` + `Cargo.lock` only.
