### PR TITLE
ci(release): enable auto-merge on Homebrew cask bump PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,14 +359,32 @@ jobs:
 
       - name: Bump Homebrew cask
         env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ steps.tap-token.outputs.token }}
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_ENV_HINTS: 1
           APP_SLUG: ${{ steps.tap-token.outputs.app-slug }}
         run: |
           BOT_USER="${APP_SLUG}[bot]"
-          BOT_ID=$(GH_TOKEN="${HOMEBREW_GITHUB_API_TOKEN}" gh api "/users/${BOT_USER}" --jq .id)
+          BOT_ID=$(gh api "/users/${BOT_USER}" --jq .id)
           export HOMEBREW_GIT_NAME="${BOT_USER}"
           export HOMEBREW_GIT_EMAIL="${BOT_ID}+${BOT_USER}@users.noreply.github.com"
-          brew tap starhaven-io/homebrew-tap
+          brew tap starhaven-io/tap
+          brew trust starhaven-io/tap
           brew bump-cask-pr --no-fork --version "${VERSION}" starhaven-io/tap/pinprick
+
+          BRANCH_VERSION="${VERSION//,/-}"
+          BRANCH_VERSION="${BRANCH_VERSION//:/-}"
+          BRANCH="bump-pinprick-${BRANCH_VERSION}"
+          PR_NUMBER=$(gh pr list \
+            --repo starhaven-io/homebrew-tap \
+            --head "${BRANCH}" \
+            --state open \
+            --json number,headRepositoryOwner \
+            --jq 'map(select(.headRepositoryOwner.login == "starhaven-io")) | .[0].number // ""' || true)
+          if [ -n "${PR_NUMBER}" ]; then
+            gh pr merge "${PR_NUMBER}" --repo starhaven-io/homebrew-tap --auto --squash \
+              || echo "::warning::could not enable auto-merge for starhaven-io/homebrew-tap#${PR_NUMBER}"
+          else
+            echo "::warning::could not find open Homebrew cask bump PR for ${BRANCH}"
+          fi


### PR DESCRIPTION
The release workflow's cask bump job now enables GitHub auto-merge on the pull request that `brew bump-cask-pr` opens against `starhaven-io/homebrew-tap`, so the bump lands once the tap's required checks pass rather than waiting for a manual merge.

The PR is resolved by the branch brew derives (`bump-<cask>-<version>`, with `,` and `:` mapped to `-`) and filtered on the head-repo owner so a same-named branch on a fork cannot be selected. The lookup and the auto-merge enable are both best-effort: the release has already published its artifacts, so a failure only emits a warning.

This also normalizes the tap step to `brew tap starhaven-io/tap` plus `brew trust` to match the other release workflows.
