### PR TITLE
chore: align pinprick with the org-wide parity pass

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{astro,css,html,js,json,jsx,mjs,rb,tf,ts,tsx,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.{rs,swift,toml}]
+indent_style = space
+indent_size = 4

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [p-linnane]

--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -18,7 +18,9 @@ on:
 
 defaults:
   run:
-    shell: bash -xeuo pipefail {0}
+    # No -x: this workflow uses GitHub tokens in run steps and can mint
+    # short-lived app tokens.
+    shell: bash -euo pipefail {0}
 
 concurrency:
   group: audit-actions
@@ -51,7 +53,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Build pinprick
-        run: cargo build
+        run: cargo build --locked
 
       - name: Scan for new releases
         env:

--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -7,7 +7,8 @@ on:
 
 defaults:
   run:
-    shell: bash -xeuo pipefail {0}
+    # No -x: this workflow can mint and use short-lived app tokens.
+    shell: bash -euo pipefail {0}
 
 concurrency:
   group: bump-cargo-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         id: matrix
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EVENT_ACTION: ${{ github.event.action }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           # Push to main: run lint to warm the cache, and Coverage so
@@ -53,13 +52,11 @@ jobs:
           MATRIX='[{"name":"Conventional Commits","check":"commits","runner":"ubuntu-slim","fetch_depth":"0"}'
           RUN_ZIZMOR=false
 
-          # For title/body edits, only recheck conventional commits
-          if [[ "${EVENT_ACTION}" == "edited" ]]; then
-            echo "matrix=${MATRIX}]" >> "${GITHUB_OUTPUT}"
-            echo "run_zizmor=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
+          # `edited` (title/body/base) also runs the full path-derived matrix. The
+          # aggregate "conclusion" job is the only required status check, so it must
+          # certify every relevant leg for the current commit. Collapsing to a
+          # commits-only matrix on `edited` lets a green run overwrite a prior failing
+          # one on the same SHA, bypassing tests, coverage, site checks and the rest.
           CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
 
           # Rust or build workflow changes: lint + test
@@ -214,7 +211,7 @@ jobs:
 
       - name: Clippy
         if: matrix.check == 'lint'
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: Rustfmt
         if: matrix.check == 'lint'
@@ -254,7 +251,7 @@ jobs:
 
       - name: Test
         if: matrix.check == 'test'
-        run: cargo test
+        run: cargo test --locked
 
       # --- Coverage ---
 
@@ -331,7 +328,7 @@ jobs:
         working-directory: site
         run: npm run deploy:dry
         env:
-          WRANGLER_SEND_METRICS: 'false'
+          WRANGLER_SEND_METRICS: "false"
 
       # --- Verify Audited Actions ---
 
@@ -351,7 +348,7 @@ jobs:
 
       - name: Build pinprick
         if: matrix.check == 'verify-audited'
-        run: cargo build --release
+        run: cargo build --locked --release
 
       - name: Verify audited-actions entries
         if: matrix.check == 'verify-audited'

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -12,7 +12,8 @@ on:
 
 defaults:
   run:
-    shell: bash -xeuo pipefail {0}
+    # No -x: this job handles Cloudflare and catalog-signing secrets.
+    shell: bash -euo pipefail {0}
 
 permissions: {}
 
@@ -76,4 +77,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_SEND_METRICS: 'false'
+          WRANGLER_SEND_METRICS: "false"

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -15,6 +15,10 @@ concurrency:
   group: "pinprick-audit-${{ github.ref }}"
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
 permissions: {}
 
 jobs:
@@ -42,7 +46,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Build pinprick
-        run: cargo build
+        run: cargo build --locked
 
       - name: Save cargo cache (debug)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
 
 defaults:
   run:
-    shell: bash -xeuo pipefail {0}
+    # No -x: this workflow handles signing/notarization secrets, generated
+    # keychain passwords, and short-lived app tokens.
+    shell: bash -euo pipefail {0}
 
 concurrency:
   group: release
@@ -78,7 +80,7 @@ jobs:
       - name: Build
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo build --release --target "${TARGET}"
+        run: cargo build --locked --release --target "${TARGET}"
 
       - name: Codesign binary
         if: matrix.sign
@@ -223,7 +225,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify packageable
-        run: cargo publish --dry-run
+        run: cargo publish --locked --dry-run
 
       - name: Authenticate to crates.io
         id: auth
@@ -232,7 +234,7 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish
+        run: cargo publish --locked
 
   bump-cask:
     name: Bump Homebrew cask

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-# Build
-/target
-
-# Claude Code
+# Local machine/editor/agent state
 .claude/
-
-# macOS
+.codex/
 .DS_Store
+.vscode/
+
+# Build outputs
+/target

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ pinprick/
 └── .gitignore
 ```
 
-## Architecture
+## Project-specific notes
 
 ### Commands
 
@@ -103,15 +103,7 @@ Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name
 - `1` — findings present (audit) or updates available (update dry-run)
 - `2` — error
 
-## Code style and conventions
-
-- `cargo clippy` with zero warnings
-- `cargo fmt` for formatting
-- No unnecessary abstractions — flat module structure, no nested directories
-- `thiserror` for typed errors in library code, `anyhow` for context-rich error propagation in commands
-- `LazyLock` for compiled regex constants
-
-## CI workflows (.github/workflows/)
+### CI workflows (`.github/workflows/`)
 
 - **audit-actions.yml** — Weekly scan of tracked actions for new releases, automated PRs for clean entries
 - **bump-cargo-tools.yml** — Weekly check for newer versions of the cargo-installed CI lint tools (typos, cargo-deny, cargo-nextest, cargo-llvm-cov); opens a PR bumping the pins in ci.yml
@@ -123,17 +115,37 @@ Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name
 - **release.yml** — Manual dispatch: dry-run crate publishing, build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io, bump the Homebrew cask
 - **zizmor.yml** — GitHub Actions security audit on push to main
 
-## Commit conventions
+## Safety / do-not-touch rules
 
-Conventional Commits format: `type(scope): description`
+1. Do not round-trip workflow files through a YAML parser when writing pins or
+   updates; preserve the single-line `uses:` replacement model.
+2. Keep repo-local config suppressions visible on stderr, and preserve
+   `--no-repo-config` for scanning repositories the caller does not control.
+3. Treat remote action source as untrusted input. Audit may inspect fetched
+   JavaScript, Python, Docker, and action metadata, but it must not execute
+   fetched action code.
+4. Keep SARIF rule IDs stable when refining detections so downstream code
+   scanning configuration keeps working.
 
-Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
+## Required checks
 
-All commits must:
+- `cargo clippy` with zero warnings
+- `cargo fmt` for formatting
+- No unnecessary abstractions — flat module structure, no nested directories
+- `thiserror` for typed errors in library code, `anyhow` for context-rich error propagation in commands
+- `LazyLock` for compiled regex constants
+
+## Commit and PR conventions
+
+- Conventional Commits format: `type(scope): description`
+
+- Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
+
 - Sign off every commit with `git commit -s` for DCO (enforced by the `.githooks/commit-msg` hook — run `just install-hooks` once per clone to enable it).
-- Add a `Co-Authored-By` trailer for the agent/model that authored the change, placed after `Signed-off-by` (e.g. `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`). Bump the model version as newer ones ship.
+- When authored with an AI coding agent, add a `Co-Authored-By` trailer after `Signed-off-by`, naming the agent and model. Current examples: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` or `Co-Authored-By: Codex GPT-5 <noreply@openai.com>`. Bump the model version as newer ones ship.
 
-## Git workflow
+### Git workflow
 
-- Never commit directly to main — always create a feature branch and open a PR
-- PR descriptions should contain only a summary of the changes — no test plan sections, no bot attribution, no generated-by footers
+- Never commit directly to `main`; create a feature branch and open a PR.
+- PR descriptions should contain only a concise summary of changes. Do not add
+  test-plan sections, bot attribution, or generated-with footers.

--- a/README.md
+++ b/README.md
@@ -251,10 +251,6 @@ just install-hooks  # Install git hooks: pre-push check + DCO sign-off (once per
 
 Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format and include a DCO sign-off (`git commit -s`). Run `just install-hooks` once per clone to enable the git hooks (a pre-push `just check` and DCO sign-off enforcement).
 
-## Acknowledgements
-
-Built with [Claude Code](https://claude.ai/code).
-
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE) (`AGPL-3.0-only`).

--- a/justfile
+++ b/justfile
@@ -2,11 +2,11 @@
 
 # Build the project
 build:
-    cargo build
+    cargo build --locked
 
 # Build in release mode
 build-release:
-    cargo build --release
+    cargo build --locked --release
 
 # Clean build artifacts
 clean:
@@ -16,7 +16,7 @@ clean:
 
 # Run tests
 test:
-    cargo test
+    cargo test --locked
 
 # Lint
 
@@ -26,7 +26,7 @@ audit:
 
 # Run clippy
 clippy:
-    cargo clippy -- -D warnings
+    cargo clippy --locked --all-targets -- -D warnings
 
 # Check formatting
 fmt-check:
@@ -83,7 +83,7 @@ add-action owner_repo:
           - uses: ${OWNER}/${REPO}@${LATEST_SHA} # ${LATEST}
     YAML
 
-    cargo run --release --quiet -- --json audit "$TMPDIR"
+    cargo run --locked --release --quiet -- --json audit "$TMPDIR"
 
     FILE="audited-actions/${OWNER}/${REPO}.json"
     mkdir -p "$(dirname "$FILE")"
@@ -115,7 +115,7 @@ site-format-check:
 
 # Install site dependencies
 site-install:
-    cd site && npm install
+    cd site && npm ci --strict-allow-scripts
 
 # Preview the built site
 site-preview:
@@ -143,7 +143,7 @@ check:
         echo "--- $1 --- skipped ($2 not found)"
         skipped+=("$2 (brew install $3)")
     }
