### PR TITLE
ci(codeql): set explicit analysis category

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:actions"


### PR DESCRIPTION
Sets an explicit `/language:actions` analysis category on the CodeQL workflow so every `codeql.yml` across the estate declares its category. No change to what is scanned.