### PR TITLE
fix(release): drop cargo dry-run from the slim Release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,9 +162,6 @@ jobs:
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
           echo "tag=v${VERSION}" >> "${GITHUB_OUTPUT}"
 
-      - name: Verify packageable
-        run: cargo publish --dry-run
-
       - name: Create tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Release job runs on `ubuntu-slim` with no Rust toolchain, so the `cargo publish --dry-run` packageability check that #280 added before tag creation failed with `cargo: command not found` and aborted the 0.16.0 release before anything was tagged or published. The check is redundant with the `publish-crate` job, which runs its own `cargo publish --dry-run` after setting up Rust and right before the real `cargo publish`, so this drops the broken step and restores the release flow that shipped 0.15.0 cleanly.
