### PR TITLE
feat(workflow): discover Forgejo and Gitea workflow roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ pinprick/
 
 ### Commands
 
-- `pinprick pin [PATH] [--write]` — Scan `.github/workflows/*.yml`, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
+- `pinprick pin [PATH] [--write]` — Scan workflow files, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
 - `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
 - `pinprick audit [PATH] [--verbose] [--sarif]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans local `run:` blocks and local actions referenced with `uses: ./...`. With a token, also fetches and scans remote action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning.
 - `pinprick score [PATH] [--html]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md` (rubric v0.7.0). The offline rules (`pin.*`, `workflow.*`, `source.unverified`, `runtime.*`) need no token; with a token it additionally emits the token-gated `source.archived` and `source.advisory` rules. `runtime.*` rules reuse the `audit` shell pipeline against each workflow's `run:` blocks, distinguishing pipe-to-shell (-20) from severity-graded fetches (-15/-8/-3). `source.unverified` is an informational zero-point note — publisher outside the trusted baseline (`actions`, `github`) and the `trusted-owners` list in `.pinprick.toml`; it never affects the score or the gate. Exits 1 when any finding deducts points — zero-point informational notes never gate (matches `audit` for CI gating); outputs JSON with `--json` or a self-contained HTML report with `--html` (mutually exclusive with `--json`).
@@ -62,6 +62,12 @@ pinprick/
 ### YAML handling
 
 **Critical design decision:** workflow files are never round-tripped through a YAML parser for writing. `uses:` lines have a rigid single-line format — regex capture groups replace the ref while preserving leading whitespace, indentation, and surrounding comments. `serde_norway` is only used for read-only extraction of `run:` block contents during audit.
+
+### Workflow discovery
+
+`workflow::find_workflows` scans every forge root in `DEFAULT_FORGE_ROOTS` (`.github`, `.forgejo`, `.gitea`) for a `workflows/` subdirectory. Forgejo and Gitea use GitHub-compatible workflow syntax. Discovery is **purely additive**: each root that exists is scanned and the files are unioned, so extra roots only widen coverage. The list is a compile-time constant and is deliberately *not* configurable via `.pinprick.toml`: a scanned repo (which may be hostile, hence `--no-repo-config`) must never be able to redirect the scan to a decoy directory while real workflows hide in `.github/workflows`. Every root goes through the same symlink-refusing `open_child_dir` path, so a symlinked forge root is refused, never followed. GitLab is out of scope: `.gitlab-ci.yml` is a single file with a different schema and no `uses:` references.
+
+**Support tiers.** GitHub Actions is the first-class, fully supported target. Forgejo/Gitea support is incidental to GHA compatibility and best-effort: don't intentionally break it, but don't constrain a GitHub Actions improvement to preserve forge behavior either. When the two conflict, GHA wins. (Example: tag/release resolution is hardcoded to the github.com API, so `pin`/`update` only resolve github.com-hosted actions; that's an accepted limitation, not a bug to fix at GHA's expense.)
 
 ### GitHub auth
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The action wraps `pinprick audit` only. Use the CLI directly for `pin`, `update`
 
 All commands default to the current directory. Pass a path to target a different repository root. Use `--json` for machine-readable output.
 
+> **Forge support.** GitHub Actions is pinprick's first-class, fully supported target. Forgejo and Gitea run GitHub-compatible Actions, so workflows under `.forgejo/workflows/` and `.gitea/workflows/` are discovered and scanned alongside `.github/workflows/` (whichever exist are all scanned). That support is incidental to GHA compatibility and best-effort: we won't intentionally break it, but we also won't hold back a GitHub Actions improvement to preserve forge behavior. When the two conflict, GHA wins. Concretely today, `pin` and `update` resolve through the github.com API, so they handle github.com-hosted actions (the common case) but not actions hosted on a Forgejo or Gitea instance; `audit` and `score` need no network for their local rules.
+
 ```bash
 # Pin action tags to full SHAs
 pinprick pin

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -5,6 +5,8 @@ description: Scan actions for runtime fetch patterns that bypass pinning.
 
 Scan workflow `run:` blocks and action source code for runtime fetch patterns that bypass SHA pinning.
 
+Workflows are discovered under `.github/workflows/`, `.forgejo/workflows/`, and `.gitea/workflows/` (whichever exist are all scanned). Forgejo and Gitea use GitHub-compatible workflow syntax.
+
 ```bash
 pinprick audit
 pinprick audit /path/to/repo

