### PR TITLE
ci: run the Rust matrix on cargo-deny workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           CHANGED=$(git diff --name-only "${BASE_SHA}...HEAD")
 
           # Rust or build workflow changes: lint + test + MSRV
-          if echo "${CHANGED}" | grep -qE '\.rs$|^Cargo\.(toml|lock)$|^rust-toolchain\.toml$|^clippy\.toml$|^rustfmt\.toml$|^\.github/workflows/(ci|release)\.yml$'; then
+          if echo "${CHANGED}" | grep -qE '\.rs$|^Cargo\.(toml|lock)$|^rust-toolchain\.toml$|^clippy\.toml$|^rustfmt\.toml$|^\.github/workflows/(ci|cargo-deny|release)\.yml$'; then
             add_check '{"name":"Lint","check":"lint","runner":"ubuntu-24.04"}'
             add_check '{"name":"Test (Linux)","check":"test","runner":"ubuntu-24.04"}'
             add_check '{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-24.04-arm"}'


### PR DESCRIPTION
The shared Renovate preset's regex manager bumps `cargo install cargo-deny --locked --version <version>` wherever it appears under `.github/workflows`, including `cargo-deny.yml`. A pull request touching only that file produced an empty matrix, so a cargo-deny bump could land without lint, tests, coverage, or MSRV certifying it. Adding `cargo-deny` to the Rust path selector closes that gap; unrelated workflow-only changes still do not trigger the matrix.
