### PR TITLE
ci: gate --no-mac-metadata tar flag to macOS in release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,14 @@ jobs:
           mkdir -p staging
           cp "target/${TARGET}/release/pinprick" staging/
           cp LICENSE staging/
-          /usr/bin/tar --no-mac-metadata --no-xattrs -czf "${ARTIFACT}.tar.gz" -C staging .
+          # Keep AppleDouble/xattr metadata out of the tarball. --no-mac-metadata
+          # is a bsdtar-only flag (macOS); GNU tar on the Linux runners rejects it
+          # and only needs --no-xattrs, so gate it on the runner OS.
+          TAR_FLAGS=(--no-xattrs)
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            TAR_FLAGS+=(--no-mac-metadata)
+          fi
+          /usr/bin/tar "${TAR_FLAGS[@]}" -czf "${ARTIFACT}.tar.gz" -C staging .
           echo "ARTIFACT=${ARTIFACT}" >> "${GITHUB_ENV}"
 
       - name: Generate build provenance


### PR DESCRIPTION
The release Package step tars every build with `/usr/bin/tar --no-mac-metadata --no-xattrs`. `--no-mac-metadata` is a bsdtar-only flag, so GNU tar on the Linux runners rejects it and all four Linux builds fail at packaging while the darwin leg is fine. This surfaced on the first release dispatched since the flag was added in #330, because packaging is only exercised by release.yml.

Gate `--no-mac-metadata` behind `RUNNER_OS=macOS` and keep `--no-xattrs` on both legs (GNU tar 1.27+ and bsdtar both accept it). Verified both flag sets against bsdtar and GNU-tar semantics.

Unblocks the 0.20.0 release, which aborted cleanly at this step with nothing published.