### PR TITLE
fix(deps): pin wrangler to exact 4.110.0

### DIFF
--- a/justfile
+++ b/justfile
@@ -175,6 +175,8 @@ check:
     (cd site && npm run format:check) || failed=1
     echo "--- site-build ---"
     (cd site && npm run build) || failed=1
+    echo "--- site-deploy-dry ---"
+    (cd site && WRANGLER_SEND_METRICS=false npm run deploy:dry) || failed=1
     if [ ${#skipped[@]} -gt 0 ]; then
         echo ""
         echo "Checks skipped due to missing tools:"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "prettier": "^3.9.5",
         "prettier-plugin-astro": "^0.14.1",
-        "wrangler": "^4.110.0"
+        "wrangler": "4.110.0"
       },
       "engines": {
         "node": ">=26.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "prettier": "^3.9.5",
     "prettier-plugin-astro": "^0.14.1",
-    "wrangler": "^4.110.0"
+    "wrangler": "4.110.0"
   },
   "allowScripts": {
     "esbuild": false,


### PR DESCRIPTION
Wrangler 4.111.0 rejects the legacy_env field emitted by the Astro/Cloudflare adapter's generated config, so hold wrangler at exactly 4.110.0 until the upstream adapter fix is usable. The lockfile already resolved the direct dependency to 4.110.0, so the lockfile diff is limited to the root package specification, with no dependency-graph, integrity, or transitive churn. The adapter's ^4.83.0 peer range and the Cloudflare Vite plugin's nested 4.103.0 copy are unchanged and still satisfied by the exact pin. Every install path is npm ci off the lockfile, so no CI or deploy command can select 4.111.0 from these declarations, and the deploy dry-run reports wrangler 4.110.0. Also add a telemetry-suppressed site deploy dry-run to just check, so the local gate mirrors the CI step that catches a bad wrangler before it reaches a deploy. The matching Dependabot ignore lands through the fleet hub in starhaven-io/.github#85 and reaches this repository through the sync bot after a hub release, which is why .fleet.yml and .github/dependabot.yml are absent here.