### PR TITLE
chore: release 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.20.1"
+version = "0.21.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the crate to `0.21.0`.

Headline change since `0.20.1`: the `source.unverified` scoring rule and its `trusted-owners` config key are removed (rubric `0.9.0`). `pinprick score` no longer emits the publisher note, and `trusted-owners` is no longer a recognized config field.

Merging this dispatches `release.yml` to tag `v0.21.0`, build the release assets, publish to crates.io, and open the Homebrew cask bump.
