### PR TITLE
fix: correctness and CI hardening from the project review

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,3 +1,18 @@
 #!/bin/sh
 # Runs the same checks as CI before pushing.
+#
+# Deletion-only pushes carry no code (git reports an all-zero local
+# sha for each deleted ref on stdin), so skip the checks for them.
+
+deleting_only=1
+while read -r local_ref local_sha remote_ref remote_sha; do
+    case "$local_sha" in
+        *[!0]*) deleting_only=0 ;;
+    esac
+done
+
+if [ "$deleting_only" -eq 1 ]; then
+    exit 0
+fi
+
 just check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,14 @@ jobs:
           # one on the same SHA, bypassing tests, coverage, site checks and the rest.
           CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
 
-          # Rust or build workflow changes: lint + test
+          # Rust or build workflow changes: lint + test + MSRV
           if echo "${CHANGED}" | grep -qE '\.rs$|^Cargo\.(toml|lock)$|^clippy\.toml$|^rustfmt\.toml$|^\.github/workflows/(ci|release)\.yml$'; then
             MATRIX+=',{"name":"Lint","check":"lint","runner":"ubuntu-24.04"}'
             MATRIX+=',{"name":"Test (Linux)","check":"test","runner":"ubuntu-24.04"}'
             MATRIX+=',{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-24.04-arm"}'
             MATRIX+=',{"name":"Test (macOS)","check":"test","runner":"macos-26"}'
             MATRIX+=',{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}'
+            MATRIX+=',{"name":"MSRV","check":"msrv","runner":"ubuntu-24.04"}'
           fi
 
           # Audited-actions changes: verify all entries
@@ -254,6 +255,21 @@ jobs:
       - name: Test
         if: matrix.check == 'test'
         run: cargo test --locked
+
+      # --- MSRV ---
+
+      - name: Install MSRV toolchain
+        if: matrix.check == 'msrv'
+        run: |
+          # The declared rust-version is only a promise if something builds
+          # with it — the other legs all use the runner's latest stable.
+          MSRV=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].rust_version')
+          rustup toolchain install "${MSRV}" --profile minimal
+          echo "MSRV=${MSRV}" >> "${GITHUB_ENV}"
+
+      - name: Check with MSRV toolchain
+        if: matrix.check == 'msrv'
+        run: cargo "+${MSRV}" check --locked --all-targets
 
       # --- Coverage ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,65 @@ concurrency:
 permissions: {}
 
 jobs:
-  build:
-    name: Build (${{ matrix.target }})
+  preflight:
+    name: Preflight
     # Releases come from main only — a dispatch from any other branch would
     # tag and publish whatever that branch contains. Guarding the entry job
     # skips the whole chain via `needs`.
     if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::Could not extract version from Cargo.toml"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      # Fail before the five build jobs spend their minutes: a forgotten
