### PR TITLE
feat(audit): scan run blocks nested in parallel steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ pinprick/
 
 **Critical design decision:** workflow files are never round-tripped through a YAML parser for writing. `uses:` lines have a rigid single-line format — regex capture groups replace the ref while preserving leading whitespace, indentation, and surrounding comments. `serde_norway` is only used for read-only extraction of `run:` block contents during audit.
 
+That read-only `run:` extraction (`extract_run_blocks` for workflows and `scan_action_yml_runs` for composite actions) recurses into `parallel:` step groups. GitHub's parallel-steps feature models a `parallel:` step as a sequence of nested steps, so `run:` blocks inside a parallel group (including `parallel:` nested in `parallel:`) are scanned by both `audit` and `score`. A `background:`/`wait:`/`cancel:` step carries no nested `run:` and needs no special handling; line anchoring still walks blocks in document order.
+
 ### Workflow discovery
 
 `workflow::find_workflows` scans every forge root in `DEFAULT_FORGE_ROOTS` (`.github`, `.forgejo`, `.gitea`) for a `workflows/` subdirectory. Forgejo and Gitea use GitHub-compatible workflow syntax. Discovery is **purely additive**: each root that exists is scanned and the files are unioned, so extra roots only widen coverage. The list is a compile-time constant and is deliberately *not* configurable via `.pinprick.toml`: a scanned repo (which may be hostile, hence `--no-repo-config`) must never be able to redirect the scan to a decoy directory while real workflows hide in `.github/workflows`. Every root goes through the same symlink-refusing `open_child_dir` path, so a symlinked forge root is refused, never followed. GitLab is out of scope: `.gitlab-ci.yml` is a single file with a different schema and no `uses:` references.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -374,26 +374,62 @@ pub fn extract_run_blocks(path: &Path, content: &str) -> Result<Vec<(usize, Stri
     let mut blocks = Vec::new();
     let mut cursor: usize = 0; // 0-based line index, monotonically advancing
 
-    // Walk jobs.*.steps[].run. serde_norway's Mapping preserves insertion
-    // order, so iterating here visits `run:` blocks in document order and we
-    // can anchor each one at the next matching line, never earlier ones.
+    // Walk jobs.*.steps[].run, including nested parallel groups.
+    // serde_norway's Mapping preserves insertion order, so iterating here
+    // visits `run:` blocks in document order and we can anchor each one at
+    // the next matching line, never earlier ones.
     if let Some(jobs) = yaml.get("jobs").and_then(|j| j.as_mapping()) {
         for (_job_name, job) in jobs {
-            if let Some(steps) = job.get("steps").and_then(|s| s.as_sequence()) {
-                for step in steps {
-                    if let Some(run) = step.get("run").and_then(|r| r.as_str()) {
-                        let (line, next_cursor) = find_run_line(content, run, cursor);
-                        cursor = next_cursor;
-                        // Line 0 (not found) is kept — the block is still
-                        // scanned, just unanchored.
-                        blocks.push((line, run.to_string()));
-                    }
+            if let Some(steps) = job.get("steps") {
+                for run in collect_step_run_blocks(steps) {
+                    let (line, next_cursor) = find_run_line(content, run, cursor);
+                    cursor = next_cursor;
+                    // Line 0 (not found) is kept — the block is still
+                    // scanned, just unanchored.
+                    blocks.push((line, run.to_string()));
                 }
             }
         }
     }
 
     Ok(blocks)
+}
+
+/// Collect the `run:` block bodies under a `steps:` sequence in document
+/// order, descending into `parallel:` groups.
+///
+/// GitHub documents `parallel:` as a sequence of steps, so a nested group is
+/// walked exactly like the top-level `steps:` list — which also covers
+/// `parallel:` nested inside `parallel:`. A `background: true` step keeps its
+/// own `run:` key and is collected like any other step. Steps without a `run:`
+/// (`uses:`, `wait:`, `cancel:`) contribute nothing.
+fn collect_step_run_blocks(steps: &Value) -> Vec<&str> {
+    fn collect<'a>(steps: &'a Value, runs: &mut Vec<&'a str>) {
+        let Some(sequence) = steps.as_sequence() else {
+            return;
+        };
+
+        for step in sequence {
+            let Some(mapping) = step.as_mapping() else {
+                continue;
+            };
+            for (key, value) in mapping {
+                match key.as_str() {
+                    Some("run") => {
+                        if let Some(run) = value.as_str() {
+                            runs.push(run);
+                        }
+                    }
+                    Some("parallel") => collect(value, runs),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let mut runs = Vec::new();
+    collect(steps, &mut runs);
+    runs
 }
 
 /// Locate the 1-based line of `run_content` in the raw file, starting the
@@ -1992,17 +2028,12 @@ fn scan_action_yml_runs(
     collector: &mut AuditCollector,
     config: &Config,
 ) {
-    // runs.steps[].run (composite actions). base_line 0: positions are
-    // block-relative — the block is never located inside the fetched file.
-    if let Some(steps) = yaml
-        .get("runs")
-        .and_then(|r| r.get("steps"))
-        .and_then(|s| s.as_sequence())
-    {
-        for step in steps {
-            if let Some(run) = step.get("run").and_then(|r| r.as_str()) {
-                scan_shell_content(run, source_file, 0, action_name, collector, config);
-            }
+    // runs.steps[].run (composite actions), including nested parallel groups.
+    // base_line 0: positions are block-relative — the block is never located
+    // inside the fetched file.
+    if let Some(steps) = yaml.get("runs").and_then(|r| r.get("steps")) {
+        for run in collect_step_run_blocks(steps) {
+            scan_shell_content(run, source_file, 0, action_name, collector, config);
         }
     }
 
@@ -2117,6 +2148,160 @@ more stuff
         let file = "echo hello world\nother\n";
         let (line, cursor) = find_run_line(file, "echo hello", 0);
         assert_eq!((line, cursor), (1, 1));
+    }
+
+    #[test]
+    fn extract_run_blocks_recurses_into_parallel_steps() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo outside
+      - parallel:
+          - run: echo nested one
+          - name: Nested two
+            run: |
+              echo nested two
+"#;
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let runs = blocks.iter().map(|(_, run)| run.trim()).collect::<Vec<_>>();
+
+        assert_eq!(
+            runs,
+            vec!["echo outside", "echo nested one", "echo nested two"]
+        );
+    }
+
+    #[test]
+    fn extract_run_blocks_anchors_nested_parallel_blocks_in_document_order() {
+        let yaml = "\
+jobs:
+  test:
+    steps:
+      - run: |
+          echo shared
+          echo first
+      - parallel:
+          - run: |
+              echo shared
+              echo nested
+      - run: |
+          echo shared
+          echo third
+";
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let lines = blocks.iter().map(|(line, _run)| *line).collect::<Vec<_>>();
+
+        assert_eq!(lines, vec![5, 9, 12]);
+    }
+
+    #[test]
+    fn scan_shell_content_flags_parallel_pipe_to_shell() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: curl https://example.com/install.sh | sh
+"#;
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let mut c = AuditCollector::new(false);
+
+        for (line, run) in blocks {
+            scan_shell_content(&run, "workflow.yml", line, "", &mut c, &DEFAULT_CONFIG);
+        }
+
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
+    }
+
+    #[test]
+    fn parallel_control_steps_do_not_create_spurious_findings() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - wait: server
+      - parallel:
+          - wait: server
+          - cancel: server
+          - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          - run: echo safe
+      - cancel: server
+"#;
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let mut c = AuditCollector::new(false);
+
+        for (line, run) in &blocks {
+            scan_shell_content(run, "workflow.yml", *line, "", &mut c, &DEFAULT_CONFIG);
+        }
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].1.trim(), "echo safe");
+        assert!(c.findings.is_empty());
+    }
+
+    #[test]
+    fn scan_content_finds_uses_inside_parallel_group() {
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - uses: actions/checkout@v4
+"#;
+        let refs = workflow::scan_content(yaml);
+
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].full_name(), "actions/checkout");
+    }
+
+    #[test]
+    fn extract_run_blocks_recurses_into_nested_parallel() {
+        // `parallel:` nested inside `parallel:` — each level is a sequence of
+        // steps, walked the same way as the top-level list.
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo outer
+          - parallel:
+              - run: echo inner
+"#;
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let runs = blocks.iter().map(|(_, run)| run.trim()).collect::<Vec<_>>();
+
+        assert_eq!(runs, vec!["echo outer", "echo inner"]);
+    }
+
+    #[test]
+    fn extract_run_blocks_flags_backgrounded_service_run() {
+        // A `background: true` step keeps its `run:`, so a risky service start
+        // must still be scanned.
+        let yaml = r#"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start service
+        run: curl https://example.com/install.sh | sh
+        background: true
+"#;
+        let blocks = extract_run_blocks(Path::new("workflow.yml"), yaml).unwrap();
+        let mut c = AuditCollector::new(false);
+
+        for (line, run) in blocks {
+            scan_shell_content(&run, "workflow.yml", line, "", &mut c, &DEFAULT_CONFIG);
+        }
+
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
     }
 
     #[test]
