### PR TITLE
fix(deps): pin esbuild override to exact 0.28.1

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -27,7 +27,7 @@
     "wrangler": "^4.100.0"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "0.28.1"
   },
   "allowScripts": {
     "esbuild": true,


### PR DESCRIPTION
Pins the site's `esbuild` override to exact `0.28.1` (was `^0.28.1`), matching the version Wrangler already requires exactly. Under the caret range Astro/Vite can still resolve the vulnerable `esbuild@0.27.7`; the exact pin holds the site dependency tree on the patched release and stops drift back to a vulnerable minor. No lockfile change — `esbuild` already resolves to `0.28.1` through Wrangler — so this only hardens `site/package.json` against future drift. Part of the same one-line pin across the sibling Astro sites (starhaven.io, macOSdb, pkgstory).

### Verification
- `npm install --package-lock-only --ignore-scripts` (in `site/`) → no lockfile change; `esbuild` stays at `0.28.1`
- `npm audit` → **0 vulnerabilities**
- `just check` (clippy, cargo test, cargo-deny, site Prettier + Astro build) passes
