### PR TITLE
build(deps): drop redundant esbuild override, bump js-yaml to 4.3.0

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4175,9 +4175,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/site/package.json
+++ b/site/package.json
@@ -26,9 +26,6 @@
     "prettier-plugin-astro": "^0.14.1",
     "wrangler": "^4.110.0"
   },
-  "overrides": {
-    "esbuild": "0.28.1"
-  },
   "allowScripts": {
     "esbuild": false,
     "fsevents": false,


### PR DESCRIPTION
Drop the esbuild override, now redundant: wrangler already pins esbuild to exactly 0.28.1, so the override only forced the version the dependency tree resolves to on its own. Bump js-yaml 4.2.0 to 4.3.0 to clear its npm audit advisory. The lockfile diff is limited to the js-yaml entry, and npm ci plus the install-script policy remain valid.