+      # version bump previously surfaced only at tag creation, after every
+      # binary was already built.
+      - name: Fail if tag already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh api "repos/${REPOSITORY}/git/ref/tags/${TAG}" --silent 2>/dev/null; then
+            echo "::error::Tag ${TAG} already exists — bump the version in Cargo.toml before dispatching a release"
+            exit 1
+          fi
+
+      - name: Fail if version already on crates.io
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # Piped to jq: a JSON API probe, not fetched code — pinprick's own
+          # audit exempts this form.
+          if curl -fsS -A "pinprick-release-preflight" \
+            "https://crates.io/api/v1/crates/pinprick/${VERSION}" | jq -e .version > /dev/null; then
+            echo "::error::pinprick ${VERSION} is already on crates.io — bump the version in Cargo.toml before dispatching a release"
+            exit 1
+          fi
+
+      # A workflow_dispatch can fire while main is red; don't publish an
+      # untested commit to crates.io and the release page.
+      - name: Test
+        run: cargo test --locked
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: preflight
     environment:
       name: release
       deployment: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pinprick"
 version = "0.19.0"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"
 license = "AGPL-3.0-only"
 repository = "https://github.com/starhaven-io/pinprick"

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1491,56 +1491,38 @@ fn check_url_patterns(
     collector: &mut AuditCollector,
     config: &Config,
 ) {
-    for pattern in patterns {
-        if !pattern.regex.is_match(line) {
-            continue;
-        }
-        // Check EVERY URL, not just the first: a versioned/trusted decoy before
-        // the real fetch must not suppress the finding. Allowed only if all URLs
-        // are exempt; any unexempt one is a finding.
-        let mut allowed_reason: Option<&str> = None;
-        let mut dangerous = false;
-        for url in extract_urls(line) {
-            if url_has_version(url) {
-                allowed_reason.get_or_insert("versioned URL");
-            } else if config.is_host_trusted(url) {
-                allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
-            } else if config.is_extra_data_format_exempt(url) {
-                allowed_reason.get_or_insert(REASON_EXTRA_DATA_FORMAT);
-            } else if config.is_data_format_exempt(url) {
-                allowed_reason.get_or_insert("data format URL");
-            } else if url_piped_to_jq(line, url) {
-                allowed_reason.get_or_insert("piped to jq");
-            } else {
-                dangerous = true;
-                break;
-            }
-        }
+    // The URL classification below is line-level, so every matching pattern
+    // would reach the identical verdict on the identical URL set: record once
+    // for the first match instead of once per pattern (`curl … && wget …`
+    // previously emitted two findings for the same line).
+    let Some(pattern) = patterns.iter().find(|p| p.regex.is_match(line)) else {
+        return;
+    };
 
-        if dangerous {
-            if let Some(reason) = allowed_reason {
-                collector.push_allowed(AuditMatch {
-                    severity: output::severity_str(&pattern.severity).to_string(),
-                    category: category_str(&pattern.category).to_string(),
-                    action: action_name.to_string(),
-                    source_file: source_file.to_string(),
-                    line: Some(line_num),
-                    pattern_matched: line.trim().to_string(),
-                    reason: reason.to_string(),
-                });
-            }
-            collector.push_finding(AuditFinding {
-                severity: output::severity_str(&pattern.severity).to_string(),
-                category: category_str(&pattern.category).to_string(),
-                action: action_name.to_string(),
-                source_file: source_file.to_string(),
-                line: Some(line_num),
-                pattern_matched: line.trim().to_string(),
-                description: pattern.description.to_string(),
-                workflow_file: None,
-                workflow_line: None,
-            });
-        } else if let Some(reason) = allowed_reason {
+    // Check EVERY URL, not just the first: a versioned/trusted decoy before
+    // the real fetch must not suppress the finding. Allowed only if all URLs
+    // are exempt; any unexempt one is a finding.
+    let mut allowed_reason: Option<&str> = None;
+    let mut dangerous = false;
+    for url in extract_urls(line) {
+        if url_has_version(url) {
+            allowed_reason.get_or_insert("versioned URL");
+        } else if config.is_host_trusted(url) {
+            allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
+        } else if config.is_extra_data_format_exempt(url) {
+            allowed_reason.get_or_insert(REASON_EXTRA_DATA_FORMAT);
+        } else if config.is_data_format_exempt(url) {
+            allowed_reason.get_or_insert("data format URL");
+        } else if url_piped_to_jq(line, url) {
+            allowed_reason.get_or_insert("piped to jq");
+        } else {
+            dangerous = true;
+            break;
+        }
+    }
+
+    if dangerous {
+        if let Some(reason) = allowed_reason {
             collector.push_allowed(AuditMatch {
                 severity: output::severity_str(&pattern.severity).to_string(),
                 category: category_str(&pattern.category).to_string(),
@@ -1551,8 +1533,29 @@ fn check_url_patterns(
                 reason: reason.to_string(),
             });
         }
-        // No URL on the line: nothing to record.
+        collector.push_finding(AuditFinding {
+            severity: output::severity_str(&pattern.severity).to_string(),
+            category: category_str(&pattern.category).to_string(),
+            action: action_name.to_string(),
+            source_file: source_file.to_string(),
+            line: Some(line_num),
+            pattern_matched: line.trim().to_string(),
+            description: pattern.description.to_string(),
+            workflow_file: None,
+            workflow_line: None,
+        });
+    } else if let Some(reason) = allowed_reason {
+        collector.push_allowed(AuditMatch {
+            severity: output::severity_str(&pattern.severity).to_string(),
+            category: category_str(&pattern.category).to_string(),
+            action: action_name.to_string(),
+            source_file: source_file.to_string(),
+            line: Some(line_num),
+            pattern_matched: line.trim().to_string(),
+            reason: reason.to_string(),
+        });
     }
+    // No URL on the line: nothing to record.
 }
 
 fn check_patterns(
@@ -2387,6 +2390,23 @@ jobs:
         assert_eq!(c.findings[0].severity, "high");
         assert!(c.findings[0].description.contains("piped to shell"));
         assert!(c.allowed.is_empty());
+    }
+
+    #[test]
+    fn shell_scan_records_one_finding_when_multiple_url_patterns_match() {
+        // curl and wget on one line reach the same line-level URL verdict;
+        // two findings for the same line would be duplicate noise.
+        let mut c = AuditCollector::new(false);
+        scan_shell_content(
+            "curl -O https://example.com/a.tar.gz && wget https://example.com/b.tar.gz\n",
+            "test.sh",
+            1,
+            "",
+            &mut c,
+            &DEFAULT_CONFIG,
+        );
+        assert_eq!(c.findings.len(), 1);
+        assert_eq!(c.findings[0].line, Some(1));
     }
 
     #[test]

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -205,7 +205,20 @@ impl AuditedActions {
         let key = self.catalog_key.as_ref()?;
 
         let url = format!("{}/{action_key}.json", self.remote_url);
-        let bytes = self.fetch_url(&url).await?;
+        let bytes = match self.fetch_url(&url).await {
+            Ok(Some(bytes)) => bytes,
+            // 404: the action has no remote catalog — a normal, silent miss.
+            Ok(None) => return None,
+            // Network or server failure is not absence: the action may well be
+            // audited, we just couldn't find out. Say so instead of silently
+            // degrading coverage for the rest of the run.
+            Err(()) => {
+                eprintln!(
+                    "warning: could not fetch remote catalog for {action_key} — treating it as unaudited for this run"
+                );
+                return None;
+            }
+        };
 
         // The signature is served next to the catalog file (minisign's `.minisig`
         // convention). A catalog without a valid signature is not honored — a
@@ -213,10 +226,16 @@ impl AuditedActions {
         // catalog with a missing or bad signature is worth a warning: it means
         // either serving infra is misconfigured or someone tampered with it.
         let sig_bytes = match self.fetch_url(&format!("{url}.minisig")).await {
-            Some(b) => b,
-            None => {
+            Ok(Some(b)) => b,
+            Ok(None) => {
                 eprintln!(
                     "warning: remote catalog for {action_key} has no signature — ignoring it"
+                );
+                return None;
+            }
+            Err(()) => {
+                eprintln!(
+                    "warning: could not fetch the signature for {action_key}'s remote catalog — ignoring it"
                 );
                 return None;
             }
@@ -232,21 +251,30 @@ impl AuditedActions {
         Some(parse_entries(&String::from_utf8_lossy(&bytes)))
     }
 
-    /// GET a URL and return the (size-capped) body, or `None` on any failure.
-    async fn fetch_url(&self, url: &str) -> Option<Vec<u8>> {
+    /// GET a URL and return the (size-capped) body. `Ok(None)` means the
+    /// server said the resource doesn't exist (404) — confirmed absence.
+    /// `Err(())` is any other failure (network, non-404 status, oversized
+    /// body), where absence was NOT confirmed.
+    async fn fetch_url(&self, url: &str) -> Result<Option<Vec<u8>>, ()> {
         let resp = self
             .client
             .get(url)
             .header("User-Agent", "pinprick")
             .send()
             .await
-            .ok()?;
+            .map_err(|_| ())?;
 
+        if resp.status().as_u16() == 404 {
+            return Ok(None);
+        }
         if !resp.status().is_success() {
-            return None;
+            return Err(());
         }
 
-        crate::github::read_capped(resp).await.ok()
+        crate::github::read_capped(resp)
+            .await
+            .map(Some)
+            .map_err(|_| ())
     }
 }
 
@@ -600,6 +628,49 @@ mod tests {
             aa.catalog_key = Some(key);
             aa.remote_url = server.uri();
             assert!(aa.fetch_remote_list("actions/missing").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_url_distinguishes_absence_from_failure() {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/missing.json"))
+                .respond_with(ResponseTemplate::new(404))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/broken.json"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+
+            let aa = AuditedActions::new(false);
+            // 404 is confirmed absence; a server error is not.
+            assert_eq!(
+                aa.fetch_url(&format!("{}/missing.json", server.uri()))
+                    .await,
+                Ok(None)
+            );
+            assert_eq!(
+                aa.fetch_url(&format!("{}/broken.json", server.uri())).await,
+                Err(())
+            );
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_server_error_is_none() {
+            let (key, _) = test_identity();
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/actions/flaky.json"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&server)
+                .await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/flaky").await.is_none());
         }
 
         #[tokio::test]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,12 +1,15 @@
 use anyhow::{Result, bail};
 
 pub async fn resolve_token() -> Option<String> {
-    // A set-but-empty GITHUB_TOKEN (common in CI) counts as absent — fall
-    // through to gh.
-    if let Ok(token) = std::env::var("GITHUB_TOKEN")
-        && !token.is_empty()
-    {
-        return Some(token);
+    // A set-but-empty token variable (common in CI) counts as absent — fall
+    // through to the next source. GH_TOKEN is the variable the gh CLI itself
+    // honors, so check it before shelling out to gh.
+    for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(token) = std::env::var(var)
+            && !token.is_empty()
+        {
+            return Some(token);
+        }
     }
 
     let output = tokio::process::Command::new("gh")

--- a/src/github.rs
+++ b/src/github.rs
@@ -268,9 +268,26 @@ impl GitHubClient {
         unreachable!("loop always returns or continues until last_attempt")
     }
 
+    /// Base URL for a repo's API routes, with owner and repo percent-encoded
+    /// so a crafted `uses:` ref can't reshape the request path.
+    fn repo_url(&self, owner: &str, repo: &str) -> Result<String> {
+        Ok(format!(
+            "{}/repos/{}/{}",
+            self.base,
+            encode_path_segment(owner)?,
+            encode_path_segment(repo)?
+        ))
+    }
+
     /// Resolve a tag to its commit SHA, following annotated tag objects.
     pub async fn resolve_tag(&self, owner: &str, repo: &str, tag: &str) -> Result<String> {
-        let url = format!("{}/repos/{owner}/{repo}/git/ref/tags/{tag}", self.base);
+        // Tags may legitimately contain `/` (e.g. `release/v1.2`), so encode
+        // per segment rather than as a single component.
+        let url = format!(
+            "{}/git/ref/tags/{}",
+            self.repo_url(owner, repo)?,
+            percent_encode_path(tag)?
+        );
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -286,8 +303,9 @@ impl GitHubClient {
 
         if git_ref.object.object_type == "tag" {
             let tag_url = format!(
-                "{}/repos/{owner}/{repo}/git/tags/{}",
-                self.base, git_ref.object.sha
+                "{}/git/tags/{}",
+                self.repo_url(owner, repo)?,
+                encode_path_segment(&git_ref.object.sha)?
             );
             let tag_resp = self.get(&tag_url).await?;
             ensure_success(
@@ -310,10 +328,13 @@ impl GitHubClient {
         sha: &str,
         original_tag: &str,
     ) -> String {
-        let url = format!(
-            "{}/repos/{owner}/{repo}/git/matching-refs/tags/{original_tag}",
-            self.base
-        );
+        let Ok(base) = self.repo_url(owner, repo) else {
+            return original_tag.to_string();
+        };
+        let Ok(encoded_tag) = percent_encode_path(original_tag) else {
+            return original_tag.to_string();
+        };
+        let url = format!("{base}/git/matching-refs/tags/{encoded_tag}");
         let Ok(resp) = self.get(&url).await else {
             return original_tag.to_string();
         };
@@ -339,7 +360,12 @@ impl GitHubClient {
     }
 
     async fn resolve_annotated_tag(&self, owner: &str, repo: &str, tag_sha: &str) -> String {
-        let url = format!("{}/repos/{owner}/{repo}/git/tags/{tag_sha}", self.base);
+        let (Ok(base), Ok(encoded_sha)) =
+            (self.repo_url(owner, repo), encode_path_segment(tag_sha))
+        else {
+            return String::new();
+        };
+        let url = format!("{base}/git/tags/{encoded_sha}");
         let Ok(resp) = self.get(&url).await else {
             return String::new();
         };
@@ -351,7 +377,7 @@ impl GitHubClient {
 
     /// List releases for a repo (first page, most recent first).
     pub async fn list_releases(&self, owner: &str, repo: &str) -> Result<Vec<Release>> {
-        let url = format!("{}/repos/{owner}/{repo}/releases?per_page=30", self.base);
+        let url = format!("{}/releases?per_page=30", self.repo_url(owner, repo)?);
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -370,7 +396,7 @@ impl GitHubClient {
     /// actions are virtually always on a recent tag, so paginating further
     /// isn't worth the latency.
     async fn fetch_tags(&self, owner: &str, repo: &str) -> Result<Vec<TagListEntry>> {
-        let url = format!("{}/repos/{owner}/{repo}/tags?per_page=100", self.base);
+        let url = format!("{}/tags?per_page=100", self.repo_url(owner, repo)?);
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
             bail!(GitHubError::RepoNotFound {
@@ -412,8 +438,8 @@ impl GitHubClient {
         repo: &str,
     ) -> Result<Vec<SecurityAdvisory>> {
         let url = format!(
-            "{}/repos/{owner}/{repo}/security-advisories?state=published&per_page=100",
-            self.base
+            "{}/security-advisories?state=published&per_page=100",
+            self.repo_url(owner, repo)?
         );
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
@@ -431,7 +457,7 @@ impl GitHubClient {
 
     /// Return `true` if the repo is archived on GitHub.
     pub async fn is_archived(&self, owner: &str, repo: &str) -> Result<bool> {
-        let url = format!("{}/repos/{owner}/{repo}", self.base);
+        let url = self.repo_url(owner, repo)?;
         let resp = self.get(&url).await?;
 
         if resp.status().as_u16() == 404 {
@@ -449,8 +475,9 @@ impl GitHubClient {
     /// Fetch the file tree for a repo at a given SHA.
     pub async fn fetch_tree(&self, owner: &str, repo: &str, sha: &str) -> Result<Vec<TreeEntry>> {
         let url = format!(
-            "{}/repos/{owner}/{repo}/git/trees/{sha}?recursive=1",
-            self.base
+            "{}/git/trees/{}?recursive=1",
+            self.repo_url(owner, repo)?,
+            encode_path_segment(sha)?
         );
         let resp = self.get(&url).await?;
         if resp.status().as_u16() == 404 {
@@ -473,11 +500,11 @@ impl GitHubClient {
         path: &str,
         git_ref: &str,
     ) -> Result<String> {
-        let encoded_path = percent_encode_path(path);
+        let encoded_path = percent_encode_path(path)?;
         let encoded_ref = percent_encode_component(git_ref);
         let url = format!(
-            "{}/repos/{owner}/{repo}/contents/{encoded_path}?ref={encoded_ref}",
-            self.base
+            "{}/contents/{encoded_path}?ref={encoded_ref}",
+            self.repo_url(owner, repo)?
         );
         let resp = self.get_with_accept(&url, ACCEPT_RAW).await?;
 
@@ -496,11 +523,23 @@ impl GitHubClient {
     }
 }
 
-fn percent_encode_path(path: &str) -> String {
-    path.split('/')
-        .map(percent_encode_component)
-        .collect::<Vec<_>>()
-        .join("/")
+fn percent_encode_path(path: &str) -> Result<String> {
+    Ok(path
+        .split('/')
+        .map(encode_path_segment)
+        .collect::<Result<Vec<_>>>()?
+        .join("/"))
+}
+
+/// Percent-encode a single URL path segment, rejecting dot-segments. The
+/// WHATWG URL parser collapses `.`/`..` segments even when percent-encoded,
+/// so a crafted value could climb out of its path position; git and GitHub
+/// both forbid such names, so refusing them loses nothing.
+fn encode_path_segment(value: &str) -> Result<String> {
+    if value == "." || value == ".." {
+        bail!("invalid path segment {value:?}");
+    }
+    Ok(percent_encode_component(value))
 }
 
 fn percent_encode_component(value: &str) -> String {
@@ -600,13 +639,22 @@ mod tests {
     #[test]
     fn percent_encode_path_preserves_separators() {
         assert_eq!(
-            percent_encode_path("dir/a file#x.js"),
+            percent_encode_path("dir/a file#x.js").unwrap(),
             "dir/a%20file%23x.js"
         );
         assert_eq!(
             percent_encode_component("refs/heads/feature?x&y"),
             "refs%2Fheads%2Ffeature%3Fx%26y"
         );
+    }
+
+    #[test]
+    fn encode_path_segment_rejects_dot_segments() {
+        assert!(encode_path_segment(".").is_err());
+        assert!(encode_path_segment("..").is_err());
+        assert!(percent_encode_path("../../etc").is_err());
+        // Dotted-but-not-dot-segment values pass through.
+        assert_eq!(encode_path_segment("v1.2.3").unwrap(), "v1.2.3");
     }
 
     mod network {
@@ -636,6 +684,38 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(sha, "deadbeef");
+        }
+
+        #[tokio::test]
+        async fn resolve_tag_percent_encodes_owner_repo_and_tag() {
+            let server = MockServer::start().await;
+            // Metacharacters in owner/repo/tag must not reshape the request
+            // path; slashes inside tag names stay literal separators.
+            Mock::given(method("GET"))
+                .and(path("/repos/o%23x/r%3Fx/git/ref/tags/release/v1%20x"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "object": { "sha": "deadbeef", "type": "commit" }
+                })))
+                .mount(&server)
+                .await;
+
+            let sha = client_for(&server)
+                .await
+                .resolve_tag("o#x", "r?x", "release/v1 x")
+                .await
+                .unwrap();
+            assert_eq!(sha, "deadbeef");
+        }
+
+        #[tokio::test]
+        async fn resolve_tag_rejects_dot_segment_components() {
+            // No mock mounted: a dot-segment owner or tag must error before
+            // any request is sent, not climb the API path.
+            let server = MockServer::start().await;
+            let client = client_for(&server).await;
+            assert!(client.resolve_tag("..", "r", "v1").await.is_err());
+            assert!(client.resolve_tag("o", "r", "../../x").await.is_err());
+            assert_eq!(server.received_requests().await.unwrap().len(), 0);
         }
 
         #[tokio::test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -408,14 +408,25 @@ impl GitHubClient {
         resp.json().await.context("parsing tags")
     }
 
-    /// Find a tag name pointing at the given commit SHA, if any.
+    /// Find a tag name pointing at the given commit SHA, if any. A release
+    /// commit typically carries several tags (`v4`, `v4.2`, `v4.2.1`, maybe
+    /// `nightly`); prefer the most specific version-like name — mirroring
+    /// `find_exact_tag` — so callers compare against `v4.2.1` rather than a
+    /// sliding `v4` or a moving `nightly`.
     pub async fn sha_to_tag(&self, owner: &str, repo: &str, sha: &str) -> Result<Option<String>> {
-        Ok(self
+        let names: Vec<String> = self
             .fetch_tags(owner, repo)
             .await?
             .into_iter()
-            .find(|t| t.commit.sha == sha)
-            .map(|t| t.name))
+            .filter(|t| t.commit.sha == sha)
+            .map(|t| t.name)
+            .collect();
+        Ok(names
+            .iter()
+            .filter(|t| is_version_like_tag(t))
+            .max_by_key(|t| t.len())
+            .cloned()
+            .or_else(|| names.into_iter().next()))
     }
 
     /// List tag names for a repo. The `update` command falls back to this when
@@ -556,6 +567,14 @@ fn percent_encode_component(value: &str) -> String {
 
 fn is_unreserved(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~')
+}
+
+/// Whether a tag looks like a version (optional `v` followed by a digit).
+/// Mirrors `update::is_version_like`.
+fn is_version_like_tag(tag: &str) -> bool {
+    tag.strip_prefix('v')
+        .unwrap_or(tag)
+        .starts_with(|c: char| c.is_ascii_digit())
 }
 
 fn ensure_success(resp: &reqwest::Response, operation: String) -> Result<()> {
@@ -837,6 +856,33 @@ mod tests {
                 Some("v2")
             );
             assert_eq!(c.sha_to_tag("o", "r", "zzz").await.unwrap(), None);
+        }
+
+        #[tokio::test]
+        async fn sha_to_tag_prefers_most_specific_version_tag() {
+            let server = MockServer::start().await;
+            // nightly, v4, and v4.2.1 all point at the release commit — the
+            // caller must see v4.2.1, not whichever the API listed first.
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/tags"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                    { "name": "nightly", "commit": { "sha": "aaa" } },
+                    { "name": "v4", "commit": { "sha": "aaa" } },
+                    { "name": "v4.2.1", "commit": { "sha": "aaa" } },
+                    { "name": "stable", "commit": { "sha": "bbb" } }
+                ])))
+                .mount(&server)
+                .await;
+            let c = client_for(&server).await;
+            assert_eq!(
+                c.sha_to_tag("o", "r", "aaa").await.unwrap().as_deref(),
+                Some("v4.2.1")
+            );
+            // No version-like tag at the SHA: fall back to the first match.
+            assert_eq!(
+                c.sha_to_tag("o", "r", "bbb").await.unwrap().as_deref(),
+                Some("stable")
+            );
         }
 
         #[tokio::test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -555,7 +555,10 @@ pub fn severity_str(s: &Severity) -> &'static str {
 
 // ── SARIF 2.1.0 ─────────────────────────────────────────────────────────────
 
-const SARIF_SCHEMA: &str = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+// Immutable published URL — the spec repo's `master` branch has moved schema
+// paths before, which would leave emitted documents pointing at a dead link.
+const SARIF_SCHEMA: &str =
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
 const SARIF_VERSION: &str = "2.1.0";
 const TOOL_NAME: &str = "pinprick";
 const TOOL_URI: &str = "https://pinprick.rs";
@@ -777,6 +780,32 @@ mod sarif_tests {
         assert_eq!(results[0]["level"], "error");
         assert_eq!(results[1]["level"], "warning");
         assert_eq!(results[2]["level"], "note");
+    }
+
+    #[test]
+    fn every_category_has_sarif_rule_metadata() {
+        use crate::audit_patterns::{Category, category_str};
+        // The match is exhaustive on purpose: adding a Category variant fails
+        // compilation here until the list below (and SARIF_RULES) grows with it.
+        let all = [
+            Category::DockerUnpinned,
+            Category::JavaScriptFetch,
+            Category::PythonFetch,
+            Category::ShellFetch,
+        ];
+        for category in &all {
+            match category {
+                Category::DockerUnpinned
+                | Category::JavaScriptFetch
+                | Category::PythonFetch
+                | Category::ShellFetch => {}
+            }
+            let id = format!("pinprick/{}", category_str(category));
+            assert!(
+                SARIF_RULES.iter().any(|r| r.id == id),
+                "no SARIF rule metadata for category {id} — findings would carry a ruleId with no rule"
+            );
+        }
     }
 
     #[test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -225,7 +225,7 @@ fn pick_latest_release(releases: &[Release]) -> Option<&Release> {
 fn pick_latest_tag(tags: &[String]) -> Option<&String> {
     let pick = |stable_only: bool| {
         tags.iter()
-            .filter(|t| is_version_like(t) && (!stable_only || !parse_version(t).1))
+            .filter(|t| is_version_like(t) && (!stable_only || parse_version(t).1.is_none()))
             .reduce(|best, t| if is_newer(best, t) { t } else { best })
     };
     pick(true).or_else(|| pick(false))
@@ -274,28 +274,43 @@ fn is_newer(current: &str, candidate: &str) -> bool {
     if cand.len() != cur.len() {
         return cand.len() > cur.len();
     }
-    // Exactly equal numerically: a stable release is newer than a pre-release.
+    // Exactly equal numerically: a stable release is newer than a pre-release,
+    // and two pre-releases order by semver identifier rules.
     match (cur_pre, cand_pre) {
-        (true, false) => true,
-        (false, true) => false,
+        (Some(_), None) => true,
+        (Some(cur), Some(cand)) => prerelease_newer(&cur, &cand),
         _ => false,
     }
 }
 
-/// Parse a version string into (numeric components, has pre-release suffix).
-/// Semver `-suffix` and `+build` tails are stripped before the numeric split.
-fn parse_version(s: &str) -> (Vec<u64>, bool) {
+/// Whether `candidate` is a newer pre-release than `current`, per semver
+/// pre-release ordering (`rc.1` < `rc.2`, `beta` < `rc1`). Suffixes that
+/// aren't valid semver pre-release identifiers stay conservative: neither
+/// is newer.
+fn prerelease_newer(current: &str, candidate: &str) -> bool {
+    match (
+        semver::Prerelease::new(current),
+        semver::Prerelease::new(candidate),
+    ) {
+        (Ok(cur), Ok(cand)) => cand > cur,
+        _ => false,
+    }
+}
+
+/// Parse a version string into (numeric components, pre-release suffix).
+/// The semver `+build` tail is stripped before the numeric split.
+fn parse_version(s: &str) -> (Vec<u64>, Option<String>) {
     let s = s.trim_start_matches('v');
-    let (head, has_suffix) = match s.split_once('-') {
-        Some((before, _)) => (before, true),
-        None => (s, false),
+    let (head, pre) = match s.split_once('-') {
+        Some((before, suffix)) => (before, Some(suffix.to_string())),
+        None => (s, None),
     };
     let head = head.split_once('+').map(|(b, _)| b).unwrap_or(head);
     let parts = head
         .split('.')
         .filter_map(|p| p.parse::<u64>().ok())
         .collect();
-    (parts, has_suffix)
+    (parts, pre)
 }
 
 #[cfg(test)]
@@ -362,10 +377,21 @@ mod tests {
     }
 
     #[test]
-    fn two_prereleases_same_numeric_are_equal() {
-        // Conservative: we don't try to order rc1 vs rc2, so neither is newer.
-        assert!(!is_newer("v1.2.3-rc1", "v1.2.3-rc2"));
+    fn two_prereleases_same_numeric_order_by_semver_rules() {
+        assert!(is_newer("v1.2.3-rc1", "v1.2.3-rc2"));
         assert!(!is_newer("v1.2.3-rc2", "v1.2.3-rc1"));
+        assert!(is_newer("v1.2.3-rc.1", "v1.2.3-rc.2"));
+        assert!(is_newer("v1.2.3-beta", "v1.2.3-rc1"));
+        assert!(!is_newer("v1.2.3-rc1", "v1.2.3-beta"));
+        // Identical pre-releases: neither is newer.
+        assert!(!is_newer("v1.2.3-rc1", "v1.2.3-rc1"));
+    }
+
+    #[test]
+    fn invalid_prerelease_suffixes_stay_conservative() {
+        // Not valid semver pre-release identifiers — don't guess an order.
+        assert!(!is_newer("v1.2.3-r_c1", "v1.2.3-r_c2"));
+        assert!(!is_newer("v1.2.3-r_c2", "v1.2.3-r_c1"));
     }
 
     #[test]

--- a/tests/pin.rs
+++ b/tests/pin.rs
@@ -51,6 +51,19 @@ fn all_pinned_dry_run_exits_zero() {
 }
 
 #[test]
+fn gh_token_env_var_is_honored() {
+    // GH_TOKEN (the variable the gh CLI itself uses) must work as a fallback
+    // when GITHUB_TOKEN is unset. All-pinned workflow, so no network follows.
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .env("GH_TOKEN", "dummy")
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(0);
+}
+
+#[test]
 fn no_token_json_error() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
     let output = common::pinprick_cmd()


### PR DESCRIPTION
Quick wins from the project review: correctness and security tightening across the GitHub client, auth, audit, and update paths, plus CI and release gating.

- Percent-encode owner/repo/tag/sha segments in GitHub API URL paths and reject `.`/`..` segments, so a crafted ref cannot reshape a request path.
- Honor `GH_TOKEN` as a second environment fallback before shelling out to `gh`.
- Record one URL finding per line in audit, so a line running both `curl` and `wget` no longer emits duplicate findings for the same content.
- Order pre-releases with semver identifier rules so a `v1.2.3-rc1` pin sees the `rc2` update, and prefer the most specific version-like tag when mapping a SHA back to a name.
- Warn when the remote audited-actions catalog fetch fails instead of silently treating the action as unaudited for the rest of the run.
- Pin the SARIF `$schema` to the immutable OASIS URL and add an exhaustive parity test between `Category` and `SARIF_RULES`.
- Verify the declared MSRV in PR CI, and preflight release dispatches: fail fast when the version was not bumped and run the test suite before any target build.
- Skip the pre-push hook's check suite for deletion-only pushes.