### PR TITLE
ci(cache): make ci.yml sole writer for cargo-debug cache

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -16,6 +16,9 @@ on:
         default: ""
         type: string
 
+env:
+  CARGO_INCREMENTAL: 0
+
 defaults:
   run:
     # No -x: this workflow uses GitHub tokens in run steps and can mint
@@ -50,7 +53,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Build pinprick
         run: cargo build --locked

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+env:
+  CARGO_INCREMENTAL: 0
+
 concurrency:
   group: "pinprick-audit-${{ github.ref }}"
   cancel-in-progress: true
@@ -34,7 +37,6 @@ jobs:
           persist-credentials: false
 
       - name: Restore cargo cache (debug)
-        id: cargo-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -43,21 +45,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-
 
       - name: Build pinprick
         run: cargo build --locked
-
-      - name: Save cargo cache (debug)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.cargo-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ runner.arch }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run pinprick audit
         env:


### PR DESCRIPTION
The `cargo-debug` Actions cache was growing generation over generation. `pinprick-audit.yml` restored the previous `cargo-debug-*` cache via the prefix `restore-keys`, built into `target/`, then saved a new exact-key cache before `ci.yml` could save its clean one — so each generation inherited and re-saved the prior bloated `target/` (live evidence: restored an 828 MB cache, saved an 892 MB one).

This makes `ci.yml` the sole writer for the shared `cargo-debug-${Cargo.lock hash}` cache:

- Add `CARGO_INCREMENTAL: 0` to both debug-build audit workflows so no incremental cruft accumulates in `target/`.
- Drop the `cargo-debug-` prefix `restore-keys` fallback from both audit workflows so they only restore exact `Cargo.lock`-keyed hits and never inherit a prior generation's `target/`.
- Remove the audit-side `Save cargo cache (debug)` step from `pinprick-audit.yml`, leaving `ci.yml` (which already saves on push to main via the Lint leg) as the only writer.

On a cache miss the audit workflows cold-build `./target/debug/pinprick` from scratch, so SARIF upload and the scheduled `audit-actions` scan are unaffected. The now-orphaned `id: cargo-cache` on the restore step is also dropped.
