### PR TITLE
refactor(score): structure pipe-to-shell findings

### DIFF
--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -16,11 +16,19 @@ pub enum Category {
     ShellFetch,
 }
 
+/// Internal semantic labels for findings whose behavior cannot be derived from
+/// severity/category alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindingKind {
+    PipeToShell,
+}
+
 pub struct Pattern {
     pub regex: &'static LazyLock<Regex>,
     pub severity: Severity,
     pub category: Category,
     pub description: &'static str,
+    pub(crate) finding_kind: Option<FindingKind>,
 }
 
 // ── Shell patterns (for run: blocks and action.yml) ─────────────────────────
@@ -113,30 +121,35 @@ pub static SHELL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "curl fetching from a 'latest' URL — can change without notice",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_WGET_LATEST,
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "wget fetching from a 'latest' URL — can change without notice",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_GO_INSTALL_LATEST,
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "go install @latest/@main — not version-pinned",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_IWR_LATEST,
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "PowerShell fetching from a 'latest' URL — can change without notice",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_BREW_HEAD,
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "brew install --HEAD — builds from upstream main, bypasses pinning",
+            finding_kind: None,
         },
     ]
 });
@@ -149,18 +162,21 @@ pub static SHELL_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "curl fetching URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_WGET_UNVERSIONED,
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "wget fetching URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &SH_IWR_UNVERSIONED,
             severity: Severity::Medium,
             category: Category::ShellFetch,
             description: "PowerShell fetching URL without version pinning",
+            finding_kind: None,
         },
     ]
 });
@@ -175,24 +191,28 @@ pub static SHELL_PIPE_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "fetch piped to shell — payload not written to disk, cannot be checksummed",
+            finding_kind: Some(FindingKind::PipeToShell),
         },
         Pattern {
             regex: &SH_PROC_SUB_FETCH,
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "shell reading fetched content via process substitution — bypasses pinning",
+            finding_kind: Some(FindingKind::PipeToShell),
         },
         Pattern {
             regex: &SH_CMD_SUB_FETCH,
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "shell executing fetched content via command substitution — bypasses pinning",
+            finding_kind: Some(FindingKind::PipeToShell),
         },
         Pattern {
             regex: &SH_IEX_FETCH,
             severity: Severity::High,
             category: Category::ShellFetch,
             description: "PowerShell Invoke-Expression on fetched content — bypasses pinning",
+            finding_kind: Some(FindingKind::PipeToShell),
         },
     ]
 });
@@ -224,36 +244,42 @@ pub static JS_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "fetch() with 'latest' URL — runtime supply chain risk",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_AXIOS_LATEST,
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "axios request to 'latest' URL",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_GOT_LATEST,
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "got() request to 'latest' URL",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_HTTP_LATEST,
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "http.get() to 'latest' URL",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_EXEC_SPAWN_CURL,
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "exec()/spawn() shelling out to curl/wget — runtime fetch bypasses pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_CHILD_PROC_CURL,
             severity: Severity::High,
             category: Category::JavaScriptFetch,
             description: "child_process curl — runtime fetch bypasses pinning",
+            finding_kind: None,
         },
     ]
 });
@@ -265,30 +291,35 @@ pub static JS_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "fetch() to external URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_AXIOS_URL,
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "axios request to external URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_GOT_URL,
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "got() request to external URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_HTTP_URL,
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "http.get() to external URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &JS_REQUIRE_HTTP_GET,
             severity: Severity::Medium,
             category: Category::JavaScriptFetch,
             description: "http.get() to external URL without version pinning",
+            finding_kind: None,
         },
     ]
 });
@@ -315,24 +346,28 @@ pub static DOCKER_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::DockerUnpinned,
             description: "FROM :latest — image not pinned to specific version",
+            finding_kind: None,
         },
         Pattern {
             regex: &DOCKER_FROM_UNTAGGED,
             severity: Severity::High,
             category: Category::DockerUnpinned,
             description: "FROM without tag — implicitly pulls :latest",
+            finding_kind: None,
         },
         Pattern {
             regex: &DOCKER_RUN_CURL,
             severity: Severity::Medium,
             category: Category::DockerUnpinned,
             description: "curl in Dockerfile RUN — check URL is versioned",
+            finding_kind: None,
         },
         Pattern {
             regex: &DOCKER_RUN_WGET,
             severity: Severity::Medium,
             category: Category::DockerUnpinned,
             description: "wget in Dockerfile RUN — check URL is versioned",
+            finding_kind: None,
         },
     ]
 });
