### PR TITLE
ci: give edited PR events their own concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ defaults:
     shell: bash -xeuo pipefail {0}
 
 concurrency:
-  group: "ci-${{ github.ref }}"
+  # PR body/title edits fire `edited` events; give them their own per-run group so
+  # they can't cancel in-flight tests from the preceding `opened`/`synchronize` run.
+  group: ${{ github.event.action == 'edited' && format('ci-edit-{0}-{1}', github.ref, github.run_id) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Summary

Editing a PR's title, body, or base branch fires a `pull_request` `edited` event. Those events currently share the `ci-${{ github.ref }}` concurrency group with the preceding `opened`/`synchronize` run, so with `cancel-in-progress: true` an edit cancels the in-flight checks on the same SHA and restarts them from scratch.

This gives `edited` events their own per-run group (`ci-edit-{ref}-{run_id}`) so they no longer cancel a running CI. Behavior on `opened`/`synchronize`/`reopened`/`push` is unchanged.

Brings the concurrency block into parity with Brewy across the fleet.
