### PR TITLE
chore: release 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 rust-version = "1.87.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Release 0.19.0. Bumps `version` in `Cargo.toml` and `Cargo.lock`.

Since v0.18.0:

- feat: discover Forgejo and Gitea workflow roots (#310)
- fix: bind runtime-fetch suppressions to the artifact they vouch for (#309)
- chore: bump bytes from 1.11.1 to 1.12.0 (#307)