### PR TITLE
docs(security): add security policy and email contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately by emailing
+[security@pinprick.rs](mailto:security@pinprick.rs) or using
+[GitHub's private vulnerability reporting](https://github.com/starhaven-io/pinprick/security/advisories/new).
+Do not open a public issue for an undisclosed vulnerability.
+
+Include the affected component, version, or commit; reproduction steps; potential
+impact; and any suggested mitigation. We will acknowledge the report,
+investigate it, and coordinate disclosure with you.
+
+Reports about unsafe runtime fetches performed by third-party GitHub Actions
+should normally be sent to that action's maintainer; report them here when
+pinprick fails to detect or accurately describe the behavior.
+
+## Supported versions
+
+Only the latest released version of pinprick is supported with security fixes.

--- a/site/src/pages/.well-known/security.txt.ts
+++ b/site/src/pages/.well-known/security.txt.ts
@@ -6,14 +6,18 @@ const getSecurityTxt = (canonicalURL: URL) => {
   expires.setUTCFullYear(expires.getUTCFullYear() + 1);
   expires.setUTCHours(0, 0, 0, 0);
 
-  return `Contact: https://github.com/starhaven-io/pinprick/security/advisories/new
+  return `Contact: mailto:security@pinprick.rs
+Contact: https://github.com/starhaven-io/pinprick/security/advisories/new
 Expires: ${expires.toISOString()}
 Preferred-Languages: en
 Canonical: ${canonicalURL.href}
+Policy: https://github.com/starhaven-io/pinprick/security/policy
 `;
 };
 
 export const GET: APIRoute = ({ site }) => {
   const canonicalURL = new URL('.well-known/security.txt', site);
-  return new Response(getSecurityTxt(canonicalURL));
+  return new Response(getSecurityTxt(canonicalURL), {
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+  });
 };


### PR DESCRIPTION
Add a repository security policy and list mailto:security@pinprick.rs in .well-known/security.txt alongside GitHub private reporting. The endpoint also gains a Policy field and returns text/plain; charset=utf-8.