### PR TITLE
docs: redesign docs site and document the GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ To try unreleased changes from `main`:
 cargo install --git https://github.com/starhaven-io/pinprick
 ```
 
+### GitHub Action
+
+For CI audit runs, use the shipped [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). It installs a pinned pinprick release, verifies the archive checksum, runs `pinprick audit`, and can upload SARIF:
+
+```yaml
+name: GitHub Actions supply chain audit
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  pinprick:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run pinprick
+        uses: starhaven-io/pinprick-action@d52684fdf26c13aec4a37eb09029af8fd41b6f01 # v0.1.0
+```
+
+The action wraps `pinprick audit` only. Use the CLI directly for `pin`, `update`, and `score`. For console-mode pull request feedback, set `advanced-security: false`; see the action README for the full matrix.
+
 ## Usage
 
 All commands default to the current directory. Pass a path to target a different repository root. Use `--json` for machine-readable output.
@@ -65,7 +99,7 @@ pinprick audit
 # Target a specific repo
 pinprick audit /path/to/repo
 
-# Show every matched pattern, including ones that passed the version check
+# Show every matched pattern, including allowed matches
 pinprick audit --verbose
 
 # Emit SARIF 2.1.0 for GitHub code scanning
@@ -92,17 +126,17 @@ Resolve action tag references to full SHAs (dry-run by default):
 ```
 $ pinprick pin
 .github/workflows/ci.yml
-  actions/checkout @v4 -> @de0fac2e…ce83dd # v6.0.2
-  actions/upload-artifact @v4 -> @bbbca2dd…f024f # v7.0.0
+  actions/checkout @v7 -> @9c091bb21b7c… # v7.0.0
+  actions/upload-artifact @v7 -> @043fb46d1a93… # v7.0.1
 
-  ! actions/checkout@v4 -- sliding tag, resolved to v6.0.2
+  ! actions/checkout@v7 -- sliding tag, resolved to v7.0.0
   ! Homebrew/actions/setup-homebrew@main -- branch ref — pin to a SHA manually
 
 Would pin 2 actions across 1 file (2 skipped)
 Run with --write to apply.
 ```
 
-Sliding tags like `@v4` are resolved to their exact version. Branch refs like `@main` are flagged.
+Sliding tags like `@v7` are resolved to their exact version. Branch refs like `@main` are flagged.
 
 ### Update
 
@@ -111,7 +145,7 @@ Check pinned actions for newer releases (dry-run by default):
 ```
 $ pinprick update
 .github/workflows/ci.yml
-  actions/checkout  v4.1.0 -> v6.0.2
+  actions/checkout  v4.1.0 -> v7.0.0
 
 1 update available. Run with --write to apply.
 ```
@@ -196,26 +230,26 @@ Cache cleaned.
 
 ## What the audit detects
 
-| Category | Examples | Severity |
-|----------|----------|----------|
-| Pipe-to-shell | `curl`/`wget` piped to `sh`/`bash`/`python` (any URL) | High |
-| Pipe-to-shell | `bash <(curl ...)`, `bash -c "$(curl ...)"`, `eval "$(curl ...)"` | High |
-| Pipe-to-shell | PowerShell `iex (iwr ...)` / `Invoke-Expression (... DownloadString ...)` | High |
-| Shell | `curl`/`wget` to `/latest/` URLs | High |
-| Shell | `curl`/`wget` to unversioned URLs | Medium |
-| Shell | `gh release download` without a tag | Medium |
-| Shell | `git clone` without a pinned `--branch` ref (unless a `git checkout <sha>` follows within 3 lines) | Medium |
-| Shell | `go install @latest`, unpinned `pip`/`npm`/`cargo install`/`gem install` | Low |
-| PowerShell | `Invoke-WebRequest`/`iwr`/`irm` to `/latest/` URLs | High |
-| PowerShell | `Invoke-WebRequest`/`iwr`/`irm` to unversioned URLs | Medium |
-| JavaScript | `fetch()`/`axios`/`got` to `/latest/` URLs | High |
-| JavaScript | `exec("curl ...")`, `child_process` curl | High |
-| Python | `requests.get`/`urllib` to `/latest/` URLs | High |
-| Python | `subprocess` shelling out to `curl`/`wget` | High |
-| Docker | `FROM :latest` or untagged | High |
-| Docker | `RUN curl`/`wget` piped to a shell | High |
-| Docker | `curl`/`wget` in `RUN` instructions | Medium |
-| Docker | `ADD` with an `http(s)://` URL source | Medium |
+| Category      | Examples                                                                                           | Severity |
+| ------------- | -------------------------------------------------------------------------------------------------- | -------- |
+| Pipe-to-shell | `curl`/`wget` piped to `sh`/`bash`/`python` (any URL)                                              | High     |
+| Pipe-to-shell | `bash <(curl ...)`, `bash -c "$(curl ...)"`, `eval "$(curl ...)"`                                  | High     |
+| Pipe-to-shell | PowerShell `iex (iwr ...)` / `Invoke-Expression (... DownloadString ...)`                          | High     |
+| Shell         | `curl`/`wget` to `/latest/` URLs                                                                   | High     |
+| Shell         | `curl`/`wget` to unversioned URLs                                                                  | Medium   |
+| Shell         | `gh release download` without a tag                                                                | Medium   |
+| Shell         | `git clone` without a pinned `--branch` ref (unless a `git checkout <sha>` follows within 3 lines) | Medium   |
+| Shell         | `go install @latest`, unpinned `pip`/`npm`/`cargo install`/`gem install`                           | Low      |
+| PowerShell    | `Invoke-WebRequest`/`iwr`/`irm` to `/latest/` URLs                                                 | High     |
+| PowerShell    | `Invoke-WebRequest`/`iwr`/`irm` to unversioned URLs                                                | Medium   |
+| JavaScript    | `fetch()`/`axios`/`got` to `/latest/` URLs                                                         | High     |
+| JavaScript    | `exec("curl ...")`, `child_process` curl                                                           | High     |
+| Python        | `requests.get`/`urllib` to `/latest/` URLs                                                         | High     |
+| Python        | `subprocess` shelling out to `curl`/`wget`                                                         | High     |
+| Docker        | `FROM :latest` or untagged                                                                         | High     |
+| Docker        | `RUN curl`/`wget` piped to a shell                                                                 | High     |
+| Docker        | `curl`/`wget` in `RUN` instructions                                                                | Medium   |
+| Docker        | `ADD` with an `http(s)://` URL source                                                              | Medium   |
 
 Pipe-to-shell is flagged even when the URL is versioned — a piped payload is never written to disk, so it cannot be checksum-verified and the versioned path pins the URL but not the content.
 
@@ -225,11 +259,11 @@ Findings followed by checksum verification (`sha256sum`, `gpg --verify`, etc.) w
 
 ## Exit codes
 