--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -3,7 +3,9 @@ title: pin
 description: Resolve action tag references to full SHAs.
 ---
 
-Scan `.github/workflows/*.yml` files and resolve action tag references to full SHA-pinned references.
+Scan workflow files and resolve action tag references to full SHA-pinned references.
+
+Workflows are discovered under `.github/workflows/`, `.forgejo/workflows/`, and `.gitea/workflows/`; whichever exist are all scanned. Forgejo and Gitea use GitHub-compatible workflow syntax, so the same pinning applies. The set of forge roots is fixed and cannot be changed by a repository's `.pinprick.toml`, so a scanned repo can never redirect the scan away from `.github`. Tag resolution goes through the github.com API, so refs to actions hosted on a Forgejo or Gitea instance cannot be resolved; only github.com-hosted actions (the common case) are pinned.
 
 ```bash
 pinprick pin                # dry-run (show what would be pinned)

--- a/site/src/content/docs/commands/score.md
+++ b/site/src/content/docs/commands/score.md
@@ -5,6 +5,8 @@ description: Compute a posture grade for a repository's Actions supply chain.
 
 Compute a single posture score (0–100, letter grade A–F) for a repository's GitHub Actions configuration. Implements the public [scoring rubric](https://github.com/starhaven-io/pinprick/blob/main/docs/scoring.md) — every point deducted maps to a named rule, so the grade can be re-derived by hand from the finding list.
 
+Workflows are discovered under `.github/workflows/`, `.forgejo/workflows/`, and `.gitea/workflows/` (whichever exist are all scanned). Forgejo and Gitea use GitHub-compatible workflow syntax.
+
 ```bash
 pinprick score
 pinprick score /path/to/repo

--- a/site/src/content/docs/commands/update.md
+++ b/site/src/content/docs/commands/update.md
@@ -5,6 +5,8 @@ description: Check pinned actions for newer releases.
 
 Check SHA-pinned actions for newer releases and optionally update them.
 
