### PR TITLE
docs: bump pinprick-action ref to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@834248de335b3a7c862e1c75b2c7a4dd7940c7d0 # v0.3.0
+        uses: starhaven-io/pinprick-action@5adca23b3098208cd4d19cd291abb3ae1c4cb432 # v0.4.0
 ```
 
 The action wraps `pinprick audit` only. Use the CLI directly for `pin`, `update`, and `score`. For console-mode pull request feedback, set `advanced-security: false`; see the action README for the full matrix.

--- a/site/src/content/docs/getting-started/github-action.md
+++ b/site/src/content/docs/getting-started/github-action.md
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@834248de335b3a7c862e1c75b2c7a4dd7940c7d0 # v0.3.0
+        uses: starhaven-io/pinprick-action@5adca23b3098208cd4d19cd291abb3ae1c4cb432 # v0.4.0
 ```
 
 ## Usage without GitHub Advanced Security
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@834248de335b3a7c862e1c75b2c7a4dd7940c7d0 # v0.3.0
+        uses: starhaven-io/pinprick-action@5adca23b3098208cd4d19cd291abb3ae1c4cb432 # v0.4.0
         with:
           advanced-security: false
 ```
@@ -83,7 +83,7 @@ Each example pins `pinprick-action` to a full commit SHA with the release tag in
 
 ```yaml
 - name: Run pinprick
-  uses: starhaven-io/pinprick-action@834248de335b3a7c862e1c75b2c7a4dd7940c7d0 # v0.3.0
+  uses: starhaven-io/pinprick-action@5adca23b3098208cd4d19cd291abb3ae1c4cb432 # v0.4.0
   with:
     fail-on-findings: true
 ```
@@ -92,7 +92,7 @@ Each example pins `pinprick-action` to a full commit SHA with the release tag in
 
 | Input               | Default  | Meaning                                                                                                                                                                              |
 | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `version`           | `0.19.0` | pinprick version to install. The `v0.3.0` action release pins this default for deterministic runs. Use `latest` for the newest pinprick release, or an exact version like `v0.19.0`. |
+| `version`           | `0.20.0` | pinprick version to install. The `v0.4.0` action release pins this default for deterministic runs. Use `latest` for the newest pinprick release, or an exact version like `v0.20.0`. |
 | `path`              | `.`      | Repository path to scan.                                                                                                                                                             |
 | `advanced-security` | `true`   | Upload SARIF results to GitHub code scanning. When `false`, the action prints normal console output.                                                                                 |
 | `fail-on-findings`  | `false`  | Fail the workflow when `pinprick audit` reports findings. Without this, findings are emitted as a warning and the workflow continues.                                                |


### PR DESCRIPTION
Points the README and site github-action docs at the new pinprick-action v0.4.0 release (commit 5adca23), which defaults to pinprick 0.20.0. Updates the four `uses:` example refs and the inputs-table version mentions (0.19.0 to 0.20.0, v0.3.0 to v0.4.0).