-| Code | Meaning |
-|------|---------|
-| 0 | Clean — no findings, no pending updates |
-| 1 | Findings present (audit), score deductions present, or updates available (update dry-run) |
-| 2 | Error |
+| Code | Meaning                                                                                   |
+| ---- | ----------------------------------------------------------------------------------------- |
+| 0    | Clean — no findings, no pending updates                                                   |
+| 1    | Findings present (audit), score deductions present, or updates available (update dry-run) |
+| 2    | Error                                                                                     |
 
 ## Building
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -27,6 +27,9 @@ export default defineConfig({
       title: 'pinprick',
       description: 'GitHub Actions supply chain security.',
       favicon: '/favicon.svg',
+      logo: {
+        src: './src/assets/pinprick-logo.svg',
+      },
       customCss: ['./src/styles/custom.css'],
       lastUpdated: true,
       components: {
@@ -49,6 +52,7 @@ export default defineConfig({
           items: [
             { label: 'Introduction', slug: 'getting-started/introduction' },
             { label: 'Installation', slug: 'getting-started/installation' },
+            { label: 'GitHub Action', slug: 'getting-started/github-action' },
           ],
         },
         {

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,6 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <circle cx="16" cy="8" r="5" fill="#e94560"/>
-  <line x1="16" y1="13" x2="16" y2="30" stroke="#e94560" stroke-width="2.5" stroke-linecap="round"/>
-  <line x1="16" y1="30" x2="14" y2="26" stroke="#e94560" stroke-width="2" stroke-linecap="round"/>
-  <line x1="16" y1="30" x2="18" y2="26" stroke="#e94560" stroke-width="2" stroke-linecap="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 48 48" fill="none" role="img" aria-label="pinprick">
+  <rect width="48" height="48" rx="9" fill="#1c1a18" />
+  <path d="M11 15 L22 24 L11 33" stroke="#ef4444" stroke-width="6.4" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="33" cy="15" r="5" fill="#f7f7f5" />
+  <path d="M29.6 16.6 L36.4 16.6 L34.7 29 L31.3 29 Z" fill="#f7f7f5" />
+  <path d="M31.3 29 L34.7 29 L33 39.5 Z" fill="#ef4444" />
 </svg>

--- a/site/src/assets/pinprick-logo.svg
+++ b/site/src/assets/pinprick-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none" role="img" aria-label="pinprick">
+  <rect width="48" height="48" rx="8" fill="#1c1a18" />
+  <rect x="0.75" y="0.75" width="46.5" height="46.5" rx="7.25" stroke="#f7f7f5" stroke-opacity="0.12" stroke-width="1.5" />
+  <path d="M13 15 L23 23 L13 31" stroke="#ef4444" stroke-width="5.2" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="32.5" cy="14.5" r="4.4" fill="#f7f7f5" />
+  <path d="M30.2 16 L34.8 16 L33.4 30 L31.6 30 Z" fill="#f7f7f5" />
+  <path d="M31.6 30 L33.4 30 L32.5 38 Z" fill="#ef4444" />
+</svg>

--- a/site/src/content/docs/404.md
+++ b/site/src/content/docs/404.md
@@ -2,17 +2,16 @@
 title: '404'
 template: splash
 editUrl: false
+lastUpdated: false
 hero:
   title: '404'
-  tagline: That page isn't here. The URL may be wrong, or the page may have moved.
+  tagline: That page is not pinned here. Check the URL or head back to the docs.
   image:
     html: |
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="160" height="160" fill="none" aria-hidden="true">
-        <circle cx="16" cy="8" r="5" fill="#dc2626"/>
-        <line x1="16" y1="13" x2="16" y2="30" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
-        <line x1="16" y1="30" x2="14" y2="26" stroke="#dc2626" stroke-width="2" stroke-linecap="round"/>
-        <line x1="16" y1="30" x2="18" y2="26" stroke="#dc2626" stroke-width="2" stroke-linecap="round"/>
-      </svg>
+      <div class="pp-not-found-mark" aria-hidden="true">
+        <span>404</span>
+        <code>ref not found</code>
+      </div>
   actions:
     - text: Back to docs
       link: /getting-started/introduction/

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -31,15 +31,17 @@ See [Audited Actions](/configuration/audited-actions) for details on how the lis
 
 ## Without a token
 
-When no GitHub token is available, audit scans only workflow `run:` blocks. Action source code is not fetched. This still catches the most common patterns (shell commands fetching unversioned resources) but misses JavaScript, Python, and Docker patterns inside actions.
+When no GitHub token is available, audit scans workflow `run:` blocks and local actions referenced with `uses: ./...`. Remote action source code is not fetched. This still catches the most common patterns in repository-owned workflow code, but misses JavaScript, Python, and Docker patterns inside remote actions.
 
 ## Output formats
 
 - Default: colored human-readable output with severity buckets
 - `--json`: machine-readable JSON for CI integration
 - `--sarif`: SARIF 2.1.0 for upload to GitHub code scanning
-- `--verbose`: also report _allowed_ matches (fetches that fired a rule but were dropped because the URL is versioned)
+- `--verbose`: also report _allowed_ matches (fetches that fired a rule but were dropped because the URL is versioned, data-shaped, piped to `jq`, checksum-verified, or matched by `trusted-hosts`)
 - `--no-repo-config`: ignore the scanned repository's `.pinprick.toml` and use the global config (or defaults)
+
+For GitHub Actions CI, [`starhaven-io/pinprick-action`](/getting-started/github-action/) wraps this command and optional SARIF upload.
 
 ## Auditing repositories you don't control
 
@@ -50,11 +52,11 @@ The scanned repository's own `.pinprick.toml` applies during an audit — `ignor
 ```
 $ pinprick audit
 Scanning .github/workflows/ci.yml
-  actions/checkout@de0fac2e audited (bundled)
-  actions/upload-artifact@bbbca2dd audited (bundled)
+  actions/checkout@9c091bb audited (bundled)
+  actions/upload-artifact@043fb46 audited (bundled)
 Scanning .github/workflows/release.yml
-  actions/attest@59d89421 audited (bundled)
-  rust-lang/crates-io-auth-action@bbd81622 audited (local cache)
+  actions/attest@59d8942 audited (bundled)
+  rust-lang/crates-io-auth-action@c6f97d4 audited (local cache)
   Fetching Homebrew/actions/setup-homebrew@main (unpinned)
 
 No runtime fetch risks found.

--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -15,8 +15,8 @@ pinprick pin /path/to/repo
 
 - Dry-run by default — shows what would change without writing files, exits 1 when there are unpinned actions (useful for CI gating)
 - `--write` rewrites files in-place with `@sha # tag` format, preserving all comments and formatting
-- Tag refs (e.g., `@v4.3.1`) are resolved to their commit SHA via the GitHub API
-- Sliding tags (e.g., `@v4`) are resolved to the exact release version — `@v4` becomes `# v4.3.1`, not `# v4`
+- Tag refs (e.g., `@v7.0.0`) are resolved to their commit SHA via the GitHub API
+- Sliding tags (e.g., `@v7`) are resolved to the exact release version — `@v7` becomes `# v7.0.0`, not `# v7`
 - Already-pinned refs (40-char hex SHAs) are skipped silently
 - Branch refs (e.g., `@main`) are flagged — pin to a SHA manually
 - Annotated tags are followed to their underlying commit SHA
@@ -26,10 +26,10 @@ pinprick pin /path/to/repo
 ```
 $ pinprick pin
 .github/workflows/ci.yml
-  actions/checkout @v4 -> @de0fac2e…ce83dd # v4.3.1
-  actions/upload-artifact @v4 -> @bbbca2dd…f024f # v7.0.0
+  actions/checkout @v7 -> @9c091bb21b7c… # v7.0.0
+  actions/upload-artifact @v7 -> @043fb46d1a93… # v7.0.1
 
-  ! actions/checkout@v4 -- sliding tag, resolved to v4.3.1
+  ! actions/checkout@v7 -- sliding tag, resolved to v7.0.0
   ! Homebrew/actions/setup-homebrew@main -- branch ref — pin to a SHA manually
 
 Would pin 2 actions across 1 file (2 skipped)

--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -39,10 +39,10 @@ Matching is case-sensitive. Matching is against `owner/repo` only — subpaths a
 ```
 $ pinprick update
 .github/workflows/ci.yml
-  actions/checkout v4.1.0 -> v6.0.2
-    https://github.com/actions/checkout/releases/tag/v6.0.2
-  actions/setup-node v4.0.0 -> v6.3.0
-    https://github.com/actions/setup-node/releases/tag/v6.3.0
+  actions/checkout v4.1.0 -> v7.0.0
+    https://github.com/actions/checkout/releases/tag/v7.0.0
+  actions/setup-node v4.0.0 -> v6.4.0
+    https://github.com/actions/setup-node/releases/tag/v6.4.0
 
 2 updates available. Run with --write to apply.
 ```

--- a/site/src/content/docs/configuration/audited-actions.md
+++ b/site/src/content/docs/configuration/audited-actions.md
@@ -22,11 +22,11 @@ Verification is fail-closed. A missing or invalid signature — or a binary buil
 
 Each SHA was scanned for **unversioned runtime fetch patterns**. Specifically:
 
-- Shell: `curl`/`wget` to `/latest/` or unversioned URLs, `gh release download` without a tag, `go install @latest`, unpinned `pip`/`npm`
-- PowerShell: `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` to `/latest/` or unversioned URLs
+- Shell: pipe-to-shell, `curl`/`wget` to `/latest/` or unversioned URLs, `gh release download` without a tag, unpinned `git clone`, `go install @latest`, and unpinned package installs
+- PowerShell: pipe-to-shell equivalents, `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm` to `/latest/` or unversioned URLs, and unpinned `Install-Module` / `Install-Script`
 - JavaScript: `fetch()`/`axios`/`got`/`http.get` to `/latest/` or unversioned URLs, `exec()`/`child_process` shelling out to `curl`
 - Python: `urllib.request.urlopen`/`requests.get` to `/latest/` or unversioned URLs, `subprocess` shelling out to `curl`/`wget`
-- Docker: `FROM :latest` or untagged, `curl`/`wget` in `RUN` instructions
+- Docker: `FROM :latest` or untagged, `curl`/`wget` in `RUN` instructions, and remote `ADD` sources
 
 ## What "audited" does NOT mean
 
@@ -55,5 +55,5 @@ To add a new entry to the audited-actions list:
 Each file is a JSON array:
 
 ```json
-[{ "sha": "de0fac2e4500dabe0009e67214ff5f5447ce83dd", "tag": "v6.0.2" }]
+[{ "sha": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0", "tag": "v7.0.0" }]
 ```

--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -8,7 +8,7 @@ pinprick reads configuration from TOML files in two locations:
 1. **Global** — `~/.config/pinprick/config.toml`
 2. **Per-repo** — `.pinprick.toml` in the repository root
 
-Per-repo config overrides global config. Both are optional — pinprick uses sensible defaults.
+Per-repo config overrides global config as a whole file; fields are not merged. Both are optional — pinprick uses sensible defaults.
 
 ## Options
 
@@ -28,6 +28,9 @@ extra-data-formats = ["proto", "graphql"]
 # URL host exactly matches an entry is downgraded from a finding to an allowed
 # match. Case-insensitive.
 trusted-hosts = ["artifacts.example.com"]
+
+# Additional GitHub owners trusted for the zero-point source.unverified score note.
+trusted-owners = ["my-org"]
 
 # Suppress specific findings
 [ignore]
@@ -81,6 +84,12 @@ trusted-hosts = [
 - Package manager installs (`pip install foo`, `npm install foo`) — those are package registries, not HTTP hosts
 
 To suppress a specific pattern that `trusted-hosts` doesn't cover, use [`ignore.patterns`](#ignorepatterns) instead.
+
+### `trusted-owners`
+
+A list of GitHub owners to treat as trusted for the `source.unverified` scoring note. The baseline trusted set is `actions` and `github`; this setting extends that list for your own org or reviewed vendors.
+
+Matching is exact owner, case-insensitive. This option only affects the zero-point `source.unverified` note in `pinprick score`. It does not skip auditing, suppress runtime findings, or trust downloads from the owner.
 
 ### `ignore.actions`
 

--- a/site/src/content/docs/getting-started/github-action.md
+++ b/site/src/content/docs/getting-started/github-action.md
@@ -1,0 +1,132 @@
+---
+title: GitHub Action
+description: Run pinprick audit in GitHub Actions.
+---
+
+[`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action) is the shipped composite action for CI audit runs. It installs a pinprick release, verifies the downloaded archive checksum, runs `pinprick audit`, and optionally uploads SARIF to GitHub code scanning.
+
+The action runs `audit` only. Use the CLI directly for `pin`, `update`, and `score`.
+
+## Usage with GitHub Advanced Security
+
+This is the default mode. The action emits SARIF and uploads findings to GitHub code scanning so they appear in the repository's Security tab.
+
+In this mode, the action does not fail the workflow when pinprick reports findings unless `fail-on-findings: true` is set. Use GitHub rulesets if you want code scanning alerts to block merges.
+
+Run SARIF upload on trusted events such as `push` or `workflow_dispatch`. Pull requests from forks receive a read-only token, so SARIF upload can fail there; use console mode for pull request feedback.
+
+```yaml
+name: GitHub Actions supply chain audit
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  pinprick:
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read # needed for checkout and private/internal repositories
+      actions: read # needed for private/internal repositories
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run pinprick
+        uses: starhaven-io/pinprick-action@d52684fdf26c13aec4a37eb09029af8fd41b6f01 # v0.1.0
+```
+
+## Usage without GitHub Advanced Security
+
+Set `advanced-security: false` to print results to the workflow log instead of uploading SARIF. This mode is suitable for pull requests from forks.
+
+```yaml
+name: GitHub Actions supply chain audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+
+permissions: {}
+
+jobs:
+  pinprick:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run pinprick
+        uses: starhaven-io/pinprick-action@d52684fdf26c13aec4a37eb09029af8fd41b6f01 # v0.1.0
+        with:
+          advanced-security: false
+```
+
+Each example pins `pinprick-action` to a full commit SHA with the release tag in a trailing comment, not a mutable tag. Bump the SHA when you adopt a newer release.
+
+## Fail on findings
+
+```yaml
+- name: Run pinprick
+  uses: starhaven-io/pinprick-action@d52684fdf26c13aec4a37eb09029af8fd41b6f01 # v0.1.0
+  with:
+    fail-on-findings: true
+```
+
+## Inputs
+
+| Input               | Default  | Meaning                                                                                                                                                                              |
+| ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `version`           | `0.17.0` | pinprick version to install. The `v0.1.0` action release pins this default for deterministic runs. Use `latest` for the newest pinprick release, or an exact version like `v0.17.0`. |
+| `path`              | `.`      | Repository path to scan.                                                                                                                                                             |
+| `advanced-security` | `true`   | Upload SARIF results to GitHub code scanning. When `false`, the action prints normal console output.                                                                                 |
+| `fail-on-findings`  | `false`  | Fail the workflow when `pinprick audit` reports findings. Without this, findings are emitted as a warning and the workflow continues.                                                |
+
+## Outputs
+
+| Output       | Meaning                                                               |
+| ------------ | --------------------------------------------------------------------- |
+| `sarif-file` | Path to the generated SARIF file when `advanced-security` is enabled. |
+
+## Permissions
+
+Start workflows with `permissions: {}` and grant permissions only at the job that runs pinprick.
+
+| Permission               | Required when                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------- |
+| `security-events: write` | `advanced-security: true` uploads SARIF to code scanning.                     |
+| `contents: read`         | Checking out the repository, and Advanced Security on private/internal repos. |
+| `actions: read`          | Advanced Security on private/internal repos.                                  |
+
+The action passes the workflow's `GITHUB_TOKEN` to pinprick so it can fetch and audit external action source when the job permissions allow it. Without a token, pinprick still scans local workflow `run:` blocks and local actions.
+
+## Exit behavior
+
+| Code | Meaning          | Action behavior                                                |
+| ---- | ---------------- | -------------------------------------------------------------- |
+| `0`  | Clean            | Succeeds.                                                      |
+| `1`  | Findings present | Succeeds by default; fails only with `fail-on-findings: true`. |
+| `2+` | Error            | Fails.                                                         |
+
+In Advanced Security mode, SARIF upload happens before optional `fail-on-findings` failure so findings are still available in code scanning.
+
+## Runner support
+
+The action supports Linux x64, Linux ARM64, and macOS ARM64 runners. On Linux, it downloads the `gnu` release assets, so self-hosted Linux runners need a compatible glibc for the selected pinprick release. Use a direct CLI install on musl/Alpine runners.
+
+Windows and macOS x64 runners are not supported by the wrapper.

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -37,6 +37,12 @@ The `gnu` builds link against the system glibc. They are built on Ubuntu 24.04, 
 The musl binaries are statically linked, but pinprick makes HTTPS calls to the GitHub API and reads the host's trusted CA certificates at runtime. On Alpine, install them with `apk add ca-certificates`.
 :::
 
+## GitHub Action
+
+For CI audit runs without hand-rolling the install step, use [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). The action installs a pinned pinprick release, verifies the downloaded archive checksum, runs `pinprick audit`, and can upload SARIF to GitHub code scanning.
+
+See [GitHub Action](/getting-started/github-action/) for a SHA-pinned workflow example and input reference.
+
 ## Shell completions
 
 Generate completions for your shell:

--- a/site/src/content/docs/getting-started/introduction.md
+++ b/site/src/content/docs/getting-started/introduction.md
@@ -3,22 +3,25 @@ title: Introduction
 description: What pinprick does and why it exists.
 ---
 
-pinprick is a CLI tool for GitHub Actions supply chain security — **pin** (SHA pinning) + **prick** (a small, sharp probe finding tiny holes in your supply chain). It does three things:
+pinprick is a CLI tool for GitHub Actions supply chain security — **pin** (SHA pinning) + **prick** (a small, sharp probe finding tiny holes in your supply chain). It does four things:
 
-1. **Pin** — resolve action tag references (e.g., `actions/checkout@v4`) to full SHA-pinned references
+1. **Pin** — resolve action tag references (e.g., `actions/checkout@v7`) to full SHA-pinned references
 2. **Update** — check pinned actions for newer releases and update them
 3. **Audit** — fetch action source code and scan for unversioned runtime fetches that bypass pinning
+4. **Score** — compute a reproducible posture grade against a public, versioned rubric
 
 ## Why
 
 For static analysis of your workflow files — template injection, excessive permissions, credential leaks — use [zizmor](https://github.com/zizmorcore/zizmor). It's excellent.
 
-pinprick picks up where static analysis leaves off. SHA-pinning actions is table stakes, but even a pinned action can `curl` down `releases/latest` at runtime. pinprick pins your actions, keeps them updated, and audits their source code for unversioned runtime fetches in shell scripts, JavaScript, Python, and Dockerfiles.
+pinprick picks up where static analysis leaves off. SHA-pinning actions is table stakes, but even a pinned action can `curl` down `releases/latest` at runtime. pinprick pins your actions, keeps them updated, audits their source code for unversioned runtime fetches in shell scripts, JavaScript, Python, and Dockerfiles, and gives you a single score to track over time.
+
+For CI audit runs, the shipped [GitHub Action](/getting-started/github-action/) wraps `pinprick audit` and optional SARIF upload. Use the CLI directly for pinning, updates, and scoring.
 
 ## Exit codes
 
-| Code | Meaning                                                        |
-| ---- | -------------------------------------------------------------- |
-| 0    | Clean — no findings, no pending updates                        |
-| 1    | Findings present (audit) or updates available (update dry-run) |
-| 2    | Error                                                          |
+| Code | Meaning                                                                                   |
+| ---- | ----------------------------------------------------------------------------------------- |
+| 0    | Clean — no findings, no pending updates                                                   |
+| 1    | Findings present (audit), score deductions present, or updates available (update dry-run) |
+| 2    | Error                                                                                     |

--- a/site/src/content/docs/index.md
+++ b/site/src/content/docs/index.md
@@ -3,37 +3,139 @@ title: pinprick
 description: GitHub Actions supply chain security. Pin actions to SHAs, audit them for runtime fetch patterns that bypass pinning, and score a repository's overall posture.
 template: splash
 editUrl: false
+head:
+  - tag: title
+    content: 'pinprick: GitHub Actions supply chain security'
 hero:
-  title: GitHub Actions supply chain security
-  tagline: SHA-pin your actions. Audit their source for runtime fetches that bypass pinning. Score the result.
+  title: pinprick
+  tagline: Pin GitHub Actions to immutable SHAs, audit what they fetch at runtime, and keep the score visible in CI.
   image:
     html: |
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="220" height="220" fill="none" aria-hidden="true">
-        <circle cx="16" cy="8" r="5" fill="#dc2626"/>
-        <line x1="16" y1="13" x2="16" y2="30" stroke="#dc2626" stroke-width="2.5" stroke-linecap="round"/>
-        <line x1="16" y1="30" x2="14" y2="26" stroke="#dc2626" stroke-width="2" stroke-linecap="round"/>
-        <line x1="16" y1="30" x2="18" y2="26" stroke="#dc2626" stroke-width="2" stroke-linecap="round"/>
-      </svg>
+      <div class="pp-hero-visual" aria-hidden="true">
+        <div class="pp-score-chip">
+          <span>score</span>
+          <strong>A</strong>
+          <small>95 / 100</small>
+        </div>
+        <div class="pp-terminal pp-terminal--hero">
+          <div class="pp-terminal-bar">
+            <span></span>
+            <span></span>
+            <span></span>
+            <b>pinprick audit</b>
+          </div>
+          <pre><code>$ pinprick audit&#10;Scanning .github/workflows/ci.yml&#10;  actions/checkout@9c091bb audited (bundled)&#10;  actions/upload-artifact@043fb46 audited (bundled)&#10;Scanning .github/workflows/release.yml&#10;  rust-lang/crates-io-auth-action@c6f97d4 audited (bundled)&#10;&#10;No runtime fetch risks found.&#10;Audited 3 actions: 3 bundled.</code></pre>
+        </div>
+      </div>
   actions:
-    - text: Get started
-      link: /getting-started/introduction/
+    - text: Start hardening
+      link: /getting-started/installation/
       icon: right-arrow
       variant: primary
-    - text: View on GitHub
-      link: https://github.com/starhaven-io/pinprick
-      icon: external
+    - text: Audit rules
+      link: /reference/detections/
+      icon: document
       variant: minimal
 ---
 
-## What it does
+<div class="pp-home">
+  <section class="pp-install-strip" aria-label="Install pinprick">
+    <span class="pp-eyebrow">Install</span>
+    <code>brew install starhaven-io/tap/pinprick</code>
+    <a href="/getting-started/installation/">More options</a>
+  </section>
 
-- **[`pin`](/commands/pin/)** — resolve action tag references (`actions/checkout@v4`) to full SHA-pinned references, preserving the tag as a comment.
-- **[`update`](/commands/update/)** — check SHA-pinned actions for newer releases and update them.
-- **[`audit`](/commands/audit/)** — scan workflow `run:` blocks and action source code for runtime fetch patterns that bypass pinning (shell, PowerShell, JavaScript, Python, Docker).
-- **[`score`](/commands/score/)** — compute a single posture grade (0–100, A–F) against a [public, versioned rubric](https://github.com/starhaven-io/pinprick/blob/main/docs/scoring.md).
+  <section class="pp-workflow" aria-labelledby="workflow-title">
+    <div>
+      <p class="pp-eyebrow">Workflow</p>
+      <h2 id="workflow-title">Make action pinning measurable, not ceremonial.</h2>
+      <p>
+        pinprick covers the part of Actions supply chain security that gets blurry after the YAML looks clean:
+        mutable tags, runtime downloads, stale SHAs, and the drift between policy and reality.
+      </p>
+    </div>
+    <ol class="pp-steps" aria-label="pinprick workflow">
+      <li>
+        <span>01</span>
+        <strong>Pin</strong>
+        Resolve tags to full commit SHAs while preserving the human-readable tag comment.
+      </li>
+      <li>
+        <span>02</span>
+        <strong>Audit</strong>
+        Inspect workflow scripts and action source for fetches that escape SHA pinning.
+      </li>
+      <li>
+        <span>03</span>
+        <strong>Update</strong>
+        Move pinned actions forward when newer releases are ready to review.
+      </li>
+      <li>
+        <span>04</span>
+        <strong>Score</strong>
+        Turn the posture into a reproducible grade that can gate CI or trend over time.
+      </li>
+    </ol>
+  </section>
 
-## Why
+  <section class="pp-command-grid" aria-label="Command overview">
+    <a class="pp-command-card" href="/commands/pin/">
+      <span class="pp-command-name">pin</span>
+      <strong>Rewrite mutable action refs.</strong>
+      <code>actions/checkout@v7 -> @9c091bb21b7c... # v7.0.0</code>
+    </a>
+    <a class="pp-command-card" href="/commands/audit/">
+      <span class="pp-command-name">audit</span>
+      <strong>Find runtime fetches.</strong>
+      <code>curl .../latest/tool.tar.gz</code>
+    </a>
+    <a class="pp-command-card" href="/commands/update/">
+      <span class="pp-command-name">update</span>
+      <strong>Keep pinned actions fresh.</strong>
+      <code>pinprick update --write</code>
+    </a>
+    <a class="pp-command-card" href="/commands/score/">
+      <span class="pp-command-name">score</span>
+      <strong>Report a posture grade.</strong>
+      <code>Grade: A (95 / 100)</code>
+    </a>
+  </section>
 
-For static analysis of workflow files — template injection, excessive permissions, credential leaks — use [zizmor](https://github.com/zizmorcore/zizmor). It's excellent.
+  <section class="pp-split" aria-labelledby="runtime-title">
+    <div>
+      <p class="pp-eyebrow">Runtime audit</p>
+      <h2 id="runtime-title">Pinned action, unpinned payload? That still shows up.</h2>
+      <p>
+        SHA pinning fixes the action checkout. It does not prove the action avoids mutable downloads once the job
+        starts. pinprick follows the reachable source and flags shell, PowerShell, JavaScript, Python, and Docker
+        fetch patterns that reintroduce drift.
+      </p>
+      <a class="pp-text-link" href="/reference/detections/">Review every detection rule</a>
+    </div>
+    <div class="pp-report-card" aria-label="Example runtime findings">
+      <div class="pp-report-row pp-report-row--high">
+        <span>high</span>
+        <strong>pipe to shell</strong>
+        <code>curl -fsSL ... | sh</code>
+      </div>
+      <div class="pp-report-row pp-report-row--medium">
+        <span>medium</span>
+        <strong>unversioned URL</strong>
+        <code>wget https://example.com/tool</code>
+      </div>
+      <div class="pp-report-row pp-report-row--low">
+        <span>low</span>
+        <strong>unpinned install</strong>
+        <code>npm install package</code>
+      </div>
+    </div>
+  </section>
 
-pinprick picks up where static analysis leaves off. SHA-pinning is table stakes, but a pinned action can still `curl` down `releases/latest` at runtime. pinprick keeps your pins fresh, audits the source code reachable through them, and gives you a single number to track over time.
+  <section class="pp-ci-band" aria-label="CI outputs">
+    <div>
+      <span class="pp-eyebrow">CI ready</span>
+      <strong>Run the CLI locally, or drop starhaven-io/pinprick-action into CI for audit plus SARIF upload.</strong>
+    </div>
+    <a href="/getting-started/github-action/">Configure the action</a>
+  </section>
+</div>

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -1,130 +1,812 @@
-/* ==========================================================
-   pinprick — Starlight theme overrides
-   ----------------------------------------------------------
-   Dark-first. Light works as an alternate via prefers-color-scheme
-   (Starlight's ThemeProvider reads the OS preference and sets
-   data-theme on <html> before paint). No toggle UI — ThemeSelect
-   is overridden to an empty component.
+/* pinprick Starlight redesign */
 
-   Based on the starhaven-io design system, pinprick brand,
-   "amped" direction: deeper red accent, 2px header rule, accented
-   sidebar current item, filled HIGH severity badges, monospace
-   red wordmark.
-   ========================================================== */
-
-/* ----- Tokens — dark (default) ----------------------------- */
 :root,
 :root[data-theme='dark'] {
-  /* Accent — deeper crimson red */
-  --sl-color-accent-low: #2a0a0e;
-  --sl-color-accent: #dc2626;
-  --sl-color-accent-high: #fecaca;
-  /* Pull the wordmark and other "text-accent" chrome onto the pure
-     accent red rather than the default washed-out accent-high. */
+  --sl-color-accent-low: #3b1114;
+  --sl-color-accent: #ef4444;
+  --sl-color-accent-high: #ffd1d1;
   --sl-color-text-accent: var(--sl-color-accent);
 
-  /* Neutrals — near-black, true neutral (chroma 0) */
-  --sl-color-white: #ffffff;
-  --sl-color-gray-1: #eeeeee;
-  --sl-color-gray-2: #c2c2c2;
-  --sl-color-gray-3: #8b8b8b;
-  --sl-color-gray-4: #585858;
-  --sl-color-gray-5: #2e2e2e;
-  --sl-color-gray-6: #1a1a1a;
-  --sl-color-black: #0e0e0e;
+  --sl-color-white: #f7f7f5;
+  --sl-color-gray-1: #ece8e1;
+  --sl-color-gray-2: #c7c0b7;
+  --sl-color-gray-3: #978f86;
+  --sl-color-gray-4: #625b55;
+  --sl-color-gray-5: #2f2c2a;
+  --sl-color-gray-6: #1f1d1b;
+  --sl-color-black: #11100f;
 
-  /* Semantic aliases */
-  --pp-sev-medium: #f5a623;
+  --pp-bg-elevated: #171513;
+  --pp-bg-soft: #201d1a;
+  --pp-border: rgba(247, 247, 245, 0.13);
+  --pp-border-strong: rgba(247, 247, 245, 0.22);
+  --pp-shadow: 0 20px 50px rgba(0, 0, 0, 0.34);
+  --pp-red: #ef4444;
+  --pp-signal: #d8ff3f;
+  --pp-warning: #d7d33f;
+  --pp-green: #22c55e;
+  --pp-pill-high-bg: #dc2626;
+  --pp-pill-high-fg: #ffffff;
+  --pp-pill-medium-bg: #d7d33f;
+  --pp-pill-medium-fg: #15170c;
+  --pp-pill-low-bg: #22c55e;
+  --pp-pill-low-fg: #07130b;
+  --pp-muted: #a49b91;
+  --pp-code-bg: #121110;
+  --pp-code-fg: #f7f7f5;
+  --pp-code-muted: #c7c0b7;
+  --pp-inline-code-bg: color-mix(in srgb, var(--pp-code-bg) 82%, transparent);
+  --pp-inline-code-fg: var(--sl-color-white);
 }
 
-/* ----- Tokens — light (alternate) -------------------------- */
 :root[data-theme='light'] {
   --sl-color-accent-low: #fee2e2;
-  --sl-color-accent: #b91c1c;
-  --sl-color-accent-high: #450a0a;
+  --sl-color-accent: #c81e1e;
+  --sl-color-accent-high: #4c0b0b;
   --sl-color-text-accent: var(--sl-color-accent);
 
-  --sl-color-white: #121212;
-  --sl-color-gray-1: #383838;
-  --sl-color-gray-2: #585858;
-  --sl-color-gray-3: #8b8b8b;
-  --sl-color-gray-4: #c2c2c2;
-  --sl-color-gray-5: #eeeeee;
-  --sl-color-gray-6: #f8f8f8;
-  --sl-color-black: #ffffff;
+  --sl-color-white: #171412;
+  --sl-color-gray-1: #312b27;
+  --sl-color-gray-2: #5d554d;
+  --sl-color-gray-3: #82786d;
+  --sl-color-gray-4: #c9c0b6;
+  --sl-color-gray-5: #eee7de;
+  --sl-color-gray-6: #f8f3ec;
+  --sl-color-black: #fffdf9;
 
-  --pp-sev-medium: #bf5700;
+  --pp-bg-elevated: #ffffff;
+  --pp-bg-soft: #fbf4ec;
+  --pp-border: rgba(48, 38, 30, 0.15);
+  --pp-border-strong: rgba(48, 38, 30, 0.24);
+  --pp-shadow: 0 22px 60px rgba(75, 47, 24, 0.14);
+  --pp-red: #c81e1e;
+  --pp-signal: #647200;
+  --pp-warning: #747000;
+  --pp-green: #15803d;
+  --pp-pill-high-bg: #c81e1e;
+  --pp-pill-high-fg: #ffffff;
+  --pp-pill-medium-bg: #d7d33f;
+  --pp-pill-medium-fg: #15170c;
+  --pp-pill-low-bg: #22c55e;
+  --pp-pill-low-fg: #07130b;
+  --pp-muted: #71685f;
+  --pp-code-bg: #171412;
+  --pp-code-fg: #f7f7f5;
+  --pp-code-muted: #d8d0c6;
+  --pp-inline-code-bg: #f2e9e0;
+  --pp-inline-code-fg: #171412;
 }
 
-/* ----- Header: 2px accent rule ----------------------------- */
-/* Scoped to the outer <header> element. Starlight nests a second
-   <div class="header"> inside it for layout; an unscoped .header
-   selector would draw a second rule under the wordmark. */
+html {
+  background: var(--sl-color-black);
+}
+
+body {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--sl-color-accent-low) 22%, transparent), transparent 23rem),
+    linear-gradient(
+      135deg,
+      transparent 0 62%,
+      color-mix(in srgb, var(--sl-color-accent) 9%, transparent) 62% 63%,
+      transparent 63%
+    ),
+    radial-gradient(circle at 10% 0%, color-mix(in srgb, var(--sl-color-accent) 16%, transparent), transparent 28rem),
+    var(--sl-color-black);
+}
+
+::selection {
+  color: #ffffff;
+  background: color-mix(in srgb, var(--sl-color-accent) 72%, #000000);
+}
+
+/* Header and navigation */
 header.header {
-  border-bottom: 2px solid var(--sl-color-accent) !important;
+  border-bottom: 1px solid color-mix(in srgb, var(--sl-color-accent) 72%, var(--pp-border)) !important;
+  background: color-mix(in srgb, var(--sl-color-black) 88%, transparent);
+  box-shadow: 0 1px 0 var(--pp-border);
+  backdrop-filter: blur(18px);
 }
 
-/* ----- Wordmark: red, monospace, tight --------------------- */
 .site-title {
+  color: var(--sl-color-white);
   font-family: var(--sl-font-mono);
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-.site-title:hover {
-  opacity: 0.85;
+  font-weight: 800;
+  letter-spacing: 0;
 }
 
-/* ----- Sidebar current item: accent-soft + 2px left rule --- */
-/* Replace Starlight's default "inverted block" current-page treatment
-   (accent bg + invert text) with the amped treatment: accent-low bg,
-   accent text, 2px left accent border. */
+.site-title:hover {
+  color: var(--sl-color-accent);
+}
+
+.site-title img {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px var(--pp-border);
+}
+
+.header a,
+.sidebar-pane a {
+  text-underline-offset: 0.2em;
+}
+
+.sidebar-pane {
+  border-inline-end-color: var(--pp-border);
+  background: color-mix(in srgb, var(--sl-color-black) 93%, transparent);
+}
+
+.sidebar-pane summary,
+.sidebar-pane a {
+  border-radius: 6px;
+}
+
 .sidebar-pane a[aria-current='page'],
 .sidebar-pane a[aria-current='page']:hover,
 .sidebar-pane a[aria-current='page']:focus {
-  color: var(--sl-color-accent);
-  background-color: var(--sl-color-accent-low);
-  border-inline-start: 2px solid var(--sl-color-accent);
-  border-radius: 0;
+  color: var(--sl-color-white);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--sl-color-accent) 20%, transparent), transparent),
+    color-mix(in srgb, var(--sl-color-accent-low) 80%, transparent);
+  border-inline-start: 3px solid var(--sl-color-accent);
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
 }
 
-/* ----- Version badge (rendered in SocialIcons.astro) ------- */
-.version-badge {
-  font-size: 0.75rem;
-  font-family: var(--sl-font-mono);
-  color: var(--sl-color-gray-3);
-  text-decoration: none;
-  padding: 0.2rem 0.5rem;
-  border: 1px solid var(--sl-color-gray-5);
-  border-radius: 0.25rem;
-  margin-right: 0.5rem;
-  transition:
-    color 0.2s,
-    border-color 0.2s;
+.right-sidebar {
+  border-inline-start-color: var(--pp-border);
 }
+
+.right-sidebar a[aria-current='true'] {
+  color: var(--sl-color-accent);
+}
+
+/* Header version badge */
+.version-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.85rem;
+  margin-right: 0.5rem;
+  padding: 0.2rem 0.55rem;
+  color: var(--sl-color-gray-2);
+  font-family: var(--sl-font-mono);
+  font-size: 0.75rem;
+  line-height: 1;
+  text-decoration: none;
+  border: 1px solid var(--pp-border-strong);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--pp-bg-elevated) 84%, transparent);
+}
+
 .version-badge:hover {
   color: var(--sl-color-white);
-  border-color: var(--sl-color-gray-3);
+  border-color: color-mix(in srgb, var(--sl-color-accent) 58%, var(--pp-border));
 }
 
-/* ----- Severity pills (e.g. in Markdown tables via HTML) --- */
-.sev {
-  display: inline-block;
-  padding: 0.15em 0.55em;
+/* Splash hero */
+.hero {
+  align-items: center;
+  gap: 2.5rem;
+  padding-block: 3.5rem 2rem;
+}
+
+.hero h1 {
+  color: var(--sl-color-white);
+  font-family: var(--sl-font-mono);
+  letter-spacing: 0;
+}
+
+.hero .tagline {
+  max-width: 44rem;
+  color: var(--sl-color-gray-2);
+  font-size: 1.18rem;
+  line-height: 1.65;
+}
+
+.hero .actions {
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.hero .actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 4rem;
+  gap: 0.7rem;
+  padding: 0 1.45rem;
+  border-radius: 8px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.hero .actions a:first-child {
+  min-width: 14.5rem;
+}
+
+.hero .actions a svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex: 0 0 auto;
+}
+
+.hero .actions a:not([data-variant='minimal']) {
+  box-shadow: 0 14px 32px color-mix(in srgb, var(--sl-color-accent) 23%, transparent);
+}
+
+.hero .actions a[data-variant='minimal'] {
+  color: var(--sl-color-white);
+  border: 1px solid var(--pp-border-strong);
+  background: color-mix(in srgb, var(--pp-bg-elevated) 72%, transparent);
+}
+
+.hero-html {
+  width: min(34rem, calc(100vw - 2rem));
+}
+
+.pp-hero-visual {
+  width: 100%;
+  min-height: 24rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.pp-terminal {
+  overflow: hidden;
+  color: #f7f7f5;
+  border: 1px solid var(--pp-border-strong);
+  border-radius: 8px;
+  background: var(--pp-code-bg);
+  box-shadow: var(--pp-shadow);
+}
+
+.pp-terminal--hero {
+  order: 1;
+  width: 100%;
+}
+
+.pp-terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.35rem;
+  padding-inline: 0.85rem;
+  color: #a9a29a;
+  font-family: var(--sl-font-mono);
+  font-size: 0.78rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  background: #1d1a18;
+}
+
+.pp-terminal-bar span {
+  width: 0.64rem;
+  height: 0.64rem;
   border-radius: 999px;
-  font-size: 0.7rem;
+  background: var(--pp-red);
+}
+
+.pp-terminal-bar span:nth-child(2) {
+  background: var(--pp-signal);
+}
+
+.pp-terminal-bar span:nth-child(3) {
+  background: var(--pp-green);
+}
+
+.pp-terminal-bar b {
+  margin-left: auto;
   font-weight: 600;
-  letter-spacing: 0.03em;
+}
+
+.pp-terminal pre {
+  margin: 0;
+  padding: 1.15rem;
+  overflow-x: auto;
+  font-size: 0.82rem;
+  line-height: 1.65;
+  white-space: pre;
+}
+
+.pp-terminal code {
+  color: inherit;
+  background: transparent;
+}
+
+.pp-score-chip {
+  position: relative;
+  order: 2;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 0.15rem 0.6rem;
+  align-items: center;
+  align-self: flex-end;
+  min-width: 9.5rem;
+  margin-top: 0.75rem;
+  margin-right: 0.8rem;
+  padding: 0.8rem 0.9rem;
+  color: #f7f7f5;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: color-mix(in srgb, #171412 88%, var(--pp-green));
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.34);
+}
+
+.pp-score-chip span,
+.pp-score-chip small {
+  color: #b9d9c4;
+  font-family: var(--sl-font-mono);
+  font-size: 0.72rem;
   text-transform: uppercase;
 }
-.sev-high {
-  background: var(--sl-color-accent);
-  color: #fff;
+
+.pp-score-chip strong {
+  grid-row: span 2;
+  color: var(--pp-green);
+  font-size: 2.3rem;
+  line-height: 1;
 }
-.sev-medium {
-  background: color-mix(in srgb, var(--pp-sev-medium) 25%, transparent);
-  color: var(--pp-sev-medium);
+
+/* Homepage */
+.pp-home {
+  display: grid;
+  gap: 2rem;
+  margin-top: 1.75rem;
 }
-.sev-low {
-  background: color-mix(in srgb, var(--sl-color-gray-3) 20%, transparent);
+
+.pp-install-strip,
+.pp-workflow,
+.pp-split,
+.pp-ci-band {
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--pp-bg-elevated) 82%, transparent);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--sl-color-white) 4%, transparent);
+}
+
+.pp-install-strip {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.8rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.25rem;
+}
+
+.pp-install-strip code {
+  min-width: 0;
+  min-height: 2.25rem;
+  padding: 0.42rem 0.6rem;
+  overflow-wrap: anywhere;
+  color: var(--pp-code-fg);
+  line-height: 1.25;
+  background: var(--pp-code-bg);
+  border: 1px solid var(--pp-border);
+  border-radius: 6px;
+}
+
+.pp-install-strip .pp-eyebrow {
+  margin: 0;
+}
+
+.pp-install-strip a {
+  align-self: center;
+  line-height: 1.15;
+}
+
+.pp-install-strip a,
+.pp-ci-band a,
+.pp-text-link {
+  color: var(--sl-color-accent);
+  font-weight: 700;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.22em;
+}
+
+.pp-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 0 0.65rem;
+  color: var(--pp-signal);
+  font-family: var(--sl-font-mono);
+  font-size: 0.77rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pp-workflow {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(18rem, 1.1fr);
+  gap: 2rem;
+  padding: 1.5rem;
+}
+
+.pp-workflow h2,
+.pp-split h2 {
+  margin: 0;
+  color: var(--sl-color-white);
+  font-size: 1.8rem;
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.pp-workflow p,
+.pp-split p {
   color: var(--sl-color-gray-2);
+  line-height: 1.72;
+}
+
+.pp-steps {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pp-steps li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.15rem 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--pp-bg-soft) 86%, transparent);
+}
+
+.pp-steps span {
+  grid-row: span 2;
+  color: var(--pp-signal);
+  font-family: var(--sl-font-mono);
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.pp-steps strong {
+  color: var(--sl-color-white);
+}
+
+.pp-command-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
+.pp-command-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  min-height: 12.5rem;
+  padding: 1rem;
+  color: var(--sl-color-gray-2);
+  text-decoration: none;
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--pp-bg-elevated) 96%, transparent), var(--pp-bg-soft)),
+    var(--pp-bg-elevated);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--sl-color-white) 4%, transparent);
+}
+
+.pp-command-card:hover,
+.pp-command-card:focus-visible {
+  color: var(--sl-color-white);
+  border-color: color-mix(in srgb, var(--sl-color-accent) 48%, var(--pp-border));
+  transform: translateY(-2px);
+}
+
+.pp-command-card strong {
+  display: flex;
+  align-items: flex-end;
+  min-height: 3rem;
+  color: var(--sl-color-white);
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.pp-command-card code {
+  display: flex;
+  align-items: center;
+  min-height: 4.1rem;
+  margin-top: auto;
+  padding: 0.55rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  color: var(--pp-code-fg);
+  border: 1px solid var(--pp-border);
+  border-radius: 6px;
+  background: var(--pp-code-bg);
+}
+
+.pp-command-name {
+  width: fit-content;
+  padding: 0.18rem 0.46rem;
+  color: #ffffff;
+  font-family: var(--sl-font-mono);
+  font-size: 0.82rem;
+  font-weight: 800;
+  border-radius: 999px;
+  background: var(--sl-color-accent);
+}
+
+.pp-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(20rem, 0.9fr);
+  gap: 2rem;
+  align-items: center;
+  padding: 1.5rem;
+}
+
+.pp-report-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.pp-report-row {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 0.35rem 0.75rem;
+  align-items: center;
+  padding: 0.85rem;
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+  background: var(--pp-bg-soft);
+}
+
+.pp-report-row span {
+  grid-row: span 2;
+  width: fit-content;
+  padding: 0.18rem 0.45rem;
+  color: #ffffff;
+  font-family: var(--sl-font-mono);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  border-radius: 999px;
+}
+
+.pp-report-row--high span {
+  color: var(--pp-pill-high-fg);
+  background: var(--pp-pill-high-bg);
+}
+
+.pp-report-row--medium span {
+  color: var(--pp-pill-medium-fg);
+  background: var(--pp-pill-medium-bg);
+}
+
+.pp-report-row--low span {
+  color: var(--pp-pill-low-fg);
+  background: var(--pp-pill-low-bg);
+}
+
+.pp-report-row strong {
+  color: var(--sl-color-white);
+}
+
+.pp-report-row code {
+  display: block;
+  padding: 0.35rem 0.45rem;
+  overflow-wrap: anywhere;
+  color: var(--pp-code-muted);
+  border: 1px solid var(--pp-border);
+  border-radius: 6px;
+  background: var(--pp-code-bg);
+}
+
+.pp-ci-band {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.15rem 1.25rem;
+}
+
+.pp-ci-band strong {
+  display: block;
+  max-width: 52rem;
+  color: var(--sl-color-white);
+  font-size: 1.08rem;
+}
+
+.pp-not-found-mark {
+  display: grid;
+  place-items: center;
+  width: 12rem;
+  aspect-ratio: 1;
+  color: var(--sl-color-white);
+  border: 1px solid var(--pp-border-strong);
+  border-radius: 8px;
+  background: var(--pp-bg-elevated);
+  box-shadow: var(--pp-shadow);
+}
+
+.pp-not-found-mark span {
+  color: var(--sl-color-accent);
+  font-family: var(--sl-font-mono);
+  font-size: 3.3rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.pp-not-found-mark code {
+  color: var(--sl-color-gray-2);
+  background: transparent;
+}
+
+/* Docs content */
+.sl-markdown-content {
+  line-height: 1.72;
+}
+
+.sl-markdown-content h2 {
+  margin-top: 2.6rem;
+  padding-top: 1.2rem;
+  color: var(--sl-color-white);
+  border-top: 1px solid var(--pp-border);
+}
+
+.sl-markdown-content h3 {
+  color: var(--sl-color-white);
+}
+
+.sl-markdown-content a:not(.sl-card):not(.pp-command-card) {
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.22em;
+}
+
+.sl-markdown-content :not(pre) > code {
+  padding: 0.1rem 0.28rem;
+  color: var(--pp-inline-code-fg);
+  border: 1px solid var(--pp-border);
+  border-radius: 5px;
+  background: var(--pp-inline-code-bg);
+}
+
+.sl-markdown-content .pp-install-strip code {
+  min-height: 2.25rem;
+  padding: 0.42rem 0.6rem;
+  color: var(--pp-code-fg);
+  line-height: 1.25;
+  background: var(--pp-code-bg);
+}
+
+.sl-markdown-content .pp-command-card code {
+  display: flex;
+  align-items: center;
+  min-height: 4.1rem;
+  margin-top: auto;
+  padding: 0.55rem;
+  color: var(--pp-code-fg);
+  line-height: 1.35;
+  white-space: normal;
+  background: var(--pp-code-bg);
+}
+
+.sl-markdown-content .pp-report-row code {
+  display: block;
+  padding: 0.35rem 0.45rem;
+  color: var(--pp-code-muted);
+  line-height: 1.25;
+  background: var(--pp-code-bg);
+}
+
+.sl-markdown-content pre {
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--sl-color-white) 4%, transparent);
+}
+
+.sl-markdown-content table {
+  overflow: hidden;
+  border: 1px solid var(--pp-border);
+  border-radius: 8px;
+}
+
+.sl-markdown-content th {
+  color: var(--sl-color-white);
+  background: color-mix(in srgb, var(--pp-bg-soft) 88%, transparent);
+}
+
+.sl-markdown-content tr:nth-child(even) td {
+  background: color-mix(in srgb, var(--pp-bg-soft) 34%, transparent);
+}
+
+.sl-markdown-content blockquote {
+  color: var(--sl-color-gray-2);
+  border-inline-start-color: var(--sl-color-accent);
+  background: color-mix(in srgb, var(--sl-color-accent-low) 35%, transparent);
+}
+
+.sl-markdown-content .sl-link-card,
+.sl-markdown-content .card {
+  border-radius: 8px;
+}
+
+@media (max-width: 72rem) {
+  .pp-command-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 50rem) {
+  body {
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--sl-color-accent-low) 20%, transparent), transparent 18rem),
+      var(--sl-color-black);
+  }
+
+  .hero {
+    gap: 1.5rem;
+    padding-block: 2rem 1rem;
+  }
+
+  .hero .tagline {
+    font-size: 1rem;
+    line-height: 1.58;
+  }
+
+  .hero .actions {
+    flex-wrap: wrap;
+  }
+
+  .hero .actions a {
+    min-height: 3.4rem;
+    padding-inline: 1rem;
+  }
+
+  .hero .actions a:first-child {
+    min-width: 11.5rem;
+  }
+
+  .pp-hero-visual {
+    min-height: 18rem;
+  }
+
+  .pp-terminal pre {
+    padding: 0.9rem;
+    font-size: 0.74rem;
+  }
+
+  .pp-score-chip {
+    margin-top: 0.75rem;
+    margin-right: 0.4rem;
+    justify-self: end;
+  }
+
+  .pp-hero-visual {
+    display: grid;
+  }
+
+  .pp-workflow,
+  .pp-split {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    padding: 1rem;
+  }
+
+  .pp-install-strip {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .pp-command-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pp-command-card {
+    min-height: 10.5rem;
+  }
+
+  .pp-report-row {
+    grid-template-columns: 1fr;
+  }
+
+  .pp-report-row span {
+    grid-row: auto;
+  }
 }


### PR DESCRIPTION
Redesigns the docs site homepage into a custom dark, red-accented product page (hero terminal, score chip, install strip, workflow steps, command cards, runtime-audit section, CI/action CTA), adds a new logo and favicon, and overhauls light-mode theming.

Adds a GitHub Action page documenting `starhaven-io/pinprick-action` (usage with and without Advanced Security, inputs/outputs, permissions, exit behavior, runner support), linked from the homepage, installation, audit, introduction, and README.

Content accuracy pass: documents `score` as the fourth command, the `trusted-owners` config, and the broadened audit detection list, and refreshes the command examples to current action versions.
