### PR TITLE
chore(deps): deny install scripts and gate npm ci on a policy check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,10 +283,14 @@ jobs:
         with:
           node-version: 26
 
+      - name: Check npm install-script policy
+        if: matrix.check == 'site'
+        run: node scripts/check-npm-install-policy.mjs site
+
       - name: Install site dependencies
         if: matrix.check == 'site'
         working-directory: site
-        # Fail closed on unreviewed install scripts (npm v12 default; see allowScripts in package.json).
+        # Fail if an unreviewed dependency install script is introduced.
         run: npm ci --strict-allow-scripts
 
       - name: Check formatting

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -38,9 +38,12 @@ jobs:
           node-version: 26
           package-manager-cache: false
 
+      - name: Check npm install-script policy
+        run: node scripts/check-npm-install-policy.mjs site
+
       - name: Install dependencies
         working-directory: site
-        # Fail closed on unreviewed install scripts (npm v12 default; see allowScripts in package.json).
+        # Fail if an unreviewed dependency install script is introduced.
         run: npm ci --strict-allow-scripts
 
       - name: Build site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ stable toolchain. Homebrew's standalone Rust does not honor that file, so verify
 
 - `cargo clippy` with zero warnings
 - `cargo fmt` for formatting
+- `just npm-policy` for the site dependency install-script policy
 - No unnecessary abstractions — flat module structure, no nested directories
 - `thiserror` for typed errors in library code, `anyhow` for context-rich error propagation in commands
 - `LazyLock` for compiled regex constants

--- a/justfile
+++ b/justfile
@@ -120,6 +120,12 @@ site-format-check:
 site-install:
     cd site && npm ci --strict-allow-scripts
 
+# fleet:block npm-policy
+# Verify every dependency install script is denied or exactly approved
+npm-policy:
+    node scripts/check-npm-install-policy.mjs site
+# fleet:end
+
 # Preview the built site
 site-preview:
     cd site && npm run preview
@@ -146,6 +152,7 @@ check:
         echo "--- $1 --- skipped ($2 not found)"
         skipped+=("$2 (brew install $3)")
     }
+    run node scripts/check-npm-install-policy.mjs site
     run cargo clippy --locked --all-targets -- -D warnings
     run cargo fmt -- --check
     if command -v typos &>/dev/null; then

--- a/scripts/check-npm-install-policy.mjs
+++ b/scripts/check-npm-install-policy.mjs
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const projectDirectories = process.argv.slice(2);
+
+if (projectDirectories.length === 0) {
+  console.error("usage: node check-npm-install-policy.mjs <project-directory> [...]");
+  process.exit(2);
+}
+
+function packageNameFromLocation(location) {
+  const marker = "node_modules/";
+  const markerIndex = location.lastIndexOf(marker);
+  if (markerIndex === -1) return null;
+
+  const tail = location.slice(markerIndex + marker.length);
+  const parts = tail.split("/");
+  return tail.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+function parsePinnedKey(key) {
+  const separator = key.startsWith("@")
+    ? key.indexOf("@", key.indexOf("/") + 1)
+    : key.lastIndexOf("@");
+
+  if (separator <= 0 || separator === key.length - 1) return null;
+  return { name: key.slice(0, separator), version: key.slice(separator + 1) };
+}
+
+let failed = false;
+
+for (const directory of projectDirectories) {
+  const projectDirectory = path.resolve(directory);
+  const manifestPath = path.join(projectDirectory, "package.json");
+  const lockfilePath = path.join(projectDirectory, "package-lock.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  const lockfile = JSON.parse(await readFile(lockfilePath, "utf8"));
+  const errors = [];
+
+  const policy = manifest.allowScripts;
+  if (!policy || Array.isArray(policy) || typeof policy !== "object") {
+    errors.push("allowScripts must be an object");
+  }
+
+  const scriptPackages = new Map();
+  for (const [location, metadata] of Object.entries(lockfile.packages ?? {})) {
+    if (!location || metadata.hasInstallScript !== true) continue;
+
+    const name = packageNameFromLocation(location);
+    if (!name || typeof metadata.version !== "string") {
+      errors.push(`cannot identify script-bearing lockfile entry ${location}`);
+      continue;
+    }
+
+    if (!scriptPackages.has(name)) scriptPackages.set(name, new Set());
+    scriptPackages.get(name).add(metadata.version);
+  }
+
+  if (policy && !Array.isArray(policy) && typeof policy === "object") {
+    for (const [key, value] of Object.entries(policy)) {
+      const pin = parsePinnedKey(key);
+
+      if (typeof value !== "boolean") {
+        errors.push(`${key} must be true or false`);
+        continue;
+      }
+
+      if (value === true) {
+        if (!pin) {
+          errors.push(`${key}: name-wide true approvals are forbidden`);
+        } else if (!scriptPackages.get(pin.name)?.has(pin.version)) {
+          errors.push(`${key}: approval does not match a locked install script`);
+        }
+      } else if (pin) {
+        errors.push(`${key}: denials must use the package name without a version`);
+      } else if (!scriptPackages.has(key)) {
+        errors.push(`${key}: denial does not match a locked install script`);
+      }
+    }
+
+    for (const [name, versions] of scriptPackages) {
+      for (const version of versions) {
+        if (policy[name] === false || policy[`${name}@${version}`] === true) continue;
+        errors.push(`${name}@${version}: install script is not denied or exactly approved`);
+      }
+    }
+  }
+
+  const label = path.relative(process.cwd(), projectDirectory) || ".";
+  if (errors.length > 0) {
+    failed = true;
+    for (const error of errors) console.error(`${label}: ${error}`);
+  } else {
+    const identityCount = [...scriptPackages.values()].reduce(
+      (total, versions) => total + versions.size,
+      0,
+    );
+    console.log(
+      `${label}: npm install-script policy covers ${identityCount} locked package version(s)`,
+    );
+  }
+}
+
+if (failed) process.exit(1);

--- a/site/README.md
+++ b/site/README.md
@@ -44,6 +44,10 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`             | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help`       | Get help using the Astro CLI                     |
 
+The site denies its current dependency install scripts. Run `just npm-policy`
+from the repository root to verify that every locked install script is either
+denied or approved only for an exact version.
+
 ## 👀 Want to learn more?
 
 Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).

--- a/site/package.json
+++ b/site/package.json
@@ -30,9 +30,9 @@
     "esbuild": "0.28.1"
   },
   "allowScripts": {
-    "esbuild": true,
-    "fsevents": true,
-    "sharp": true,
-    "workerd": true
+    "esbuild": false,
+    "fsevents": false,
+    "sharp": false,
+    "workerd": false
   }
 }


### PR DESCRIPTION
Ahead of npm 12, which stops running dependency lifecycle scripts unless they are explicitly approved, this switches the site's allowScripts policy from blanket approvals to explicit per-package denials and adds scripts/check-npm-install-policy.mjs to keep the policy honest against the lockfile. The checker fails if a package with an install script is neither denied by name nor approved for an exact name@version, if an approval is name-wide, or if a denial no longer matches a locked install script. It runs before every npm ci --strict-allow-scripts in CI and deploy, is exposed as just npm-policy, and is part of just check.