### PR TITLE
docs: make the fleet exception citations self-contained

### DIFF
--- a/.fleet.yml
+++ b/.fleet.yml
@@ -32,5 +32,5 @@ params:
       extra: []
     license: {}
 exceptions:
-  pinprick-audit: "build-from-source: audits the local checkout (GRAND_PARITY_PASS.md P0.2)"
-  pinprick-audit-recipe: "build-from-source: audits the local checkout (GRAND_PARITY_PASS.md P0.2)"
+  pinprick-audit: "build-from-source: audits the local checkout"
+  pinprick-audit-recipe: "build-from-source: audits the local checkout"


### PR DESCRIPTION
The build-from-source exception citations referenced a planning document that never lived in any repository; the rationale stands on its own.