@@ -343,6 +378,7 @@ pub static DOCKER_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
         severity: Severity::Medium,
         category: Category::DockerUnpinned,
         description: "Dockerfile ADD with URL source — build-time fetch bypasses pinning",
+        finding_kind: None,
     }]
 });
 
@@ -374,24 +410,28 @@ pub static PY_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::High,
             category: Category::PythonFetch,
             description: "urllib fetching from a 'latest' URL",
+            finding_kind: None,
         },
         Pattern {
             regex: &PY_REQUESTS_LATEST,
             severity: Severity::High,
             category: Category::PythonFetch,
             description: "requests library fetching from a 'latest' URL",
+            finding_kind: None,
         },
         Pattern {
             regex: &PY_SUBPROCESS_CURL,
             severity: Severity::High,
             category: Category::PythonFetch,
             description: "subprocess shelling out to curl — runtime fetch bypasses pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &PY_SUBPROCESS_WGET,
             severity: Severity::High,
             category: Category::PythonFetch,
             description: "subprocess shelling out to wget — runtime fetch bypasses pinning",
+            finding_kind: None,
         },
     ]
 });
@@ -403,12 +443,14 @@ pub static PY_URL_PATTERNS: LazyLock<Vec<Pattern>> = LazyLock::new(|| {
             severity: Severity::Medium,
             category: Category::PythonFetch,
             description: "urllib fetching external URL without version pinning",
+            finding_kind: None,
         },
         Pattern {
             regex: &PY_REQUESTS_URL,
             severity: Severity::Medium,
             category: Category::PythonFetch,
             description: "requests library fetching external URL without version pinning",
+            finding_kind: None,
         },
     ]
 });

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,7 +2,7 @@ use colored::Colorize;
 use serde::Serialize;
 use std::io::{self, Write};
 
-use crate::audit_patterns::{Category, Pattern, Severity, category_str};
+use crate::audit_patterns::{Category, FindingKind, Pattern, Severity, category_str};
 
 /// Replace control chars (C0/C1/DEL, except tab) with U+FFFD so escape sequences
 /// in fetched action source can't spoof or hide findings in the terminal.
@@ -227,6 +227,8 @@ pub struct AuditFinding {
     /// 1-based line number of the `uses:` line in `workflow_file`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workflow_line: Option<usize>,
+    #[serde(skip)]
+    pub(crate) finding_kind: Option<FindingKind>,
 }
 
 impl AuditFinding {
@@ -249,6 +251,7 @@ impl AuditFinding {
             description: description.into(),
             workflow_file: None,
             workflow_line: None,
+            finding_kind: None,
         }
     }
 
@@ -259,7 +262,7 @@ impl AuditFinding {
         line: usize,
         pattern_matched: &str,
     ) -> Self {
-        Self::new(
+        let mut finding = Self::new(
             &pattern.severity,
             &pattern.category,
             action_name,
@@ -267,7 +270,9 @@ impl AuditFinding {
             line,
             pattern_matched,
             pattern.description,
-        )
+        );
+        finding.finding_kind = pattern.finding_kind;
+        finding
     }
 }
 
@@ -803,6 +808,7 @@ mod sarif_tests {
             description: "unversioned curl".into(),
             workflow_file: None,
             workflow_line: None,
+            finding_kind: None,
         }
     }
 
@@ -826,6 +832,14 @@ mod sarif_tests {
         let doc = report(findings).build_sarif();
         let json = serde_json::to_string(&doc).unwrap();
         serde_json::from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn audit_finding_json_skips_internal_finding_kind() {
+        let mut finding = finding("high", "shell_fetch");
+        finding.finding_kind = Some(FindingKind::PipeToShell);
+        let json = serde_json::to_value(&finding).unwrap();
+        assert!(json.get("finding_kind").is_none());
     }
 
     #[test]

--- a/src/score.rs
+++ b/src/score.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use crate::audit::{self, AuditCollector};
+use crate::audit_patterns::FindingKind;
 use crate::auth;
 use crate::config::Config;
 use crate::github::{AdvisoryVulnerability, GitHubClient, GitHubError, SecurityAdvisory};
@@ -771,19 +772,10 @@ fn runtime_rule_for(finding: &AuditFinding) -> RuleId {
     }
 }
 
