### PR TITLE
chore: parity pass v2

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,4 +15,9 @@ if [ "$deleting_only" -eq 1 ]; then
     exit 0
 fi
 
+if ! command -v just >/dev/null 2>&1; then
+    echo "pre-push hook: 'just' is required. Install it with 'brew install just'." >&2
+    exit 127
+fi
+
 just check

--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -33,6 +33,7 @@ jobs:
   scan:
     name: Scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -191,6 +192,7 @@ jobs:
     needs: scan
     if: needs.scan.outputs.updated == '1'
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     environment:
       name: starhaven
       deployment: false

--- a/.github/workflows/bump-cargo-tools.yml
+++ b/.github/workflows/bump-cargo-tools.yml
@@ -19,6 +19,7 @@ jobs:
   scan:
     name: Scan
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:
@@ -83,6 +84,7 @@ jobs:
     needs: scan
     if: needs.scan.outputs.changed == '1'
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     environment:
       name: starhaven
       deployment: false

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -29,6 +29,7 @@ jobs:
   deny:
     name: Check
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: read
       issues: write # open/close the tracking issue when the scan flips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   generate-matrix:
     name: Generate matrix
     runs-on: ubuntu-slim
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
@@ -93,6 +94,7 @@ jobs:
     name: ${{ matrix.name }}
     needs: generate-matrix
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     environment:
       name: ${{ matrix.environment }}
       deployment: false
@@ -109,7 +111,6 @@ jobs:
           fetch-depth: ${{ matrix.fetch_depth || 1 }}
           persist-credentials: false
 
-      # --- Cargo caches ---
 
       - name: Restore cargo build cache
         id: cargo-build-cache
@@ -149,7 +150,6 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-
 
-      # --- Conventional Commits ---
 
       - name: Check PR title
         if: matrix.check == 'commits'
@@ -198,7 +198,6 @@ jobs:
             exit 1
           fi
 
-      # --- Lint ---
 
       - name: Add Clippy and Rustfmt
         if: matrix.check == 'lint'
@@ -206,7 +205,7 @@ jobs:
 
       - name: Install typos-cli
         if: matrix.check == 'lint'
-        run: cargo install typos-cli --locked --version 1.47.2
+        run: cargo install typos-cli --locked --version 1.48.0
 
       - name: Install cargo-deny
         if: matrix.check == 'lint'
@@ -250,13 +249,11 @@ jobs:
             ~/.cargo/.crates2.json
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-tools-${{ hashFiles('.github/workflows/ci.yml') }}
 
-      # --- Test ---
 
       - name: Test
         if: matrix.check == 'test'
         run: cargo test --locked
 
-      # --- MSRV ---
 
       - name: Install MSRV toolchain
         if: matrix.check == 'msrv'
@@ -271,7 +268,6 @@ jobs:
         if: matrix.check == 'msrv'
         run: cargo "+${MSRV}" check --locked --all-targets
 
-      # --- Coverage ---
 
       - name: Add llvm-tools
         if: matrix.check == 'coverage'
@@ -317,7 +313,6 @@ jobs:
             ~/.cargo/.crates2.json
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-cov-tools-${{ hashFiles('.github/workflows/ci.yml') }}
 
-      # --- Site ---
 
       - name: Setup Node
         if: matrix.check == 'site'
@@ -348,7 +343,6 @@ jobs:
         env:
           WRANGLER_SEND_METRICS: "false"
 
-      # --- Verify Audited Actions ---
 
       - name: Check sort order
         if: matrix.check == 'verify-audited'
@@ -410,6 +404,7 @@ jobs:
     needs: generate-matrix
     if: needs.generate-matrix.outputs.run_zizmor == 'true'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write # required for zizmor SARIF upload
@@ -427,6 +422,7 @@ jobs:
     name: conclusion
     needs: [check, zizmor]
     runs-on: ubuntu-slim
+    timeout-minutes: 15
     if: always()
     steps:
       - name: Result

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-slim
+    timeout-minutes: 30
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -24,6 +24,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-slim
+    timeout-minutes: 60
     permissions:
       contents: read # required to checkout repository
     environment: cloudflare

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -19,6 +19,7 @@ jobs:
   lychee:
     name: Check links
     runs-on: ubuntu-slim
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pinprick-audit.yml
+++ b/.github/workflows/pinprick-audit.yml
@@ -28,6 +28,7 @@ jobs:
   audit:
     name: Audit
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
     # skips the whole chain via `needs`.
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -94,6 +95,7 @@ jobs:
             runner: macos-26
             sign: true
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     permissions:
       contents: read
       attestations: write # required to generate build provenance attestations
@@ -237,6 +239,7 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-slim
+    timeout-minutes: 60
     permissions:
       contents: write # required to create tags and GitHub releases
     outputs:
@@ -307,6 +310,7 @@ jobs:
     name: Publish to crates.io
     needs: release
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     environment:
       name: release
       deployment: false
@@ -334,6 +338,7 @@ jobs:
     name: Bump Homebrew cask
     needs: release
     runs-on: macos-26
+    timeout-minutes: 60
     environment:
       name: release
       deployment: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,6 +17,7 @@ jobs:
   zizmor:
     name: Analyze
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write # required to upload SARIF results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,15 +148,15 @@ Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name
 
 ## Commit and PR conventions
 
-- Conventional Commits format: `type(scope): description`
-
-- Common types: `feat`, `fix`, `refactor`, `docs`, `ci`, `chore`
-
-- Sign off every commit with `git commit -s` for DCO (enforced by the `.githooks/commit-msg` hook — run `just install-hooks` once per clone to enable it).
-- When authored with an AI coding agent, add a `Co-Authored-By` trailer after `Signed-off-by`, naming the agent and model. Current examples: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` or `Co-Authored-By: Codex GPT-5 <noreply@openai.com>`. Bump the model version as newer ones ship.
-
-### Git workflow
-
+- Conventional Commits: `type(scope): description`. Valid types: `feat`,
+  `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`.
+- Sign off every commit with `git commit -s` for DCO (enforced by the
+  `.githooks/commit-msg` hook; run `just install-hooks` once per clone to
+  enable it).
+- When authored with an AI coding agent, add a `Co-Authored-By` trailer after
+  `Signed-off-by`, naming the agent and model. Current example:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`. Bump the model
+  version as newer ones ship.
 - Never commit directly to `main`; create a feature branch and open a PR.
 - PR descriptions should contain only a concise summary of changes. Do not add
   test-plan sections, bot attribution, or generated-with footers.


### PR DESCRIPTION
Parity pass v2 packaging. Adopts the byte-identical org conventions block in AGENTS.md, the canonical pre-push hook (deletion-only-push skip plus missing-just guard), bounds job runtimes with generous timeout-minutes, and trims comments that restate the code. Also bumps the cargo-installed typos-cli pin to 1.48.0.