### PR TITLE
chore: release 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Release 0.20.0. Bumps the crate version in Cargo.toml and Cargo.lock ahead of dispatching release.yml.

This release ships the expanded runtime-fetch detection batch (#339): Docker CLI image pulls/runs, Deno URL execution, pipx/uv/uvx installs, PowerShell Start-BitsTransfer and WebClient.DownloadFile, and non-literal curl/wget executable downloads, plus bounded tag/release pagination and the 0.8.0 scoring rubric.