### PR TITLE
ci: pin Linux runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
   scan:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -154,7 +154,7 @@ jobs:
           on: push
           jobs:
             test:
-              runs-on: ubuntu-latest
+              runs-on: ubuntu-24.04
               steps:
                 - uses: ${OWNER}/${REPO}@${TAG_SHA} # ${TAG}
           YAML

--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -19,7 +19,7 @@ permissions: {}
 jobs:
   scan:
     name: Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           # Push to main: run lint to warm the cache, and Coverage so
           # Codecov has a baseline for PR comparisons.
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            echo 'matrix=[{"name":"Lint","check":"lint","runner":"ubuntu-latest"},{"name":"Coverage","check":"coverage","runner":"ubuntu-latest","environment":"codecov"}]' >> "${GITHUB_OUTPUT}"
+            echo 'matrix=[{"name":"Lint","check":"lint","runner":"ubuntu-24.04"},{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}]' >> "${GITHUB_OUTPUT}"
             echo "run_zizmor=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -61,16 +61,16 @@ jobs:
 
           # Rust or build workflow changes: lint + test
           if echo "${CHANGED}" | grep -qE '\.rs$|^Cargo\.(toml|lock)$|^clippy\.toml$|^rustfmt\.toml$|^\.github/workflows/(ci|release)\.yml$'; then
-            MATRIX+=',{"name":"Lint","check":"lint","runner":"ubuntu-latest"}'
-            MATRIX+=',{"name":"Test (Linux)","check":"test","runner":"ubuntu-latest"}'
-            MATRIX+=',{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-22.04-arm"}'
+            MATRIX+=',{"name":"Lint","check":"lint","runner":"ubuntu-24.04"}'
+            MATRIX+=',{"name":"Test (Linux)","check":"test","runner":"ubuntu-24.04"}'
+            MATRIX+=',{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-24.04-arm"}'
             MATRIX+=',{"name":"Test (macOS)","check":"test","runner":"macos-26"}'
-            MATRIX+=',{"name":"Coverage","check":"coverage","runner":"ubuntu-latest","environment":"codecov"}'
+            MATRIX+=',{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}'
           fi
 
           # Audited-actions changes: verify all entries
           if echo "${CHANGED}" | grep -qE '^audited-actions/'; then
-            MATRIX+=',{"name":"Verify Audited Actions","check":"verify-audited","runner":"ubuntu-latest"}'
+            MATRIX+=',{"name":"Verify Audited Actions","check":"verify-audited","runner":"ubuntu-24.04"}'
           fi
 
           # Site or audited-actions changes: format check + build
@@ -373,7 +373,7 @@ jobs:
           on: push
           jobs:
             test:
-              runs-on: ubuntu-latest
+              runs-on: ubuntu-24.04
               steps:
                 - uses: ${OWNER}/${REPO}@${SHA} # ${TAG}
           YAML
@@ -391,7 +391,7 @@ jobs:
     name: zizmor
     needs: generate-matrix
     if: needs.generate-matrix.outputs.run_zizmor == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write # required for zizmor SARIF upload

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   audit:
     name: Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,13 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-musl
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
           - target: aarch64-unknown-linux-musl
-            runner: ubuntu-22.04-arm
+            runner: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             runner: macos-26
             sign: true
@@ -244,7 +244,7 @@ jobs:
   publish-crate:
     name: Publish to crates.io
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: release
       deployment: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   zizmor:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ Download a prebuilt binary from [GitHub Releases](https://github.com/starhaven-i
 - Linux arm64, musl (static) — `aarch64-unknown-linux-musl`
 - macOS Apple Silicon — `aarch64-apple-darwin`
 
-The `gnu` builds link against the system glibc and suit most mainstream distributions (Debian, Ubuntu, Fedora, …). The `musl` builds are statically linked and run on musl-based distributions such as Alpine, as well as minimal or distroless containers.
+The `gnu` builds link against the system glibc. They are built on Ubuntu 24.04, so they require **glibc 2.39 or newer** (Ubuntu 24.04+, Debian 13+, Fedora 40+). On older releases — Ubuntu 22.04, Debian 12, RHEL 9 and the like — use the statically linked `musl` builds instead. The `musl` builds carry no glibc requirement and also run on musl-based distributions such as Alpine, as well as minimal or distroless containers.
 
 :::note[musl binaries still need CA certificates]
 The musl binaries are statically linked, but pinprick makes HTTPS calls to the GitHub API and reads the host's trusted CA certificates at runtime. On Alpine, install them with `apk add ca-certificates`.


### PR DESCRIPTION
Pin the CI and release runners to explicit Ubuntu versions — `ubuntu-latest` → `ubuntu-24.04`, and the arm64 runners `ubuntu-22.04-arm` → `ubuntu-24.04-arm` — so the build and test matrix runs on a fixed OS image across both architectures instead of following GitHub's floating labels.

Both architectures now build on glibc 2.39, so the installation page is updated to state that floor and steer users on older distributions (Ubuntu 22.04, Debian 12, RHEL 9) to the static musl builds. The x86 gnu binary already built on 24.04 via `ubuntu-latest`, so this brings arm in line rather than raising a new floor.
