### PR TITLE
ci: mint app tokens right before writes and harden release packaging

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -21,8 +21,6 @@ env:
 
 defaults:
   run:
-    # No -x: this workflow uses GitHub tokens in run steps and can mint
-    # short-lived app tokens.
     shell: bash -euo pipefail {0}
 
 concurrency:
@@ -200,15 +198,6 @@ jobs:
       contents: read
       actions: read # required by download-artifact
     steps:
-      - name: Mint bot token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -231,6 +220,16 @@ jobs:
           else
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
+
+      - name: Mint bot token
+        id: app-token
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create signed commit and open PR
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -7,7 +7,6 @@ on:
 
 defaults:
   run:
-    # No -x: this workflow can mint and use short-lived app tokens.
     shell: bash -euo pipefail {0}
 
 concurrency:
@@ -91,16 +90,6 @@ jobs:
       contents: read
       actions: read # required by download-artifact
     steps:
-      - name: Mint bot token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
-          permission-workflows: write
-
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -110,6 +99,16 @@ jobs:
         with:
           name: ci-yml
           path: .github/workflows/
+
+      - name: Mint bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
 
       - name: Create signed commit and open PR
         env:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -12,7 +12,6 @@ on:
 
 defaults:
   run:
-    # No -x: this job handles Cloudflare and catalog-signing secrets.
     shell: bash -euo pipefail {0}
 
 permissions: {}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
       - name: Create and unlock temporary macOS keychain
         if: matrix.sign
         run: |
+          # Keep xtrace disabled here: this password is generated at runtime and is not a registered secret.
           TEMPORARY_KEYCHAIN_PASSWORD="$(openssl rand -base64 20)"
+          echo "::add-mask::${TEMPORARY_KEYCHAIN_PASSWORD}"
           TEMPORARY_KEYCHAIN_PATH="${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"
           security create-keychain -p "${TEMPORARY_KEYCHAIN_PASSWORD}" "${TEMPORARY_KEYCHAIN_PATH}"
           security set-keychain-settings -lut 21600 "${TEMPORARY_KEYCHAIN_PATH}"
@@ -157,7 +159,7 @@ jobs:
           mkdir -p staging
           cp "target/${TARGET}/release/pinprick" staging/
           cp LICENSE staging/
-          tar czf "${ARTIFACT}.tar.gz" -C staging .
+          /usr/bin/tar --no-mac-metadata --no-xattrs -czf "${ARTIFACT}.tar.gz" -C staging .
           echo "ARTIFACT=${ARTIFACT}" >> "${GITHUB_ENV}"
 
       - name: Generate build provenance


### PR DESCRIPTION
Two token-hygiene changes and a packaging pass.

`bump-cargo-tools` and `audit-actions` minted their GitHub App token as the first step of the update job, so it was live through checkout and artifact download. Both now mint it immediately before the commit-and-PR step. `audit-actions` additionally gates the mint on `steps.diff.outputs.changed`, so a scheduled run that finds nothing to commit no longer mints a `contents`/`pull-requests` write token it never uses. This matches how `bump-cask` and the macOSdb scan publish job already work.

The release build now packages with `/usr/bin/tar --no-mac-metadata --no-xattrs` so bsdtar does not embed `com.apple.provenance` AppleDouble metadata into the published tarball, and the runtime-generated temporary keychain password is masked with `::add-mask::` at the point of generation.

The `deploy-site` no-`-x` comment is removed: its Cloudflare token and `CATALOG_SIGNING_KEY` are registered secrets that GitHub masks regardless of xtrace, so the comment overstated the risk. The `bash -euo pipefail` default is unchanged.
