### PR TITLE
chore: release 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bump the crate version to 0.22.0 for release.

Headline changes since 0.21.0: audit checksum suppression now requires an actual verification bound to the downloaded target, so a bare or unrelated checksum command no longer hides a runtime-fetch finding; an empty `ignore.patterns` entry no longer suppresses every finding; and local-action source scanning, truncated action trees, terminal-escape output, and extended YAML block scalars are handled more strictly. `pin` and `update --write` now abort if a target line changed since it was scanned.

Cargo.toml and Cargo.lock only; `cargo check --locked` passes.