-/// Pipe-to-shell findings are identified by phrases unique to the four
-/// patterns in `SHELL_PIPE_PATTERNS` (piped to shell, process substitution,
-/// command substitution, Invoke-Expression). If those descriptions are ever
-/// changed, this mapping breaks — the `runtime_pipe_to_shell_descriptions_are_stable`
-/// test exists to catch that.
+/// Pipe-to-shell findings are structurally marked by the audit pattern table;
+/// descriptions are user-facing text and must not affect the score rule.
 fn is_pipe_to_shell_finding(finding: &AuditFinding) -> bool {
-    const MARKERS: &[&str] = &[
-        "piped to shell",
-        "process substitution",
-        "command substitution",
-        "Invoke-Expression on fetched content",
-    ];
-    MARKERS.iter().any(|m| finding.description.contains(m))
+    matches!(finding.finding_kind, Some(FindingKind::PipeToShell))
 }
 
 fn pin_rule_for(a: &ActionRef) -> Option<RuleId> {
@@ -1486,12 +1478,8 @@ jobs:
     }
 
     #[test]
-    fn runtime_pipe_to_shell_descriptions_are_stable() {
-        // If any of these descriptions change in audit_patterns.rs, the
-        // `is_pipe_to_shell_finding` mapping silently degrades — pipe-to-shell
-        // findings would get mapped to runtime.fetch.high (-15) instead of
-        // runtime.pipe_to_shell (-20). This test catches that.
-        use crate::audit_patterns::SHELL_PIPE_PATTERNS;
+    fn runtime_pipe_to_shell_uses_structured_finding_kind() {
+        use crate::audit_patterns::{FindingKind, SHELL_PIPE_PATTERNS};
         for pattern in SHELL_PIPE_PATTERNS.iter() {
             let fake = AuditFinding {
                 severity: "high".to_string(),
@@ -1500,16 +1488,38 @@ jobs:
                 source_file: String::new(),
                 line: Some(1),
                 pattern_matched: String::new(),
-                description: pattern.description.to_string(),
+                description: "copy-edit-safe pipe finding text".to_string(),
                 workflow_file: None,
                 workflow_line: None,
+                finding_kind: pattern.finding_kind,
             };
-            assert!(
-                is_pipe_to_shell_finding(&fake),
-                "pipe-to-shell description no longer matched by is_pipe_to_shell_finding: {:?}",
+            assert_eq!(
+                pattern.finding_kind.as_ref(),
+                Some(&FindingKind::PipeToShell),
+                "pipe-to-shell pattern missing structured finding kind: {:?}",
                 pattern.description
             );
+            assert!(
+                is_pipe_to_shell_finding(&fake),
+                "pipe-to-shell pattern did not set a structured finding kind: {:?}",
+                pattern.description
+            );
+            assert_eq!(runtime_rule_for(&fake), RuleId::RuntimePipeToShell);
         }
+
+        let phrase_only = AuditFinding {
+            severity: "high".to_string(),
+            category: "ShellFetch".to_string(),
+            action: String::new(),
+            source_file: String::new(),
+            line: Some(1),
+            pattern_matched: String::new(),
+            description: "fetch piped to shell but not structurally marked".to_string(),
+            workflow_file: None,
+            workflow_line: None,
+            finding_kind: None,
+        };
+        assert_eq!(runtime_rule_for(&phrase_only), RuleId::RuntimeFetchHigh);
     }
 
     #[test]


### PR DESCRIPTION
score.rs detected the -20 runtime.pipe_to_shell rule by matching four English phrases in user-facing finding descriptions, so a copy-edit to a pattern description could silently downgrade pipe-to-shell findings to runtime.fetch.high (-15). This adds an internal FindingKind marker on the audit pattern table, carries it on AuditFinding as a serde-skipped field, and matches on that instead. Descriptions are now free to change without affecting scores.

The four SHELL_PIPE_PATTERNS entries are the only marked patterns, and the field is mandatory on Pattern, so a future pattern cannot omit the decision. The old description-pinning guard test is replaced by one that asserts the structural mapping through runtime_rule_for, including that an unmarked finding whose description merely contains a pipe phrase maps to runtime.fetch.high.

Behavior-neutral and verified by measurement: binaries built from main and from this branch produce byte-identical output for --json, --json --verbose, --sarif, human, and score --json on a fixture covering all four pipe shapes (plain pipe, process substitution, command substitution, and PowerShell iex), each scoring runtime.pipe_to_shell identically. finding_kind never appears in JSON or SARIF output.