### PR TITLE
ci: swap stale claude.ai lychee exclusion for gnu.org

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -7,5 +7,6 @@ max_concurrency = 20
 timeout = 20
 max_retries = 3
 
-# claude.ai returns 403 to automated link checkers
-exclude = ["https://claude.ai/.*"]
+# gnu.org can time out or block automated link checkers from hosted runners.
+# The AGPL license URL is canonical; skip verifying it.
+exclude = ["^https://www\\.gnu\\.org/"]


### PR DESCRIPTION
gnu.org rate-limits and returns 403 to automated link checkers from hosted CI runners; the repo references it for the AGPL-3.0 license, so this excludes it from the lychee check to prevent flakes. The URL is a canonical FSF permalink.

The existing claude.ai exclusion guarded a "Built with Claude Code" README badge that no longer exists in source, so it's dropped. Brings the config in line with the rest of the fleet.