-    run cargo clippy -- -D warnings
+    run cargo clippy --locked --all-targets -- -D warnings
     run cargo fmt -- --check
     if command -v typos &>/dev/null; then
         run typos
@@ -160,7 +160,7 @@ check:
     else
         skip audit zizmor zizmor
     fi
-    run cargo test
+    run cargo test --locked
     echo "--- site-format-check ---"
     (cd site && npm run format:check) || failed=1
     echo "--- site-build ---"

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,7 +1,13 @@
-# Build
+# Local machine/editor/agent state
+.claude/
+.codex/
+.DS_Store
+.vscode/
+
+# Build outputs
 .astro/
-.wrangler/
 dist/
+.wrangler/
 
 # Dependencies
 node_modules/
@@ -12,6 +18,3 @@ node_modules/
 
 # Logs
 npm-debug.log*
-
-# macOS
-.DS_Store

--- a/site/.prettierrc
+++ b/site/.prettierrc
@@ -5,6 +5,12 @@
   "plugins": ["prettier-plugin-astro"],
   "overrides": [
     {
+      "files": ["**/*.yml", "**/*.yaml"],
+      "options": {
+        "singleQuote": false
+      }
+    },
+    {
       "files": "*.astro",
       "options": {
         "parser": "astro"

--- a/site/README.md
+++ b/site/README.md
@@ -35,14 +35,14 @@ Static assets, like favicons, can be placed in the `public/` directory.
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+| Command                         | Action                                           |
+| :------------------------------ | :----------------------------------------------- |
+| `npm ci --strict-allow-scripts` | Installs dependencies                            |
+| `npm run dev`                   | Starts local dev server at `localhost:4321`      |
+| `npm run build`                 | Build your production site to `./dist/`          |
+| `npm run preview`               | Preview your build locally, before deploying     |
+| `npm run astro ...`             | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro -- --help`       | Get help using the Astro CLI                     |
 
 ## 👀 Want to learn more?
 

--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pinprick.rs",
+  "private": true,
   "type": "module",
   "engines": {
     "node": ">=26.0.0"
@@ -29,9 +30,9 @@
     "esbuild": "^0.28.1"
   },
   "allowScripts": {
-    "sharp": true,
     "esbuild": true,
     "fsevents": true,
+    "sharp": true,
     "workerd": true
   }
 }


### PR DESCRIPTION
## Summary

Aligns pinprick with the org-wide parity pass. Grouped into three commits by type:

- **ci** — close the `edited`-event merge-gate bypass in `ci.yml` (full path-derived matrix); drop xtrace on secret/app-token jobs (`deploy-site`, `audit-actions`, `bump-cargo-tools`, `release`); add `bash -xeuo pipefail` defaults to `pinprick-audit.yml` (the local-build copy); enforce `cargo --locked` across clippy/test/build/publish; normalize `WRANGLER_SEND_METRICS` to double quotes.
- **docs** — `AGENTS.md` adopts the shared section vocabulary (Project-specific notes, nested CI workflows, Required checks, Safety / do-not-touch rules) and dual Claude/Codex co-author block; `README.md` drops the "Built with Claude Code" footer; `site/README.md` shows `npm ci --strict-allow-scripts`.
- **chore** — `justfile` locks all cargo recipes + `npm ci` for site-install; `site/package.json` gains `private` + alphabetized allowScripts; `site/.prettierrc` gets the shared YAML override; `.gitignore`/`site/.gitignore` lead with the shared local-state block; add `.editorconfig`; remove redundant `.github/FUNDING.yml`.

No tool/behavior change — CI/security, lockfile strictness, docs, and repo metadata only.
