### PR TITLE
chore: release 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the crate to 0.18.0. Headline changes since 0.17.0: symlink TOCTOU hardening in the workflow rewriter with no-follow fd-relative I/O (#299, #301) and broadened runtime-fetch audit detection with sanitized pin/update output (#300). Also includes the docs site redesign documenting the GitHub Action (#304), plus dependency and CI maintenance.
