### PR TITLE
fix(audit): harden source scanning against hostile inputs

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -635,16 +635,30 @@ pub fn scan_shell_content(
             ));
         }
 
-        if fetches_non_literal_executable(line, config) {
-            collector.push_finding(AuditFinding::new(
-                &audit_patterns::Severity::Low,
-                &audit_patterns::Category::ShellFetch,
-                action_name,
-                source_file,
-                line_num,
-                line,
-                "curl/wget downloads executable from non-literal source — cannot verify URL version",
-            ));
+        match classify_non_literal_executable(line, config) {
+            NonLiteralFetch::Finding => {
+                collector.push_finding(AuditFinding::new(
+                    &audit_patterns::Severity::Low,
+                    &audit_patterns::Category::ShellFetch,
+                    action_name,
+                    source_file,
+                    line_num,
+                    line,
+                    "curl/wget downloads executable from non-literal source — cannot verify URL version",
+                ));
+            }
+            NonLiteralFetch::ExtraDataFormat => {
+                collector.push_allowed(AuditMatch::new(
+                    &audit_patterns::Severity::Low,
+                    &audit_patterns::Category::ShellFetch,
+                    action_name,
+                    source_file,
+                    line_num,
+                    line,
+                    REASON_EXTRA_DATA_FORMAT,
+                ));
+            }
+            NonLiteralFetch::None => {}
         }
 
         if SH_GIT_CLONE.is_match(line) && !git_clone_has_pinned_ref(line) {
@@ -920,13 +934,32 @@ pub(crate) fn scan_dockerfile_content(
     }
 }
 
-fn fetches_non_literal_executable(line: &str, config: &Config) -> bool {
+enum NonLiteralFetch {
+    None,
+    Finding,
+    ExtraDataFormat,
+}
+
+fn classify_non_literal_executable(line: &str, config: &Config) -> NonLiteralFetch {
     if extract_urls(line).next().is_some() || !line.contains('$') {
-        return false;
+        return NonLiteralFetch::None;
     }
-    fetch_output_targets(line).into_iter().any(|target| {
-        !target.contains('$') && target != "/dev/null" && !config.is_data_format_exempt(&target)
-    })
+    let mut extra_data_format = false;
+    for target in fetch_output_targets(line) {
+        if target.contains('$') || target == "/dev/null" {
+            continue;
+        }
+        if config.is_extra_data_format_exempt(&target) {
+            extra_data_format = true;
+        } else if !config.is_data_format_exempt(&target) {
+            return NonLiteralFetch::Finding;
+        }
+    }
+    if extra_data_format {
+        NonLiteralFetch::ExtraDataFormat
+    } else {
+        NonLiteralFetch::None
+    }
 }
 
 fn push_pkg_finding(
@@ -1498,6 +1531,7 @@ docker run "${{ matrix.image }}" echo hi"#,
             &DEFAULT_CONFIG,
         );
         assert!(c.findings.is_empty());
+        assert_eq!(c.extra_data_format_allowed, 0);
     }
 
     #[test]

--- a/src/audit_source.rs
+++ b/src/audit_source.rs
@@ -8,6 +8,7 @@
 
 use anyhow::{Context, Result};
 use serde_norway::Value;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -146,6 +147,7 @@ fn force_include_remote_action_entrypoints(
 }
 
 fn force_include_local_action_entrypoints(
+    repo_root: &Path,
     action_dir: &Path,
     targets: &mut Vec<(PathBuf, SourceFileKind)>,
 ) {
@@ -155,7 +157,7 @@ fn force_include_local_action_entrypoints(
         .collect();
 
     for path in metadata_paths {
-        let Ok(content) = std::fs::read_to_string(&path) else {
+        let Ok(Some(content)) = read_local_source_file(repo_root, &path) else {
             continue;
         };
         let Ok(yaml) = serde_norway::from_str::<Value>(&content) else {
@@ -163,7 +165,13 @@ fn force_include_local_action_entrypoints(
         };
         for entrypoint in action_yml_entrypoint_paths(&yaml, "") {
             let path = action_dir.join(&entrypoint);
-            if local_entrypoint_is_regular_file(&path) {
+            let Some(relative) = path.strip_prefix(repo_root).ok() else {
+                continue;
+            };
+            if matches!(
+                workflow::open_child_file_path(repo_root, relative),
+                Ok(Some(_))
+            ) {
                 push_unique_local_source_target(targets, path, SourceFileKind::JavaScript);
             }
         }
@@ -232,10 +240,17 @@ fn push_unique_local_source_target(
     }
 }
 
-fn local_entrypoint_is_regular_file(path: &Path) -> bool {
-    std::fs::symlink_metadata(path)
-        .map(|metadata| metadata.file_type().is_file())
-        .unwrap_or_default()
+fn read_local_source_file(repo_root: &Path, path: &Path) -> Result<Option<String>> {
+    let relative = path
+        .strip_prefix(repo_root)
+        .with_context(|| format!("{} is outside the repository", path.display()))?;
+    let Some(mut file) = workflow::open_child_file_path(repo_root, relative)? else {
+        return Ok(None);
+    };
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .with_context(|| format!("reading {}", path.display()))?;
+    Ok(Some(content))
 }
 
 async fn fetch_remote_source_files(
@@ -369,16 +384,16 @@ pub(crate) fn scan_local_action_source(
 ) -> Result<ActionScanStatus> {
     let action_dir = local_action_dir(repo_root, action)?;
     let mut targets = collect_local_source_files(&action_dir)?;
-    force_include_local_action_entrypoints(&action_dir, &mut targets);
+    force_include_local_action_entrypoints(repo_root, &action_dir, &mut targets);
     if targets.is_empty() {
         return Ok(ActionScanStatus::Complete);
     }
 
     let mut complete = true;
     for (path, kind) in targets {
-        let content = match std::fs::read_to_string(&path) {
-            Ok(content) => content,
-            Err(_) => {
+        let content = match read_local_source_file(repo_root, &path) {
+            Ok(Some(content)) => content,
+            Ok(None) | Err(_) => {
                 complete = false;
                 continue;
             }
@@ -425,15 +440,16 @@ pub(crate) async fn scan_action_source(
         .await?;
 
     let base = action.subpath.as_deref().unwrap_or("");
-    let mut targets = select_source_files(&tree, base);
+    let mut targets = select_source_files(&tree.entries, base);
     if targets.is_empty() {
-        return Ok(ActionScanStatus::Complete);
+        return Ok(ActionScanStatus::from_complete(!tree.truncated));
     }
 
     // Fetch concurrently, then scan in tree order so findings are
     // deterministic regardless of which fetch lands first. A failed fetch
     // makes the scan incomplete, so the caller will not cache a clean verdict.
     let (mut contents, mut complete) = fetch_remote_source_files(client, action, &targets).await;
+    complete &= !tree.truncated;
     let initial_len = targets.len();
     force_include_remote_action_entrypoints(&mut targets, &contents);
     if targets.len() > initial_len {
@@ -504,7 +520,10 @@ fn scan_action_yml_runs(
 }
 
 pub(crate) fn short_sha(sha: &str) -> &str {
-    if sha.len() >= 7 { &sha[..7] } else { sha }
+    match sha.char_indices().nth(7) {
+        Some((end, _)) => &sha[..end],
+        None => sha,
+    }
 }
 
 #[cfg(test)]
@@ -600,6 +619,13 @@ runs:
     #[test]
     fn short_sha_short() {
         assert_eq!(short_sha("abc"), "abc");
+    }
+
+    #[test]
+    fn short_sha_handles_multibyte_refs() {
+        assert_eq!(short_sha("🦀🦀"), "🦀🦀");
+        assert_eq!(short_sha("aaaa🦀bb"), "aaaa🦀bb");
+        assert_eq!(short_sha("abcdef1234🦀"), "abcdef1");
     }
 
     #[test]
@@ -921,6 +947,122 @@ runs:
             err.to_string()
                 .contains("Refusing to scan symlinked directory")
         );
+        assert!(collector.findings.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_local_action_source_rejects_symlinked_entrypoint_component() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            outside.path().join("leak.js"),
+            r#"fetch("https://example.com/OUT_OF_REPO_SECRET")"#,
+        )
+        .unwrap();
+
+        let action_dir = dir.path().join(".github/actions/local");
+        std::fs::create_dir_all(&action_dir).unwrap();
+        std::fs::write(
+            action_dir.join("action.yml"),
+            "name: local\nruns:\n  using: node20\n  main: sub/leak.js\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(outside.path(), action_dir.join("sub")).unwrap();
+
+        let action = LocalActionRef {
+            path: "./.github/actions/local".to_string(),
+            line_number: 1,
+        };
+        let mut collector = AuditCollector::new(false);
+        scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).unwrap();
+
+        assert!(collector.findings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_action_source_reports_incomplete_when_tree_truncated() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/o/r/git/trees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tree": [{ "path": "action.yml", "type": "blob" }],
+                "truncated": true
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/contents/action.yml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("runs:\n  using: composite\n  steps: []\n"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base("t".into(), server.uri());
+        let action = ActionRef {
+            owner: "o".into(),
+            repo: "r".into(),
+            subpath: None,
+            ref_string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            ref_type: workflow::RefType::Sha,
+            tag_comment: Some("v1.0.0".into()),
+            line_number: 1,
+            raw_line: String::new(),
+        };
+        let mut collector = AuditCollector::new(false);
+
+        let status = scan_action_source(&client, &action, &mut collector, &DEFAULT_CONFIG)
+            .await
+            .unwrap();
+
+        assert_eq!(status, ActionScanStatus::Incomplete);
+        assert!(collector.findings.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scan_action_source_reports_incomplete_when_truncated_tree_has_no_targets() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/o/r/git/trees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tree": [{ "path": "README.md", "type": "blob" }],
+                "truncated": true
+            })))
+            .mount(&server)
+            .await;
+
+        let client = GitHubClient::with_base("t".into(), server.uri());
+        let action = ActionRef {
+            owner: "o".into(),
+            repo: "r".into(),
+            subpath: None,
+            ref_string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            ref_type: workflow::RefType::Sha,
+            tag_comment: Some("v1.0.0".into()),
+            line_number: 1,
+            raw_line: String::new(),
+        };
+        let mut collector = AuditCollector::new(false);
+
+        let status = scan_action_source(&client, &action, &mut collector, &DEFAULT_CONFIG)
+            .await
+            .unwrap();
+
+        assert_eq!(status, ActionScanStatus::Incomplete);
         assert!(collector.findings.is_empty());
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -114,6 +114,14 @@ pub struct Release {
 #[derive(Deserialize)]
 struct Tree {
     tree: Vec<TreeEntry>,
+    #[serde(default)]
+    truncated: bool,
+}
+
+#[derive(Debug)]
+pub struct RepoTree {
+    pub entries: Vec<TreeEntry>,
+    pub truncated: bool,
 }
 
 #[derive(Deserialize)]
@@ -504,7 +512,7 @@ impl GitHubClient {
     }
 
     /// Fetch the file tree for a repo at a given SHA.
-    pub async fn fetch_tree(&self, owner: &str, repo: &str, sha: &str) -> Result<Vec<TreeEntry>> {
+    pub async fn fetch_tree(&self, owner: &str, repo: &str, sha: &str) -> Result<RepoTree> {
         let url = format!(
             "{}/git/trees/{}?recursive=1",
             self.repo_url(owner, repo)?,
@@ -520,7 +528,10 @@ impl GitHubClient {
         ensure_success(&resp, format!("fetching tree for {owner}/{repo}@{sha}"))?;
         let bytes = read_capped(resp).await?;
         let tree: Tree = serde_json::from_slice(&bytes).context("parsing tree")?;
-        Ok(tree.tree)
+        Ok(RepoTree {
+            entries: tree.tree,
+            truncated: tree.truncated,
+        })
     }
 
     /// Fetch raw file content from a repo at a given ref.
@@ -1046,7 +1057,8 @@ mod tests {
 
             let c = client_for(&server).await;
             let tree = c.fetch_tree("o", "r", "sha").await.unwrap();
-            assert_eq!(tree[0].path, "action.yml");
+            assert_eq!(tree.entries[0].path, "action.yml");
+            assert!(!tree.truncated);
             let body = c.fetch_file("o", "r", "action.yml", "sha").await.unwrap();
             assert!(body.contains("using: node20"));
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -397,7 +397,7 @@ impl AuditReport {
                 "      {}",
                 sanitize_for_terminal(&f.pattern_matched).dimmed()
             );
-            println!("      {}", f.description);
+            println!("      {}", sanitize_for_terminal(&f.description));
             println!();
         }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -86,6 +86,12 @@ impl UnsafeWorkflowPath {
             ),
         }
     }
+
+    fn symlinked_file(path: &Path) -> Self {
+        Self {
+            message: format!("Refusing to scan symlinked file {}", path.display()),
+        }
+    }
 }
 
 pub fn is_unsafe_workflow_path(err: &anyhow::Error) -> bool {
@@ -435,6 +441,48 @@ pub fn open_child_dir_path(repo_root: &Path, rel: &Path) -> Result<Option<File>>
     }
 
     Ok(Some(current))
+}
+
+pub fn open_child_file_path(repo_root: &Path, rel: &Path) -> Result<Option<File>> {
+    let mut current = open_repo_root(repo_root)?;
+    let mut display_path = repo_root.to_path_buf();
+    let mut components = rel.components().peekable();
+
+    while let Some(component) = components.next() {
+        let Component::Normal(name) = component else {
+            anyhow::bail!("child path escapes the repository");
+        };
+        let Some(name) = name.to_str() else {
+            anyhow::bail!("child path contains non-UTF-8 components");
+        };
+        display_path.push(name);
+
+        if components.peek().is_some() {
+            let Some(next) = open_child_dir(&current, name, &display_path)? else {
+                return Ok(None);
+            };
+            current = next;
+            continue;
+        }
+
+        let file = match openat_file(
+            &current,
+            name,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        ) {
+            Ok(file) => file,
+            Err(e) if e == Errno::LOOP || path_is_symlink(&display_path) => {
+                return Err(UnsafeWorkflowPath::symlinked_file(&display_path).into());
+            }
+            Err(e) if e == Errno::NOENT || e == Errno::NOTDIR => return Ok(None),
+            Err(e) => {
+                return Err(e).with_context(|| format!("checking {}", display_path.display()));
+            }
+        };
+        return Ok(file.metadata()?.file_type().is_file().then_some(file));
+    }
+
+    Ok(None)
 }
 
 fn open_repo_root(repo_root: &Path) -> Result<File> {

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -89,6 +89,33 @@ jobs:
 }
 
 #[test]
+fn human_output_sanitizes_escapes_in_finding_description() {
+    let workflow = "\
+name: evil
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: \"docker run alpine\\x1b[2J\\x1b[31mSPOOFED\"
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("unpinned image"));
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "raw ESC leaked through finding description: {stdout:?}"
+    );
+}
+
+#[test]
 fn pipe_to_shell_exits_one() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_PIPE_TO_SHELL);
     common::pinprick_cmd()
@@ -708,6 +735,34 @@ fn repo_config_trusted_host_notice_without_verbose() {
         stderr.contains("trusted-host fetches: 1"),
         "expected a trusted-host notice on stderr, got: {stderr}"
     );
+}
+
+#[test]
+fn repo_config_non_literal_extra_data_format_prints_notice() {
+    let workflow = "\
+name: non-literal
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -fsSL \"$RELEASE_URL\" -o tool.bin
+";
+    let dir = common::repo_with_config("ci.yml", workflow, "extra-data-formats = [\"bin\"]\n");
+
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("extra-data-format fetches: 1"),
+        "expected a repo-config notice on stderr, got: {stderr}"
+    );
+    assert!(stderr.contains("--no-repo-config"));
 }
 
 #[test]


### PR DESCRIPTION
Hardens `audit` against hostile workflow and action source across five paths.

- Local action files are resolved component-by-component from the repo root with `openat`/`NOFOLLOW` and read from the validated descriptor, so a symlinked path component cannot redirect a read outside the repository. Intermediate, terminal, and concurrently swapped symlinks are refused, and the read no longer trusts an earlier stat.
- The GitHub trees API `truncated` flag now survives deserialization and forces an incomplete, non-cacheable scan, including when the truncated tree listed no scannable files.
- `short_sha` abbreviates on character boundaries, so a multibyte action ref can no longer panic the audit.
- Dynamic finding descriptions are sanitized in human output, so attacker-controlled data such as an image name cannot inject terminal escape sequences. JSON and SARIF output and rule IDs are unchanged.
- An `extra-data-formats` exemption of a non-literal executable fetch now triggers the repo-config notice and `--no-repo-config` guidance. Built-in data formats are not misattributed to repo config, and a dangerous output target on the same line still produces a finding.
