### PR TITLE
fix(audit): cover subpath actions with repository-level verdicts

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -160,17 +160,28 @@ jobs:
                 - uses: ${OWNER}/${REPO}@${TAG_SHA} # ${TAG}
           YAML
 
-              if ./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null; then
-                echo "  Clean — adding ${TAG}"
-                jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
-                  (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end)
-                  | sort_by([(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)), .tag]) | reverse
-                  | "[\n" + ([.[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
-                ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
-                mv "${JSON_FILE}.tmp" "${JSON_FILE}"
-                UPDATED=1
-              else
+              AUDIT_STATUS=0
+              AUDIT_JSON=$(./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null) || AUDIT_STATUS=$?
+              if [[ "${AUDIT_STATUS}" -eq 0 ]]; then
+                if jq -e '
+                  (.audited_bundled + .audited_local_cache + .audited_remote + .scanned_fresh) == 1
+                  and .ignored == 0
+                ' <<< "${AUDIT_JSON}" > /dev/null; then
+                  echo "  Clean — adding ${TAG}"
+                  jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
+                    (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end)
+                    | sort_by([(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)), .tag]) | reverse
+                    | "[\n" + ([.[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
+                  ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
+                  mv "${JSON_FILE}.tmp" "${JSON_FILE}"
+                  UPDATED=1
+                else
+                  echo "  Incomplete scan — skipping ${TAG}"
+                fi
+              elif [[ "${AUDIT_STATUS}" -eq 1 ]]; then
                 echo "  Findings detected — skipping ${TAG}"
+              else
+                echo "  Audit failed (exit ${AUDIT_STATUS}) — skipping ${TAG}"
               fi
               rm -rf "${TMPDIR}"
             done

--- a/site/src/content/docs/configuration/audited-actions.md
+++ b/site/src/content/docs/configuration/audited-actions.md
@@ -28,6 +28,8 @@ Each SHA was scanned for **unversioned runtime fetch patterns**. Specifically:
 - Python: `urllib.request.urlopen`/`requests.get` to `/latest/` or unversioned URLs, `subprocess` shelling out to `curl`/`wget`
 - Docker: `FROM :latest` or untagged, `curl`/`wget` in `RUN` instructions, and remote `ADD` sources
 
+A clean repository-level audit also covers actions exposed from subpaths at the same SHA. A clean subpath audit applies only to that subpath, not to sibling actions or the repository as a whole.
+
 ## What "audited" does NOT mean
 
 This is not a full security review. An action listed as audited may still:

--- a/src/audit_source.rs
+++ b/src/audit_source.rs
@@ -92,13 +92,21 @@ fn select_source_files(
                 .unwrap_or(path)
                 .trim_start_matches('/')
         };
-        let kind = if relative == "action.yml" || relative == "action.yaml" {
+        let filename = path.rsplit('/').next().unwrap_or(path);
+        let whole_repo = base.is_empty();
+        let kind = if relative == "action.yml"
+            || relative == "action.yaml"
+            || whole_repo && matches!(filename, "action.yml" | "action.yaml")
+        {
             SourceFileKind::ActionYml
         } else if is_javascript_source(path) {
             SourceFileKind::JavaScript
         } else if path.ends_with(".py") {
             SourceFileKind::Python
-        } else if relative == "Dockerfile" || path.ends_with(".dockerfile") {
+        } else if relative == "Dockerfile"
+            || whole_repo && filename == "Dockerfile"
+            || path.ends_with(".dockerfile")
+        {
             SourceFileKind::Dockerfile
         } else {
             continue;
@@ -109,28 +117,28 @@ fn select_source_files(
 }
 
 fn force_include_remote_action_entrypoints(
-    base: &str,
     targets: &mut Vec<(String, SourceFileKind)>,
     contents: &[Option<Result<String>>],
 ) {
-    let metadata: Vec<String> = targets
+    let metadata: Vec<(String, String)> = targets
         .iter()
         .zip(contents)
-        .filter_map(|((_, kind), content)| {
+        .filter_map(|((path, kind), content)| {
             if *kind != SourceFileKind::ActionYml {
                 return None;
             }
             let Some(Ok(content)) = content.as_ref() else {
                 return None;
             };
-            Some(content.clone())
+            Some((path.clone(), content.clone()))
         })
         .collect();
 
-    for content in metadata {
+    for (path, content) in metadata {
         let Ok(yaml) = serde_norway::from_str::<Value>(&content) else {
             continue;
         };
+        let base = path.rsplit_once('/').map_or("", |(base, _)| base);
         for entrypoint in action_yml_entrypoint_paths(&yaml, base) {
             push_unique_source_target(targets, entrypoint, SourceFileKind::JavaScript);
         }
@@ -427,7 +435,7 @@ pub(crate) async fn scan_action_source(
     // makes the scan incomplete, so the caller will not cache a clean verdict.
     let (mut contents, mut complete) = fetch_remote_source_files(client, action, &targets).await;
     let initial_len = targets.len();
-    force_include_remote_action_entrypoints(base, &mut targets, &contents);
+    force_include_remote_action_entrypoints(&mut targets, &contents);
     if targets.len() > initial_len {
         let (new_contents, new_complete) =
             fetch_remote_source_files(client, action, &targets[initial_len..]).await;
@@ -687,12 +695,14 @@ runs:
     fn select_source_files_classifies_and_filters_in_order() {
         let tree = vec![
             tree_entry("action.yml", "blob"),
+            tree_entry("sub/action.yaml", "blob"),
             tree_entry("dist/index.js", "blob"), // bundled action code — kept
             tree_entry("dist/index.mjs", "blob"),
             tree_entry("src/main.cjs", "blob"),
             tree_entry("src/main.ts", "blob"),
             tree_entry("setup.py", "blob"),
             tree_entry("Dockerfile", "blob"),
+            tree_entry("sub/Dockerfile", "blob"),
             tree_entry("README.md", "blob"), // not scannable
             tree_entry("node_modules/dep/i.js", "blob"), // vendored — skipped
             tree_entry("src", "tree"),       // directory entry — skipped
@@ -702,12 +712,14 @@ runs:
             got,
             vec![
                 ("action.yml".to_string(), SourceFileKind::ActionYml),
+                ("sub/action.yaml".to_string(), SourceFileKind::ActionYml),
                 ("dist/index.js".to_string(), SourceFileKind::JavaScript),
                 ("dist/index.mjs".to_string(), SourceFileKind::JavaScript),
                 ("src/main.cjs".to_string(), SourceFileKind::JavaScript),
                 ("src/main.ts".to_string(), SourceFileKind::JavaScript),
                 ("setup.py".to_string(), SourceFileKind::Python),
                 ("Dockerfile".to_string(), SourceFileKind::Dockerfile),
+                ("sub/Dockerfile".to_string(), SourceFileKind::Dockerfile),
             ]
         );
     }
@@ -1026,5 +1038,64 @@ runs:
         assert_eq!(status, ActionScanStatus::Complete);
         assert_eq!(collector.findings.len(), 1);
         assert_eq!(collector.findings[0].source_file, "o/r (dist/runner)");
+    }
+
+    #[tokio::test]
+    async fn repo_scan_includes_subpath_metadata_entrypoint() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/o/r/git/trees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tree": [
+                    { "path": "sub/action.yml", "type": "blob" },
+                    { "path": "sub/runner", "type": "blob" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/contents/sub/action.yml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("runs:\n  using: node20\n  main: runner\n"),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/contents/sub/runner"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"fetch("https://example.com/install")"#),
+            )
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base("t".into(), server.uri());
+        let action = ActionRef {
+            owner: "o".into(),
+            repo: "r".into(),
+            subpath: None,
+            ref_string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            ref_type: workflow::RefType::Sha,
+            tag_comment: Some("v1.0.0".into()),
+            line_number: 1,
+            raw_line: String::new(),
+        };
+        let mut collector = AuditCollector::new(false);
+
+        let status = scan_action_source(&client, &action, &mut collector, &DEFAULT_CONFIG)
+            .await
+            .unwrap();
+
+        assert_eq!(status, ActionScanStatus::Complete);
+        assert_eq!(collector.findings.len(), 1);
+        assert_eq!(collector.findings[0].source_file, "o/r (sub/runner)");
     }
 }

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -100,31 +100,34 @@ impl AuditedActions {
         subpath: Option<&str>,
         sha: &str,
     ) -> Option<AuditSource> {
-        let key = action_key(owner, repo, subpath)?;
+        let keys = action_keys(owner, repo, subpath)?;
 
-        if self
-            .bundled
-            .get(&key)
-            .is_some_and(|shas| shas.contains(sha))
+        if keys
+            .iter()
+            .any(|key| self.bundled.get(key).is_some_and(|shas| shas.contains(sha)))
         {
             return Some(AuditSource::Bundled);
         }
 
-        if !self.local.contains_key(&key) {
-            let shas = self.load_local_cache(owner, repo, &key);
-            self.local.insert(key.clone(), shas);
-        }
-        if self.local.get(&key).is_some_and(|shas| shas.contains(sha)) {
-            return Some(AuditSource::LocalCache);
+        for key in &keys {
+            if !self.local.contains_key(key) {
+                let shas = self.load_local_cache(owner, repo, key);
+                self.local.insert(key.clone(), shas);
+            }
+            if self.local.get(key).is_some_and(|shas| shas.contains(sha)) {
+                return Some(AuditSource::LocalCache);
+            }
         }
 
         if self.fetch_remote {
-            if !self.remote.contains_key(&key) {
-                let shas = self.fetch_remote_list(&key).await.unwrap_or_default();
-                self.remote.insert(key.clone(), shas);
-            }
-            if self.remote.get(&key).is_some_and(|shas| shas.contains(sha)) {
-                return Some(AuditSource::Remote);
+            for key in &keys {
+                if !self.remote.contains_key(key) {
+                    let shas = self.fetch_remote_list(key).await.unwrap_or_default();
+                    self.remote.insert(key.clone(), shas);
+                }
+                if self.remote.get(key).is_some_and(|shas| shas.contains(sha)) {
+                    return Some(AuditSource::Remote);
+                }
             }
         }
 
@@ -353,6 +356,17 @@ fn action_key(owner: &str, repo: &str, subpath: Option<&str>) -> Option<String> 
     }
 }
 
+/// A repository-level clean verdict covers every action at that commit, while
+/// a subpath verdict covers only that subpath. Keep the fallback one-way so a
+/// clean sibling action can never suppress scanning another sibling.
+fn action_keys(owner: &str, repo: &str, subpath: Option<&str>) -> Option<Vec<String>> {
+    let exact = action_key(owner, repo, subpath)?;
+    match subpath {
+        Some(_) => Some(vec![action_key(owner, repo, None)?, exact]),
+        None => Some(vec![exact]),
+    }
+}
+
 fn is_safe_subpath(path: &str) -> bool {
     !path.is_empty() && path.split('/').all(is_safe_segment)
 }
@@ -391,6 +405,63 @@ mod tests {
         }
         assert_eq!(action_key("owner/name", "repo", Some("a")), None);
         assert_eq!(action_key("owner", "repo/name", Some("a")), None);
+    }
+
+    #[test]
+    fn subpath_lookup_uses_parent_then_exact_identity() {
+        assert_eq!(
+            action_keys("owner", "repo", Some("a/b")),
+            Some(vec!["owner/repo".to_string(), "owner/repo/a/b".to_string()])
+        );
+        assert_eq!(
+            action_keys("owner", "repo", None),
+            Some(vec!["owner/repo".to_string()])
+        );
+        assert_eq!(action_keys("owner", "repo", Some("../a")), None);
+    }
+
+    #[tokio::test]
+    async fn parent_bundled_verdict_covers_subpath() {
+        let mut aa = AuditedActions::new(false);
+        aa.bundled.clear();
+        aa.bundled
+            .insert("owner/repo".to_string(), HashSet::from(["aaa".to_string()]));
+        aa.cache_dir = None;
+
+        assert_eq!(
+            aa.check("owner", "repo", Some("restore"), "aaa").await,
+            Some(AuditSource::Bundled)
+        );
+    }
+
+    #[tokio::test]
+    async fn sibling_bundled_verdict_does_not_cover_subpath() {
+        let mut aa = AuditedActions::new(false);
+        aa.bundled.clear();
+        aa.bundled.insert(
+            "owner/repo/save".to_string(),
+            HashSet::from(["aaa".to_string()]),
+        );
+        aa.cache_dir = None;
+
+        assert_eq!(
+            aa.check("owner", "repo", Some("restore"), "aaa").await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn parent_local_cache_verdict_covers_subpath() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut aa = AuditedActions::new(false);
+        aa.bundled.clear();
+        aa.cache_dir = Some(dir.path().to_path_buf());
+        aa.cache_clean("owner", "repo", None, "aaa", "v1");
+
+        assert_eq!(
+            aa.check("owner", "repo", Some("restore"), "aaa").await,
+            Some(AuditSource::LocalCache)
+        );
     }
 
     #[test]
@@ -788,6 +859,26 @@ mod tests {
             );
             assert_eq!(
                 aa.check("some", "action", Some("a"), "feedface").await,
+                Some(AuditSource::Remote)
+            );
+        }
+
+        #[tokio::test]
+        async fn parent_remote_verdict_covers_subpath() {
+            let (key, sign) = test_identity();
+            let body = serde_json::to_string(&json!([{ "sha": "feedface", "tag": "v3" }])).unwrap();
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "some/action", &body, &sign(body.as_bytes())).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.bundled.clear();
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            aa.cache_dir = None;
+
+            assert_eq!(
+                aa.check("some", "action", Some("sub"), "feedface").await,
                 Some(AuditSource::Remote)
             );
         }

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -26,6 +26,35 @@ fn clean_workflow_human_output() {
 }
 
 #[test]
+fn bundled_parent_audit_covers_action_subpaths() {
+    let workflow = "\
+name: cache
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+
+    common::pinprick_cmd()
+        .env("GITHUB_TOKEN", "dummy")
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "actions/cache/restore@55cc834 audited (bundled)",
+        ))
+        .stderr(predicate::str::contains(
+            "actions/cache/save@55cc834 audited (bundled)",
+        ))
+        .stderr(predicate::str::contains("Fetching actions/cache").not());
+}
+
+#[test]
 fn human_output_sanitizes_terminal_escapes() {
     // A matched run-block line carrying an ANSI escape must not reach the
     // terminal verbatim — otherwise a hostile action could spoof or hide a


### PR DESCRIPTION
Repository-level audited-action verdicts now cover subpath actions at the same commit, so `actions/cache/restore` and `actions/cache/save` resolve against the bundled `actions/cache` entry instead of re-fetching the whole repository. The fallback is strictly one-way: `owner/repo` covers `owner/repo/subpath`, never the reverse and never sibling-to-sibling, so a clean sibling can never suppress scanning another and unsafe or malformed subpaths still fail closed.

To keep that fallback sound, a whole-repo scan now classifies nested `action.yml`/`action.yaml` and `Dockerfile` files by basename and resolves each action's `main`/`pre`/`post` entrypoints relative to its own directory, so extensionless subpath entrypoints are fetched and scanned rather than misresolved to the repository root.

The audit-actions workflow now records a catalog entry only when a single action resolves through a complete, clean scan; incomplete scans and non-zero audit exits are skipped, keeping catalog generation fail-closed.
