### PR TITLE
fix(audit): harden pattern suppression, block-scalar scan, and add-action

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set positional-arguments := true
+
 # Build
 
 # Build the project
@@ -47,7 +49,7 @@ typos:
 add-action owner_repo:
     #!/usr/bin/env bash
     set -euo pipefail
-    OWNER_REPO="{{ owner_repo }}"
+    OWNER_REPO="$1"
     if [[ ! "$OWNER_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ || "$OWNER_REPO" == *..* ]]; then
         echo "error: expected OWNER/REPO, got '$OWNER_REPO'" >&2
         exit 2

--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -88,4 +88,4 @@ Skip scanning specific actions entirely. Useful for actions you've reviewed manu
 
 ### `ignore.patterns`
 
-Suppress individual findings by description substring. Useful for silencing specific pattern types across all actions.
+Suppress individual findings by description substring. Useful for silencing specific pattern types across all actions. Empty entries match nothing.

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -808,7 +808,7 @@ patterns = [
 ]
 ```
 
-Use this to silence a specific _rule_ across all actions. Matches by substring against the rule's description — so `"pip install"` silences the pip rule, `"unversioned URL"` silences every unversioned-URL rule. Findings matching a suppressed pattern are removed entirely, not visible under `--verbose`.
+Use this to silence a specific _rule_ across all actions. Matches by substring against the rule's description — so `"pip install"` silences the pip rule, `"unversioned URL"` silences every unversioned-URL rule. Empty entries match nothing. Findings matching a suppressed pattern are removed entirely, not visible under `--verbose`.
 
 Prefer `extra-data-formats` or `trusted-hosts` when they fit — those keep the audit trail; this one doesn't.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,7 +142,7 @@ impl Config {
         self.ignore
             .patterns
             .iter()
-            .any(|p| description.contains(p.as_str()))
+            .any(|p| !p.is_empty() && description.contains(p.as_str()))
     }
 
     /// Check if a URL is exempt from unversioned-fetch rules because its
@@ -621,5 +621,17 @@ trusted-hosts = ["artifacts.example.com", "releases.example.org"]
         assert!(cfg.is_action_ignored("aws-actions/configure-aws-credentials"));
         assert!(!cfg.is_action_ignored("actions/setup-node"));
         assert!(!cfg.is_action_ignored("actions/checkout-action"));
+    }
+
+    #[test]
+    fn empty_finding_pattern_matches_nothing() {
+        let cfg = Config {
+            ignore: IgnoreConfig {
+                actions: vec![],
+                patterns: vec![String::new()],
+            },
+            ..Config::default()
+        };
+        assert!(!cfg.is_pattern_ignored("curl fetching unversioned URL"));
     }
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -56,7 +56,14 @@ static LOCAL_USES_RE: LazyLock<Regex> = LazyLock::new(|| {
 // indent/chomping indicators (`|2-`, `>+`). Every block body is skipped so
 // literal docs or scripts cannot false-match on `uses:` text.
 static BLOCK_SCALAR_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(\s*)(?:-\s+)?[A-Za-z0-9_-]+\s*:\s*[|>][0-9+\-]*\s*(?:#.*)?$").unwrap()
+    Regex::new(concat!(
+        r#"^(\s*)(?:"#,
+        r#"(?:-\s+)?(?:[A-Za-z0-9_-]+|\"(?:[^\"\\]|\\.)*\"|'[^']*')\s*:\s*"#,
+        r#"(?:(?:&[^\s]+|![^\s]+)\s+)*"#,
+        r#"|-\s+(?:(?:&[^\s]+|![^\s]+)\s+)*"#,
+        r#")[|>][0-9+\-]*\s*(?:#.*)?$"#,
+    ))
+    .unwrap()
 });
 
 #[derive(Debug, Clone)]
@@ -941,6 +948,57 @@ jobs:
             );
             assert_eq!(refs[0].full_name(), "good/action");
         }
+    }
+
+    #[test]
+    fn scan_skips_extended_block_scalar_openers() {
+        for opener in [
+            "- |",
+            "- &script |",
+            "- !!str >",
+            "- run: &script |",
+            "- run: !!str >",
+            "- run: &script !!str |",
+            "- run: !!str &script >",
+            "- \"run\": |",
+            "- 'run': >",
+            "- \"ru\\\"n\": | # quoted key",
+        ] {
+            let yaml = format!(
+                "steps:\n  {opener}\n      - uses: evil/action@v1\n      - uses: ./fake\n  - uses: good/action@v2\n  - uses: ./real\n"
+            );
+            let refs = scan_content(&yaml);
+            assert_eq!(
+                refs.len(),
+                1,
+                "opener {opener:?} should hide external uses in its body"
+            );
+            assert_eq!(refs[0].full_name(), "good/action");
+
+            let local = scan_local_actions(&yaml);
+            assert_eq!(
+                local.len(),
+                1,
+                "opener {opener:?} should hide local uses in its body"
+            );
+            assert_eq!(local[0].path, "./real");
+        }
+    }
+
+    #[test]
+    fn scan_tagged_flow_scalar_does_not_trigger_skip() {
+        let yaml = "steps:\n  - run: !!str echo hello\n  - uses: actions/checkout@v4\n";
+        let refs = scan_content(yaml);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].full_name(), "actions/checkout");
+    }
+
+    #[test]
+    fn scan_bare_marker_without_yaml_context_does_not_trigger_skip() {
+        let yaml = "steps:\n  |\n    - uses: actions/checkout@v4\n";
+        let refs = scan_content(yaml);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].full_name(), "actions/checkout");
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -699,6 +699,26 @@ fn config_ignore_patterns() {
 }
 
 #[test]
+fn empty_config_ignore_pattern_does_not_suppress() {
+    let dir = common::repo_with_config(
+        "ci.yml",
+        common::WORKFLOW_PIPE_TO_SHELL,
+        "[ignore]\npatterns = [\"\"]\n",
+    );
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["findings"].as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn repo_config_suppression_prints_notice() {
     let dir = common::repo_with_config(
         "ci.yml",


### PR DESCRIPTION
Three contained hardening fixes for the scanner and dev tooling.

An empty `ignore.patterns` entry suppressed everything. A substring test against `""` always matches, so a single empty entry silenced the whole audit. Empty entries now match nothing; non-empty substring suppression is unchanged.

Extended block-scalar bodies were scanned as real `uses:` lines. The opener regex only recognized the plain `key: |` form, so bodies opened with a bare sequence scalar (`- |`), an anchor, a tag, combined node properties, or a quoted key were not skipped. Their inert contents produced spurious findings and could make `pin --write` rewrite text inside a run script. The regex now recognizes these openers for both external and local action scanning. It stays a strict superset of the old pattern and still requires a terminal block indicator, so no real `uses:` line is hidden and real threats inside run blocks are still detected via run-block extraction.

`just add-action` interpolated its argument textually. `{{ owner_repo }}` spliced the argument into the recipe body before bash parsed it, so a crafted `OWNER/REPO` ran arbitrary shell before the validation regex. The recipe now reads the argument through a quoted positional `$1` with `set positional-arguments`, so the value is validated as data.

Site docs for `ignore.patterns` note that empty entries match nothing.
