### PR TITLE
docs: fix GH_TOKEN auth drift and a rubric-inconsistent score fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ pinprick/
 │   ├── audit.rs             # Audit command: scan workflows + action source for runtime fetches
 │   ├── audit_patterns.rs    # Compiled regex patterns for shell/JS/Docker fetch detection
 │   ├── audited_actions.rs   # Layered lookup: bundled → local cache → remote → GitHub API
-│   ├── auth.rs              # GitHub token resolution (GITHUB_TOKEN env → gh auth token fallback)
+│   ├── auth.rs              # GitHub token resolution (GITHUB_TOKEN/GH_TOKEN env → gh auth token fallback)
 │   ├── config.rs            # TOML config file loading (.pinprick.toml, ~/.config/pinprick/)
 │   ├── github.rs            # GitHub API client (tag→SHA, releases, file trees)
 │   ├── output.rs            # Human-readable (colored) and --json output formatting
@@ -74,8 +74,9 @@ That read-only `run:` extraction (`extract_run_blocks` for workflows and `scan_a
 ### GitHub auth
 
 1. `GITHUB_TOKEN` environment variable (checked first)
-2. `gh auth token` CLI fallback
-3. Graceful degradation: `pin` and `update` require a token; `audit` works without one (reduced coverage)
+2. `GH_TOKEN` environment variable (the variable the `gh` CLI itself honors)
+3. `gh auth token` CLI fallback
+4. Graceful degradation: `pin` and `update` require a token; `audit` works without one (reduced coverage)
 
 Rate-limit handling: `github::get` retries once on network/5xx errors and sleeps through `x-ratelimit-reset` when the reset is within 60 s; longer waits bail with `RateLimit`.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ HIGH  .github/workflows/ci.yml:42
 1 finding (1 high, 0 medium, 0 low)
 ```
 
-Without a GitHub token, audit scans local workflow `run:` blocks and local actions referenced with `uses: ./...`. With a token (via `GITHUB_TOKEN` or `gh auth`), it also fetches and scans external action source code — JavaScript, Python, Dockerfiles, and composite action steps.
+Without a GitHub token, audit scans local workflow `run:` blocks and local actions referenced with `uses: ./...`. With a token (via `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth`), it also fetches and scans external action source code — JavaScript, Python, Dockerfiles, and composite action steps.
 
 Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, jq-pipe, or checksum rules.
 

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -60,6 +60,7 @@ pinprick uses the GitHub API to resolve tags, check releases, and fetch action s
 It looks for a token in this order:
 
 1. `GITHUB_TOKEN` environment variable
-2. `gh auth token` CLI fallback
+2. `GH_TOKEN` environment variable
+3. `gh auth token` CLI fallback
 
 The `pin` and `update` commands require a token. The `audit` command works without one but with reduced coverage — only local `run:` blocks are scanned.

--- a/src/score.rs
+++ b/src/score.rs
@@ -2182,7 +2182,10 @@ jobs:
     #[test]
     fn render_html_escapes_user_content() {
         // Exercise the escaping path for action refs / workflow paths that
-        // could (in theory) contain HTML metacharacters.
+        // could (in theory) contain HTML metacharacters. The finding uses
+        // `pin.full_tag` (2 points) so the fixture models a state the rubric
+        // can actually produce — `source.unverified` is 0-point informational
+        // and must never carry a deduction.
         let report = ScoreReport {
             rubric_version: RUBRIC_VERSION,
             pinprick_version: env!("CARGO_PKG_VERSION"),
@@ -2190,25 +2193,25 @@ jobs:
                 kind: "repo",
                 path: ".".to_string(),
             },
-            score: 99,
+            score: 98,
             grade: "A",
             totals: Totals {
-                points_deducted: 1,
+                points_deducted: 2,
                 findings: 1,
                 workflows_scanned: 1,
                 unique_actions: 1,
             },
             findings: vec![Finding {
-                id: "source.unverified",
-                category: Category::Source,
+                id: "pin.full_tag",
+                category: Category::Pin,
                 severity: Severity::Low,
-                points: 1,
+                points: 2,
                 action_ref: Some("<evil>/bar@v1".to_string()),
                 occurrences: vec![Occurrence {
                     workflow: "a&b.yml".to_string(),
                     line: 1,
                 }],
-                remediation: "fix it",
+                remediation: "Pin to a full 40-char SHA; keep the tag as a comment",
                 details: None,
             }],
         };


### PR DESCRIPTION
The GH_TOKEN fallback merged in #334 left the docs behind: AGENTS.md, the site installation page, and the README still described the old GITHUB_TOKEN then gh auth two-step resolution order. This catches all three up to auth.rs.

It also fixes the render_html_escapes_user_content fixture in score.rs, which deducted a point through source.unverified. That rule is a zero-point informational note, so the fixture modeled a report production can never emit. The finding is now pin.full_tag (2 points, score 98) and the escaping assertions are unchanged.