### PR TITLE
fix(ci): resolve link-check root-dir relative to the workspace

### DIFF
--- a/.fleet.yml
+++ b/.fleet.yml
@@ -15,7 +15,7 @@ params:
       group: "npm-dependencies"
       directory: "/site"
   link-check:
-    targets: "--config lychee.toml --root-dir ${{ github.workspace }}/site/dist/client './site/dist/client/**/*.html' README.md"
+    targets: "--config lychee.toml --root-dir site/dist/client './site/dist/client/**/*.html' README.md"
     build-site: true
     site-directory: "site"
     authenticated-github: false

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     uses: starhaven-io/.github/.github/workflows/reusable-link-check.yml@989b76e2b1ceaf3531da903e288e79929bd2f30e # v2026.07.05.10
     with:
-      args: "--config lychee.toml --root-dir ${{ github.workspace }}/site/dist/client './site/dist/client/**/*.html' README.md"
+      args: "--config lychee.toml --root-dir site/dist/client './site/dist/client/**/*.html' README.md"
       build-site: true
       site-directory: "site"
       authenticated-github: false


### PR DESCRIPTION
`github.workspace` is empty when evaluated in a reusable-workflow caller's `with:`, so `--root-dir ${{ github.workspace }}/…/dist/client` collapsed to a bare absolute path that does not exist, and lychee (v0.23.0, the default baked into lychee-action v2.8.0) aborts with `Invalid root directory`. A workspace-relative `--root-dir` resolves from the working directory to the built site.

One of three sibling consumer fixes for the same fleet-rendered pattern.