+Workflows are discovered under `.github/workflows/`, `.forgejo/workflows/`, and `.gitea/workflows/` (whichever exist are all scanned). Forgejo and Gitea use GitHub-compatible workflow syntax. Release checks go through the github.com API, so actions hosted on a Forgejo or Gitea instance cannot be checked; only github.com-hosted actions (the common case).
+
 ```bash
 pinprick update                       # dry-run (show available updates)
 pinprick update --write               # write updates to files

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -324,58 +324,96 @@ pub fn read_workflow(file: &WorkflowFile) -> Result<String> {
     Ok(content)
 }
 
-/// Find all workflow files in a repository.
+/// Forge roots scanned for a `workflows/` subdirectory. GitHub (`.github`),
+/// Forgejo (`.forgejo`), and Gitea (`.gitea`) all use byte-compatible workflow
+/// syntax, so the same `uses:`/`run:` scanning applies to each.
+///
+/// This list is a compile-time constant on purpose: the scanned repository's
+/// `.pinprick.toml` cannot influence it. Discovery is purely additive: every
+/// root that exists is scanned and the results are unioned, so a hostile repo
+/// can never redirect the scan to a decoy directory while real workflows hide
+/// in another. Extra roots can only widen coverage, never narrow it.
+///
+/// GitHub Actions is the first-class target; Forgejo/Gitea support is
+/// incidental to GHA compatibility and best-effort.
+pub const DEFAULT_FORGE_ROOTS: &[&str] = &[".github", ".forgejo", ".gitea"];
+
+/// Find all workflow files in a repository, scanning every default forge root.
 pub fn find_workflows(repo_root: &Path) -> Result<Vec<WorkflowFile>> {
-    let workflows = open_workflows_dir(repo_root)?;
+    find_workflows_in(repo_root, DEFAULT_FORGE_ROOTS)
+}
+
+/// Find all workflow files under the given forge roots (e.g. `.github`,
+/// `.forgejo`). Each `<root>/workflows/` directory that exists is scanned and
+/// the files are merged and sorted. It is an error for *none* of the roots to
+/// contain a `workflows/` directory.
+fn find_workflows_in(repo_root: &Path, forge_roots: &[&str]) -> Result<Vec<WorkflowFile>> {
+    let dirs = open_workflows_dirs(repo_root, forge_roots)?;
 
     let mut files = Vec::new();
-    let entries = Dir::read_from(&*workflows.fd)
-        .with_context(|| format!("reading {}", workflows.path.display()))?;
-    for entry in entries {
-        let entry = entry.with_context(|| format!("reading {}", workflows.path.display()))?;
-        let name = entry.file_name().to_bytes();
-        if name == b"." || name == b".." {
-            continue;
-        }
-        let name = std::ffi::OsStr::from_bytes(name).to_os_string();
-        let file = workflows.file(name);
-        if !is_workflow_file(file.path()) {
-            continue;
-        }
+    for workflows in &dirs {
+        let entries = Dir::read_from(&*workflows.fd)
+            .with_context(|| format!("reading {}", workflows.path.display()))?;
+        for entry in entries {
+            let entry = entry.with_context(|| format!("reading {}", workflows.path.display()))?;
+            let name = entry.file_name().to_bytes();
+            if name == b"." || name == b".." {
+                continue;
+            }
+            let name = std::ffi::OsStr::from_bytes(name).to_os_string();
+            let file = workflows.file(name);
+            if !is_workflow_file(file.path()) {
+                continue;
+            }
 
-        let file_type = workflow_entry_type(&workflows, &file)?;
-        if file_type.is_symlink() {
-            return Err(UnsafeWorkflowPath::symlinked_workflow_file(file.path()).into());
-        }
-        if file_type.is_file() {
-            files.push(file);
+            let file_type = workflow_entry_type(workflows, &file)?;
+            if file_type.is_symlink() {
+                return Err(UnsafeWorkflowPath::symlinked_workflow_file(file.path()).into());
+            }
+            if file_type.is_file() {
+                files.push(file);
+            }
         }
     }
     files.sort_by(|a, b| a.path.cmp(&b.path));
     Ok(files)
 }
 
-fn open_workflows_dir(repo_root: &Path) -> Result<WorkflowDirectory> {
+/// Open the `workflows/` directory under each existing forge root. Roots that
+/// are absent are silently skipped; a root present but symlinked is refused
+/// loudly (it is never followed). Bails if no root yields a `workflows/`
+/// directory.
+fn open_workflows_dirs(repo_root: &Path, forge_roots: &[&str]) -> Result<Vec<WorkflowDirectory>> {
     let root = open_repo_root(repo_root)?;
-    let github_path = repo_root.join(".github");
-    let Some(github) = open_child_dir(&root, ".github", &github_path)? else {
-        anyhow::bail!(
-            "No .github/workflows/ directory found in {}",
-            repo_root.display()
-        );
-    };
-    let workflows_path = github_path.join("workflows");
-    let Some(workflows) = open_child_dir(&github, "workflows", &workflows_path)? else {
-        anyhow::bail!(
-            "No .github/workflows/ directory found in {}",
-            repo_root.display()
-        );
-    };
+    let mut dirs = Vec::new();
+    for forge in forge_roots {
+        let forge_path = repo_root.join(forge);
+        let Some(forge_dir) = open_child_dir(&root, forge, &forge_path)? else {
+            continue;
+        };
+        let workflows_path = forge_path.join("workflows");
+        let Some(workflows) = open_child_dir(&forge_dir, "workflows", &workflows_path)? else {
+            continue;
+        };
+        dirs.push(WorkflowDirectory {
+            path: workflows_path,
+            fd: Arc::new(workflows),
+        });
+    }
 
-    Ok(WorkflowDirectory {
-        path: workflows_path,
-        fd: Arc::new(workflows),
-    })
+    if dirs.is_empty() {
+        let looked_for = forge_roots
+            .iter()
+            .map(|r| format!("{r}/workflows/"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "No workflow directory found in {} (looked for {looked_for})",
+            repo_root.display()
+        );
+    }
+
+    Ok(dirs)
 }
 
 fn open_repo_root(repo_root: &Path) -> Result<File> {
@@ -1024,7 +1062,7 @@ jobs:
 
     #[cfg(unix)]
     #[test]
-    fn open_workflows_dir_rejects_symlinked_workflows_directory() {
+    fn open_workflows_dirs_rejects_symlinked_workflows_directory() {
         let dir = tempfile::TempDir::new().unwrap();
         let github = dir.path().join(".github");
         let outside = dir.path().join("outside-workflows");
@@ -1032,7 +1070,70 @@ jobs:
         std::fs::create_dir_all(&outside).unwrap();
         std::os::unix::fs::symlink(&outside, github.join("workflows")).unwrap();
 
-        let err = open_workflows_dir(dir.path()).unwrap_err();
+        let err = open_workflows_dirs(dir.path(), DEFAULT_FORGE_ROOTS).unwrap_err();
+        assert!(err.to_string().contains("symlinked directory"));
+    }
+
+    #[test]
+    fn find_workflows_scans_forgejo_root() {
+        // A Forgejo/Gitea repo with no `.github` at all is still scanned.
+        let dir = tempfile::TempDir::new().unwrap();
+        let workflows = dir.path().join(".forgejo").join("workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("ci.yml"), "").unwrap();
+
+        let files = find_workflows(dir.path()).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .map(|p| display_path(p.path(), dir.path()))
+            .collect();
+        assert_eq!(names, vec![".forgejo/workflows/ci.yml"]);
+    }
+
+    #[test]
+    fn find_workflows_unions_multiple_forge_roots() {
+        // A repo mirrored across forges keeps workflows in several roots; every
+        // existing root is scanned and the results merged (additive discovery).
+        let dir = tempfile::TempDir::new().unwrap();
+        for (root, name) in [(".github", "gh.yml"), (".gitea", "gitea.yml")] {
+            let workflows = dir.path().join(root).join("workflows");
+            std::fs::create_dir_all(&workflows).unwrap();
+            std::fs::write(workflows.join(name), "").unwrap();
+        }
+
+        let files = find_workflows(dir.path()).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .map(|p| display_path(p.path(), dir.path()))
+            .collect();
+        assert_eq!(
+            names,
+            vec![".gitea/workflows/gitea.yml", ".github/workflows/gh.yml"]
+        );
+    }
+
+    #[test]
+    fn find_workflows_error_lists_all_forge_roots() {
+        // With no workflow directory anywhere, the error names every root tried
+        // so the user knows a Forgejo/Gitea layout is also supported.
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = find_workflows(dir.path()).unwrap_err().to_string();
+        assert!(err.contains(".github/workflows/"));
+        assert!(err.contains(".forgejo/workflows/"));
+        assert!(err.contains(".gitea/workflows/"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_workflows_rejects_symlinked_forgejo_directory() {
+        // The v0.18.0 symlink hardening applies to every forge root, not just
+        // `.github`: a symlinked `.forgejo` is refused, never followed.
+        let dir = tempfile::TempDir::new().unwrap();
+        let outside = dir.path().join("outside-forgejo");
+        std::fs::create_dir_all(outside.join("workflows")).unwrap();
+        std::os::unix::fs::symlink(&outside, dir.path().join(".forgejo")).unwrap();
+
+        let err = find_workflows(dir.path()).unwrap_err();
         assert!(err.to_string().contains("symlinked directory"));
     }
 

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -351,9 +351,7 @@ fn missing_workflows_dir_exits_two() {
         .arg(dir.path())
         .assert()
         .code(2)
-        .stderr(predicate::str::contains(
-            "No .github/workflows/ directory found",
-        ));
+        .stderr(predicate::str::contains("No workflow directory found"));
 }
 
 #[test]
@@ -372,7 +370,7 @@ fn missing_workflows_dir_json() {
         json["error"]
             .as_str()
             .unwrap()
-            .contains("No .github/workflows/ directory found")
+            .contains("No workflow directory found")
     );
 }
 

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -143,7 +143,7 @@ fn no_workflows_directory_errors() {
         .arg(dir.path())
         .assert()
         .code(2)
-        .stderr(predicate::str::contains("No .github/workflows/"));
+        .stderr(predicate::str::contains("No workflow directory found"));
 }
 
 #[test]


### PR DESCRIPTION
Resolves #308. pinprick discovered workflows only under `.github/workflows/`, so Forgejo and Gitea repos could not be scanned, and the v0.18.0 symlink hardening broke the prior symlink workaround.

`find_workflows` now scans `.github/workflows/`, `.forgejo/workflows/`, and `.gitea/workflows/`; whichever exist are all scanned and the results unioned. Forgejo and Gitea use GitHub-compatible workflow syntax, so the existing `uses:`/`run:` analysis applies unchanged.

The forge-root set is a compile-time constant rather than a `.pinprick.toml` key, so a scanned repo (which may be hostile, hence `--no-repo-config`) cannot redirect the scan to a decoy directory while real workflows hide in `.github/workflows`. Discovery is purely additive, and every root keeps the symlink-refusing open path.

GitHub Actions remains the first-class, fully supported target; Forgejo/Gitea support is incidental to GHA compatibility and best-effort. `pin`/`update` resolve through the github.com API, so they only handle github.com-hosted actions, while `audit`/`score` need no network for their local rules. GitLab is out of scope. Docs (README, AGENTS.md, command pages) state the support tier.