### PR TITLE
fix(release): don't misread a 404 as an existing bump branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,9 +443,11 @@ jobs:
             exit 0
           fi
 
+          # gh api writes the error body to stdout on a 404, so capture the sha
+          # only when the request succeeds; a missing branch must read as empty.
           BRANCH_SHA=$(gh api \
             "repos/${TARGET_REPOSITORY}/git/ref/heads/${BRANCH}" \
-            --jq .object.sha 2>/dev/null || true)
+            --jq .object.sha 2>/dev/null) || BRANCH_SHA=""
           if [[ -z "${BRANCH_SHA}" ]]; then
             gh api "repos/${TARGET_REPOSITORY}/git/refs" -X POST \
               -f "ref=refs/heads/${BRANCH}" \


### PR DESCRIPTION
The `bump-action` branch probe read a missing branch as present, which failed the job on its first real run during the 0.22.0 release.

`gh api ".../git/ref/heads/<branch>" --jq .object.sha 2>/dev/null || true` looks like it yields an empty string when the branch does not exist, but `gh` writes the JSON error body to stdout on a 404 and skips `--jq`, and the `|| true` only fixed the exit code. So `BRANCH_SHA` captured `{"message":"Not Found",...}`, which skipped branch creation, fell into the reuse path, and built a `compare/<base>...<error body>` URL that errored with "unsupported protocol scheme".

Capture the sha only when the request succeeds, so a missing branch reads as empty and the create path runs. The engine release itself was unaffected; only the pinprick-action bump PR step failed. Verified with actionlint and `zizmor --persona auditor`, and by simulating both the 404 and success cases.
