### PR TITLE
feat(release): add musl Linux artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ jobs:
             runner: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-22.04-arm
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-22.04-arm
           - target: aarch64-apple-darwin
             runner: macos-26
             sign: true
@@ -77,10 +81,38 @@ jobs:
           rm -f "${RUNNER_TEMP}/certificate.p12"
           security list-keychain -d user -s "${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"
 
+      - name: Set up Rust target toolchain
+        if: runner.os == 'Linux'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustup target add "${TARGET}"
+          # aws-lc-sys (via rustls) compiles C through CMake, so musl needs a toolchain.
+          if [[ "${TARGET}" == *-musl ]]; then
+            sudo apt-get update
+            sudo apt-get install -y musl-tools cmake
+          fi
+
       - name: Build
         env:
           TARGET: ${{ matrix.target }}
         run: cargo build --locked --release --target "${TARGET}"
+
+      - name: Validate binary
+        if: runner.os == 'Linux'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          BINARY="target/${TARGET}/release/pinprick"
+          "${BINARY}" --version
+          # musl artifacts must be static — a dynamic-loader entry would break on Alpine.
+          if [[ "${TARGET}" == *-musl ]]; then
+            file "${BINARY}"
+            if readelf -l "${BINARY}" | grep -q 'Requesting program interpreter'; then
+              echo "::error::${TARGET} binary is not statically linked"
+              exit 1
+            fi
+          fi
 
       - name: Codesign binary
         if: matrix.sign

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name
 - **deploy-site.yml** — Build and deploy Astro site to Cloudflare Workers
 - **link-check.yml** — Weekly lychee broken-link check across the built site and README
 - **pinprick-audit.yml** — Run pinprick audit on its own workflows with SARIF upload
-- **release.yml** — Manual dispatch: dry-run crate publishing, build cross-platform binaries (linux-amd64, linux-arm64, darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io, bump the Homebrew cask
+- **release.yml** — Manual dispatch: dry-run crate publishing, build cross-platform binaries (linux-amd64 and linux-arm64, each in glibc and static musl variants, plus darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io, bump the Homebrew cask (glibc/macOS only)
 - **zizmor.yml** — GitHub Actions security audit on push to main
 
 ## Safety / do-not-touch rules

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ targets = [
     "aarch64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
 ]
 
 [licenses]

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -25,9 +25,17 @@ cargo install --git https://github.com/starhaven-io/pinprick
 
 Download a prebuilt binary from [GitHub Releases](https://github.com/starhaven-io/pinprick/releases). Binaries are available for:
 
-- Linux (amd64)
-- Linux (arm64)
-- macOS (Apple Silicon)
+- Linux amd64, glibc — `x86_64-unknown-linux-gnu`
+- Linux arm64, glibc — `aarch64-unknown-linux-gnu`
+- Linux amd64, musl (static) — `x86_64-unknown-linux-musl`
+- Linux arm64, musl (static) — `aarch64-unknown-linux-musl`
+- macOS Apple Silicon — `aarch64-apple-darwin`
+
+The `gnu` builds link against the system glibc and suit most mainstream distributions (Debian, Ubuntu, Fedora, …). The `musl` builds are statically linked and run on musl-based distributions such as Alpine, as well as minimal or distroless containers.
+
+:::note[musl binaries still need CA certificates]
+The musl binaries are statically linked, but pinprick makes HTTPS calls to the GitHub API and reads the host's trusted CA certificates at runtime. On Alpine, install them with `apk add ca-certificates`.
+:::
 
 ## Shell completions
 


### PR DESCRIPTION
Adds `x86_64` and `aarch64` musl release targets alongside the existing glibc and macOS builds, so Alpine and other musl-based distros — plus minimal and distroless containers — get statically linked binaries.

The release workflow gains a Linux-only toolchain step that runs `rustup target add` and, for musl targets, installs `musl-tools` and `cmake` (needed by `aws-lc-sys`, which rustls pulls in). A post-build step smoke-tests `--version` and asserts the musl binaries are fully static via `readelf`. Packaging is unchanged, so the tarballs publish as `pinprick-<version>-{x86_64,aarch64}-unknown-linux-musl.tar.gz`.

Homebrew stays glibc/macOS only. `deny.toml` adds the musl triples to keep `cargo deny` in sync with the release matrix, and the installation docs now distinguish glibc vs musl and note that musl users still need host CA certificates for HTTPS.
