### PR TITLE
fix(audit): broaden runtime-fetch detection and sanitize pin/update output

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -435,9 +435,11 @@ fn join_continuations(content: &str) -> Vec<(usize, String)> {
         // A comment never continues onto the next line — a trailing backslash
         // is just comment text, so the next line is a new command. Joining it
         // into the comment would hide it from the scan.
-        let is_continuation =
-            trimmed_end.ends_with('\\') && !(pending.is_none() && is_shell_comment_line(raw));
-        let body = if is_continuation {
+        let backslash_continuation = trimmed_end.ends_with('\\');
+        let operator_continuation = ends_with_pipeline_operator(trimmed_end);
+        let is_continuation = (backslash_continuation || operator_continuation)
+            && !(pending.is_none() && is_shell_comment_line(raw));
+        let body = if backslash_continuation {
             &trimmed_end[..trimmed_end.len() - 1]
         } else {
             raw
@@ -459,6 +461,10 @@ fn join_continuations(content: &str) -> Vec<(usize, String)> {
         out.push(p);
     }
     out
+}
+
+fn ends_with_pipeline_operator(line: &str) -> bool {
+    line.ends_with('|') || line.ends_with("&&") || line.ends_with("||")
 }
 
 pub fn scan_shell_content(
@@ -1056,7 +1062,7 @@ fn select_source_files(
         };
         let kind = if relative == "action.yml" || relative == "action.yaml" {
             SourceFileKind::ActionYml
-        } else if path.ends_with(".js") || path.ends_with(".ts") {
+        } else if is_javascript_source(path) {
             SourceFileKind::JavaScript
         } else if path.ends_with(".py") {
             SourceFileKind::Python
@@ -1115,7 +1121,7 @@ fn collect_local_source_files(action_dir: &Path) -> Result<Vec<(PathBuf, SourceF
 fn source_file_kind(relative: &str) -> Option<SourceFileKind> {
     if relative == "action.yml" || relative == "action.yaml" {
         Some(SourceFileKind::ActionYml)
-    } else if relative.ends_with(".js") || relative.ends_with(".ts") {
+    } else if is_javascript_source(relative) {
         Some(SourceFileKind::JavaScript)
     } else if relative.ends_with(".py") {
         Some(SourceFileKind::Python)
@@ -1124,6 +1130,13 @@ fn source_file_kind(relative: &str) -> Option<SourceFileKind> {
     } else {
         None
     }
+}
+
+fn is_javascript_source(path: &str) -> bool {
+    path.ends_with(".js")
+        || path.ends_with(".ts")
+        || path.ends_with(".mjs")
+        || path.ends_with(".cjs")
 }
 
 fn local_action_dir(repo_root: &Path, action: &LocalActionRef) -> Result<PathBuf> {
@@ -1431,6 +1444,21 @@ more stuff
     }
 
     #[test]
+    fn join_continuations_merges_trailing_pipeline_operators() {
+        let joined = join_continuations(
+            "curl https://x.example/s.sh |\n  sh\necho ok &&\n  true\necho no ||\n  false\n",
+        );
+        assert_eq!(
+            joined,
+            vec![
+                (0, "curl https://x.example/s.sh | sh".into()),
+                (2, "echo ok && true".into()),
+                (4, "echo no || false".into()),
+            ]
+        );
+    }
+
+    #[test]
     fn join_continuations_leaves_unbroken_lines_alone() {
         let joined = join_continuations("echo one\necho two\n");
         assert_eq!(joined, vec![(0, "echo one".into()), (1, "echo two".into())]);
@@ -1458,6 +1486,23 @@ more stuff
         assert_eq!(c.findings.len(), 1);
         assert_eq!(c.findings[0].severity, "high");
         assert_eq!(c.findings[0].line, Some(1));
+    }
+
+    #[test]
+    fn shell_scan_catches_pipe_to_shell_after_pipeline_newline() {
+        let mut c = AuditCollector::new(true);
+        scan_shell_content(
+            "curl -fsSL https://example.com/releases/download/v1.2.3/install.sh |\n  bash\n",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+        assert!(c.findings[0].description.contains("piped to shell"));
+        assert!(c.allowed.is_empty());
     }
 
     #[test]
@@ -1608,6 +1653,52 @@ more stuff
             &DEFAULT_CONFIG,
         );
         assert_eq!(c.findings.len(), 1);
+        assert!(c.allowed.is_empty());
+    }
+
+    #[test]
+    fn js_scan_unversioned_got_and_http_get_are_findings() {
+        let mut c = AuditCollector::new(true);
+        scan_js_content(
+            r#"
+const a = await got("https://example.com/api/data");
+http.get("http://example.com/install.sh", cb);
+https.get("https://example.com/install.sh", cb);
+"#,
+            "test.js",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 3);
+        assert!(c.allowed.is_empty());
+        assert!(
+            c.findings
+                .iter()
+                .any(|f| f.description.contains("got() request"))
+        );
+        assert!(
+            c.findings
+                .iter()
+                .any(|f| f.description.contains("http.get()"))
+        );
+    }
+
+    #[test]
+    fn js_scan_got_method_and_require_http_get_are_findings() {
+        let mut c = AuditCollector::new(true);
+        scan_js_content(
+            r#"
+const a = await got.get("https://example.com/api/data");
+const b = require("http").get("http://example.com/install.sh", cb);
+const d = require("node:https").get("https://example.com/install.sh", cb);
+"#,
+            "test.js",
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 3);
         assert!(c.allowed.is_empty());
     }
 
@@ -2281,6 +2372,8 @@ runs:
         let tree = vec![
             tree_entry("action.yml", "blob"),
             tree_entry("dist/index.js", "blob"), // bundled action code — kept
+            tree_entry("dist/index.mjs", "blob"),
+            tree_entry("src/main.cjs", "blob"),
             tree_entry("src/main.ts", "blob"),
             tree_entry("setup.py", "blob"),
             tree_entry("Dockerfile", "blob"),
@@ -2294,6 +2387,8 @@ runs:
             vec![
                 ("action.yml".to_string(), SourceFileKind::ActionYml),
                 ("dist/index.js".to_string(), SourceFileKind::JavaScript),
+                ("dist/index.mjs".to_string(), SourceFileKind::JavaScript),
+                ("src/main.cjs".to_string(), SourceFileKind::JavaScript),
                 ("src/main.ts".to_string(), SourceFileKind::JavaScript),
                 ("setup.py".to_string(), SourceFileKind::Python),
                 ("Dockerfile".to_string(), SourceFileKind::Dockerfile),
@@ -2352,9 +2447,20 @@ runs:
         let action_dir = dir.path().join(".github/actions/local");
         std::fs::create_dir_all(action_dir.join("node_modules/dep")).unwrap();
         std::fs::create_dir_all(action_dir.join("dist")).unwrap();
+        std::fs::create_dir_all(action_dir.join("src")).unwrap();
         std::fs::write(action_dir.join("action.yml"), "name: local\n").unwrap();
         std::fs::write(
+            action_dir.join("dist/helper.mjs"),
+            "fetch('https://example.com/x')",
+        )
+        .unwrap();
+        std::fs::write(
             action_dir.join("dist/index.js"),
+            "fetch('https://example.com/x')",
+        )
+        .unwrap();
+        std::fs::write(
+            action_dir.join("src/main.cjs"),
             "fetch('https://example.com/x')",
         )
         .unwrap();
@@ -2374,7 +2480,15 @@ runs:
                     .replace('\\', "/")
             })
             .collect();
-        assert_eq!(paths, vec!["action.yml", "dist/index.js"]);
+        assert_eq!(
+            paths,
+            vec![
+                "action.yml",
+                "dist/helper.mjs",
+                "dist/index.js",
+                "src/main.cjs"
+            ]
+        );
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -211,6 +211,12 @@ re!(
 re!(JS_CHILD_PROC_CURL, r"child_process.*\bcurl\b");
 re!(JS_FETCH_URL, r#"fetch\s*\(\s*["'`]https?://"#);
 re!(JS_AXIOS_URL, r#"axios\.\w+\s*\(\s*["'`]https?://"#);
+re!(JS_GOT_URL, r#"\bgot(?:\.\w+)?\s*\(\s*["'`]https?://"#);
+re!(JS_HTTP_URL, r#"https?\.get\s*\(\s*["'`]https?://"#);
+re!(
+    JS_REQUIRE_HTTP_GET,
+    r#"require\(\s*["'](?:node:)?https?["']\s*\)\.get\s*\(\s*["'`]https?://"#
+);
 
 pub static JS_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
     vec![
@@ -266,6 +272,24 @@ pub static JS_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "axios request to external URL without version pinning",
+        },
+        Pattern {
+            regex: &JS_GOT_URL,
+            severity: Severity::Medium,
+            category: Category::JavaScriptFetch,
+            description: "got() request to external URL without version pinning",
+        },
+        Pattern {
+            regex: &JS_HTTP_URL,
+            severity: Severity::Medium,
+            category: Category::JavaScriptFetch,
+            description: "http.get() to external URL without version pinning",
+        },
+        Pattern {
+            regex: &JS_REQUIRE_HTTP_GET,
+            severity: Severity::Medium,
+            category: Category::JavaScriptFetch,
+            description: "http.get() to external URL without version pinning",
         },
     ]
 });
@@ -428,29 +452,31 @@ pub fn fetch_piped_to_jq(line: &str) -> bool {
 // the trailing class admits a following extension dot, suffix (`-rc1`), or end
 // of string (a URL whose path ends at the version, e.g. `/download/v1.2.3`).
 static VERSION_SEGMENT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"[-_/=]v?\d+(\.\d+)+(?:[-_./\s"]|$)"#).unwrap());
+    LazyLock::new(|| Regex::new(r#"[-_/]v?\d+(\.\d+)+(?:[-_./\s"]|$)"#).unwrap());
 
-/// Check if a URL contains a version segment in its **path or query** — not
-/// its host. Scanning the authority too would let a versioned-looking host (a
-/// bare IP like `10.0.0.1`, or a date-stamped hostname) whitelist an otherwise
-/// unpinned fetch, which is a detection bypass.
+/// Check if a URL contains a version segment in its **path** — not its host or
+/// query string. Scanning the authority or query too would let a
+/// versioned-looking host or inert parameter whitelist an otherwise unpinned
+/// fetch, which is a detection bypass.
 pub fn url_has_version(s: &str) -> bool {
-    VERSION_SEGMENT.is_match(url_path_and_query(s))
+    VERSION_SEGMENT.is_match(url_path(s))
 }
 
-/// Return the path+query+fragment of an `http(s)://` URL (everything from the
-/// first `/` after the authority). Returns `""` for a URL with no path, and
+/// Return the path of an `http(s)://` URL (everything from the first `/` after
+/// the authority until `?` or `#`). Returns `""` for a URL with no path, and
 /// the input unchanged for a string that is not an `http(s)://` URL.
-fn url_path_and_query(url: &str) -> &str {
+fn url_path(url: &str) -> &str {
     let Some(rest) = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))
     else {
         return url;
     };
-    let after_userinfo = rest.split_once('@').map(|(_, r)| r).unwrap_or(rest);
-    match after_userinfo.find('/') {
-        Some(i) => &after_userinfo[i..],
+    // The path starts at the first `/`, which also ends the authority. Any
+    // `user@host` userinfo and any `@` in a later path segment or query are
+    // therefore excluded without special-casing `@`.
+    match rest.find('/') {
+        Some(i) => rest[i..].split(['?', '#']).next().unwrap_or_default(),
         None => "",
     }
 }
@@ -721,6 +747,31 @@ mod tests {
     }
 
     #[test]
+    fn query_only_version_is_not_versioned() {
+        assert!(!url_has_version(
+            "https://example.com/download/install.sh?version=1.2.3"
+        ));
+        assert!(!url_has_version(
+            "https://example.com/download/install.sh?v=1.2.3#release"
+        ));
+        assert!(url_has_version(
+            "https://example.com/releases/v1.2.3/install.sh?cache=false"
+        ));
+    }
+
+    #[test]
+    fn at_sign_past_authority_does_not_break_path_version() {
+        // A `@` in a later path segment or query must not truncate the path:
+        // the version is still found and the URL counts as pinned.
+        assert!(url_has_version(
+            "https://example.com/releases/v1.2.3/tool?token=a@b"
+        ));
+        assert!(url_has_version(
+            "https://user@example.com/releases/v1.2.3/tool"
+        ));
+    }
+
+    #[test]
     fn arch_suffix_not_version() {
         // `x86_64` must not read as a version — no dotted component.
         assert!(!url_has_version("https://example.com/setup-x86_64.sh"));
@@ -730,7 +781,7 @@ mod tests {
     #[test]
     fn versioned_looking_host_not_counted() {
         // A bare-IP host (or a version-shaped authority) must NOT register as a
-        // pinned version — only the path/query is scanned, so these still fire.
+        // pinned version — only the path is scanned, so these still fire.
         assert!(!url_has_version("https://10.0.0.1/install.sh"));
         assert!(!url_has_version("https://1.2.3.4/get.sh"));
         // …but a real version in the path still counts.

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 use serde::Serialize;
+use std::io::{self, Write};
 
 use crate::audit_patterns::Severity;
 
@@ -47,48 +48,61 @@ pub struct PinReport {
 
 impl PinReport {
     pub fn print_human(&self) {
+        self.write_human(&mut io::stdout())
+            .expect("writing pin report");
+    }
+
+    fn write_human(&self, w: &mut impl Write) -> io::Result<()> {
         let mut current_file = String::new();
 
         for p in &self.pinned {
             if p.file != current_file {
                 if !current_file.is_empty() {
-                    println!();
+                    writeln!(w)?;
                 }
-                println!("{}", p.file.bold());
+                writeln!(w, "{}", sanitize_for_terminal(&p.file).bold())?;
                 current_file.clone_from(&p.file);
             }
-            println!(
+            let action = sanitize_for_terminal(&p.action);
+            let old_ref = sanitize_for_terminal(&p.old_ref);
+            let tag = sanitize_for_terminal(&p.tag);
+            writeln!(
+                w,
                 "  {} {} {} {}",
-                p.action.cyan(),
-                format!("@{}", p.old_ref).dimmed(),
+                action.cyan(),
+                format!("@{old_ref}").dimmed(),
                 "->".dimmed(),
-                format!("@{}… # {}", &p.sha[..12], p.tag).green()
-            );
+                format!("@{}… # {tag}", &p.sha[..12]).green()
+            )?;
         }
 
         for s in &self.skipped {
             if s.file != current_file {
                 if !current_file.is_empty() {
-                    println!();
+                    writeln!(w)?;
                 }
-                println!("{}", s.file.bold());
+                writeln!(w, "{}", sanitize_for_terminal(&s.file).bold())?;
                 current_file.clone_from(&s.file);
             }
-            println!(
+            let action = sanitize_for_terminal(&s.action);
+            let reason = sanitize_for_terminal(&s.reason);
+            writeln!(
+                w,
                 "  {} {}",
-                format!("! {}", s.action).yellow(),
-                format!("-- {}", s.reason).dimmed()
-            );
+                format!("! {action}").yellow(),
+                format!("-- {reason}").dimmed()
+            )?;
         }
 
         if !self.pinned.is_empty() || !self.skipped.is_empty() {
-            println!();
+            writeln!(w)?;
         }
 
         let total_files: std::collections::HashSet<&str> =
             self.pinned.iter().map(|p| p.file.as_str()).collect();
         let verb = if self.applied { "Pinned" } else { "Would pin" };
-        println!(
+        writeln!(
+            w,
             "{verb} {} action{} across {} file{}{}",
             self.pinned.len(),
             if self.pinned.len() == 1 { "" } else { "s" },
@@ -99,10 +113,11 @@ impl PinReport {
             } else {
                 format!(" ({} skipped)", self.skipped.len())
             }
-        );
+        )?;
         if !self.applied && !self.pinned.is_empty() {
-            println!("Run with {} to apply.", "--write".bold());
+            writeln!(w, "Run with {} to apply.", "--write".bold())?;
         }
+        Ok(())
     }
 
     pub fn print_json(&self) {
@@ -134,47 +149,59 @@ pub struct UpdateReport {
 
 impl UpdateReport {
     pub fn print_human(&self) {
+        self.write_human(&mut io::stdout())
+            .expect("writing update report");
+    }
+
+    fn write_human(&self, w: &mut impl Write) -> io::Result<()> {
         if self.updates.is_empty() {
-            println!("All pinned actions are up to date.");
-            return;
+            writeln!(w, "All pinned actions are up to date.")?;
+            return Ok(());
         }
 
         let mut current_file = String::new();
         for u in &self.updates {
             if u.file != current_file {
                 if !current_file.is_empty() {
-                    println!();
+                    writeln!(w)?;
                 }
-                println!("{}", u.file.bold());
+                writeln!(w, "{}", sanitize_for_terminal(&u.file).bold())?;
                 current_file.clone_from(&u.file);
             }
-            println!(
+            let action = sanitize_for_terminal(&u.action);
+            let current_tag = sanitize_for_terminal(&u.current_tag);
+            let latest_tag = sanitize_for_terminal(&u.latest_tag);
+            writeln!(
+                w,
                 "  {} {} {} {}",
-                u.action.cyan(),
-                u.current_tag.dimmed(),
+                action.cyan(),
+                current_tag.dimmed(),
                 "->".dimmed(),
-                u.latest_tag.green()
-            );
+                latest_tag.green()
+            )?;
             if let Some(url) = &u.release_url {
-                println!("    {}", url.dimmed());
+                writeln!(w, "    {}", sanitize_for_terminal(url).dimmed())?;
             }
         }
 
-        println!();
+        writeln!(w)?;
         if self.applied {
-            println!(
+            writeln!(
+                w,
                 "{} update{} applied.",
                 self.updates.len(),
                 if self.updates.len() == 1 { "" } else { "s" }
-            );
+            )?;
         } else {
-            println!(
+            writeln!(
+                w,
                 "{} update{} available. Run with {} to apply.",
                 self.updates.len(),
                 if self.updates.len() == 1 { "" } else { "s" },
                 "--write".bold()
-            );
+            )?;
         }
+        Ok(())
     }
 
     pub fn print_json(&self) {
@@ -870,6 +897,68 @@ mod audit_summary_tests {
             sanitize_for_terminal("x\ry\nz\u{7}\u{7f}"),
             "x\u{fffd}y\u{fffd}z\u{fffd}\u{fffd}"
         );
+    }
+
+    #[test]
+    fn pin_human_output_sanitizes_untrusted_fields() {
+        let report = PinReport {
+            pinned: vec![PinResult {
+                file: ".github/workflows/ci.yml".into(),
+                action: "evil\u{1b}[2J/action".into(),
+                old_ref: "main\u{7}".into(),
+                sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                tag: "v1.2.3\rrewrite".into(),
+                line: 1,
+            }],
+            skipped: vec![PinSkip {
+                file: ".github/workflows/ci.yml".into(),
+                action: "skip\u{7f}action".into(),
+                reason: "branch\u{1b}[31m ref".into(),
+                line: 2,
+            }],
+            applied: false,
+        };
+        let mut buf = Vec::new();
+        report.write_human(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("evil\u{fffd}[2J/action"));
+        assert!(out.contains("@main\u{fffd}"));
+        assert!(out.contains("# v1.2.3\u{fffd}rewrite"));
+        assert!(out.contains("skip\u{fffd}action"));
+        assert!(out.contains("branch\u{fffd}[31m ref"));
+        assert!(!out.contains('\u{7}'));
+        assert!(!out.contains('\r'));
+        assert!(!out.contains('\u{7f}'));
+    }
+
+    #[test]
+    fn update_human_output_sanitizes_untrusted_fields() {
+        let report = UpdateReport {
+            updates: vec![UpdateResult {
+                file: ".github/workflows/ci.yml".into(),
+                action: "evil\u{1b}[2J/action".into(),
+                current_tag: "v1\u{7}".into(),
+                current_sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                latest_tag: "v2\rrewrite".into(),
+                latest_sha: "abcdef0123456789abcdef0123456789abcdef01".into(),
+                line: 1,
+                release_url: Some("https://example.com/release\u{7f}".into()),
+            }],
+            up_to_date: 0,
+            applied: false,
+        };
+        let mut buf = Vec::new();
+        report.write_human(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("evil\u{fffd}[2J/action"));
+        assert!(out.contains("v1\u{fffd}"));
+        assert!(out.contains("v2\u{fffd}rewrite"));
+        assert!(out.contains("https://example.com/release\u{fffd}"));
+        assert!(!out.contains('\u{7}'));
+        assert!(!out.contains('\r'));
+        assert!(!out.contains('\u{7f}'));
     }
 
     #[test]


### PR DESCRIPTION
Second security-review batch on the audit engine. `join_continuations` now treats a trailing `|`, `&&`, or `||` as a line continuation, so a pipe-to-shell split across physical lines still trips the high-severity rule. JavaScript fetch detection covers `got()`/`got.method()`, `http.get()`/`https.get()`, and the inline `require("http").get()` form for unversioned URLs. `.mjs`/`.cjs` count as JavaScript source in both the remote and local selectors. `pin`/`update` human output routes every untrusted field, including the workflow file path, through `sanitize_for_terminal`. `url_has_version` checks the URL path only, so a query-string version no longer reads as pinning.