@@ -3009,6 +3194,24 @@ runs:
         let mut c = AuditCollector::new(false);
         scan_action_yml_runs(&yaml, "action.yml", "test-action", &mut c, &DEFAULT_CONFIG);
         assert_eq!(c.findings.len(), 1);
+    }
+
+    #[test]
+    fn scan_action_yml_composite_parallel_steps() {
+        let yaml: serde_norway::Value = serde_norway::from_str(
+            r#"
+runs:
+  using: composite
+  steps:
+    - parallel:
+        - run: curl https://example.com/install.sh | sh
+"#,
+        )
+        .unwrap();
+        let mut c = AuditCollector::new(false);
+        scan_action_yml_runs(&yaml, "action.yml", "test-action", &mut c, &DEFAULT_CONFIG);
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].severity, "high");
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -90,6 +90,28 @@ fn pipe_to_shell_json_fields() {
 }
 
 #[test]
+fn parallel_run_block_is_scanned() {
+    // A `curl | bash` nested inside a `parallel:` step group must be caught
+    // end-to-end (run-block extraction recurses into parallel groups) and must
+    // anchor to the real source line, not the `parallel:` container.
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PARALLEL_PIPE_TO_SHELL);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["severity"], "high");
+    assert_eq!(findings[0]["category"], "shell_fetch");
+    assert_eq!(findings[0]["line"], 12);
+}
+
+#[test]
 fn curl_latest_finding() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CURL_LATEST);
     let output = common::pinprick_cmd()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -74,6 +74,25 @@ jobs:
       - run: curl -fsSL https://example.com/install.sh | bash
 ";
 
