### PR TITLE
chore: release 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the crate to 0.17.0. The headline change is musl Linux build artifacts (#286) — statically linked `x86_64` and `aarch64` binaries for Alpine and other musl-based distros, plus minimal and distroless containers. Also rolled up since 0.16.0: the slim Release job fix (#283), the org-wide parity alignment (#284), and the esbuild override pin (#285).
