### PR TITLE
chore(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"


### PR DESCRIPTION
`anyhow 1.0.102` is affected by [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), an unsoundness in `Error::downcast_mut()` fixed in 1.0.103. The advisory was merged into the RustSec database on 2026-06-29 (after the lockfile was last touched), so `cargo deny check` began failing on push to main against an unchanged dependency rather than because of any code change.

This bumps the lockfile entry to 1.0.103. `cargo deny check advisories` passes locally.