+/// Pipe-to-shell nested inside a `parallel:` step group (GitHub's parallel-
+/// steps feature). Expect one high-severity finding from the nested run block,
+/// proving run-block extraction descends into parallel groups.
+pub const WORKFLOW_PARALLEL_PIPE_TO_SHELL: &str = "\
+name: parallel
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - parallel:
+          - name: Build frontend
+            run: npm run build:frontend
+          - name: Fetch installer
+            run: curl -fsSL https://example.com/install.sh | bash
+      - run: npm test
+";
+
 /// Curl with /latest/ in URL. Expect one high-severity finding.
 pub const WORKFLOW_CURL_LATEST: &str = "\
 name: curl-latest

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -187,6 +187,32 @@ jobs:
 }
 
 #[test]
+fn runtime_rule_fires_on_parallel_run_block() {
+    // The score runtime.* rules reuse extract_run_blocks, so a pipe-to-shell
+    // nested in a `parallel:` group must dent the score like a top-level block.
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PARALLEL_PIPE_TO_SHELL);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let ids: Vec<String> = json["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["id"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        ids.contains(&"runtime.pipe_to_shell".to_string()),
+        "ids: {ids:?}"
+    );
+}
+
+#[test]
 fn ignore_patterns_suppresses_runtime_score_finding() {
     let workflow = "\
 name: risky


### PR DESCRIPTION
GitHub's parallel-steps feature (shipped 2026-06-25) groups a sequence of nested steps under `parallel:`. The audit run-block extractor only walked top-level `steps[]`, so a `run:` inside a `parallel:` group was skipped by both `audit` and `score`. Extraction now recurses into `parallel:` groups (workflows and composite actions), with a real parallel-workflow fixture exercised end-to-end and an AGENTS.md note. Output is unchanged for workflows without `parallel:`.
