### PR TITLE
fix(audit): count external actions skipped by a token-less run

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ pinprick audit --verbose
 # Emit SARIF 2.1.0 for GitHub code scanning
 pinprick audit --sarif > pinprick.sarif
 
+# Audit a third-party repo without honoring its own .pinprick.toml
+pinprick audit --no-repo-config /path/to/repo
+
 # Score a repository's Actions supply chain posture
 pinprick score
 
@@ -172,7 +175,7 @@ HIGH  .github/workflows/ci.yml:42
 
 Without a GitHub token, audit scans local workflow `run:` blocks and local actions referenced with `uses: ./...`. With a token (via `GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth`), it also fetches and scans external action source code — JavaScript, Python, Dockerfiles, and composite action steps.
 
-Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, jq-pipe, or checksum rules.
+Pass `--sarif` to emit SARIF 2.1.0 for upload to [GitHub code scanning](https://docs.github.com/en/code-security/code-scanning). Pass `--verbose` to see every match, including ones that passed the version check or were downgraded to an allowed match by the trusted-host, data-format, jq-pipe, or checksum rules. When auditing a repository you don't control, pass `--no-repo-config` so the target's own `.pinprick.toml` can't set the audit policy.
 
 ### Score
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -179,6 +179,7 @@ pub async fn run(
     let mut scanned_unpinned_branch = 0usize;
     let mut scanned_unpinned_sliding = 0usize;
     let mut ignored = 0usize;
+    let mut external_skipped: HashSet<String> = HashSet::new();
 
     for file in &files {
         let display_name = workflow::display_path(file.path(), repo_root);
@@ -365,6 +366,13 @@ pub async fn run(
                     }
                 }
             }
+        } else {
+            // No token: external actions are invisible to the scan. Count
+            // them so `--json` consumers see reduced scope instead of a
+            // misleading zero.
+            for action in workflow::scan_content(&content) {
+                external_skipped.insert(remote_action_scan_key(&action));
+            }
         }
     }
 
@@ -427,6 +435,7 @@ pub async fn run(
         scanned_unpinned_branch,
         scanned_unpinned_sliding,
         ignored,
+        external_actions_skipped: external_skipped.len(),
     };
 
     if sarif {

--- a/src/output.rs
+++ b/src/output.rs
@@ -372,6 +372,12 @@ pub struct AuditReport {
     /// Number of actions skipped by `ignore.actions` in the config.
     #[serde(default)]
     pub ignored: usize,
+    /// Number of unique external actions that were NOT scanned because no
+    /// GitHub token was available. Without this, a token-less `--json` run
+    /// reports `actions_scanned: 0` and nothing else — a consumer could read
+    /// silence as cleanliness.
+    #[serde(default)]
+    pub external_actions_skipped: usize,
 }
 
 impl AuditReport {
@@ -460,10 +466,20 @@ impl AuditReport {
         }
 
         if !self.had_token {
-            println!(
-                "{}",
-                "Note: no GitHub token — action source code was not scanned.".dimmed()
-            );
+            let note = if self.external_actions_skipped > 0 {
+                format!(
+                    "Note: no GitHub token — {} external action{} not scanned.",
+                    self.external_actions_skipped,
+                    if self.external_actions_skipped == 1 {
+                        ""
+                    } else {
+                        "s"
+                    }
+                )
+            } else {
+                "Note: no GitHub token — action source code was not scanned.".to_string()
+            };
+            println!("{}", note.dimmed());
         }
     }
 
@@ -825,6 +841,7 @@ mod sarif_tests {
             scanned_unpinned_branch: 0,
             scanned_unpinned_sliding: 0,
             ignored: 0,
+            external_actions_skipped: 0,
         }
     }
 
@@ -997,6 +1014,7 @@ mod audit_summary_tests {
             scanned_unpinned_branch: 0,
             scanned_unpinned_sliding: 0,
             ignored: 0,
+            external_actions_skipped: 0,
         }
     }
 

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -984,6 +984,49 @@ fn git_clone_versioned_branch_clean() {
     assert!(findings.is_empty());
 }
 
+#[test]
+fn no_token_reports_external_actions_skipped() {
+    let workflow = "\
+name: two-actions
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@v4
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["had_token"], false);
+    assert_eq!(json["actions_scanned"], 0);
+    // Two unique external actions were invisible to the token-less scan; the
+    // duplicate checkout counts once.
+    assert_eq!(json["external_actions_skipped"], 2);
+}
+
+#[test]
+fn no_token_human_note_counts_skipped_actions() {
+    let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains(
+            "no GitHub token — 1 external action not scanned",
+        ));
+}
+
 /// A local action that ships an unrelated `Dockerfile` (an example image, a CI
 /// image, a leftover) must not be audited as if a consumer built it: the
 /// action is a Node action and `runs` never names the file.


### PR DESCRIPTION
Without a GitHub token every external-action code path is skipped, so `actions_scanned` reported 0 and the trailing note mentioned only source scanning. A `--json` consumer could not tell a genuinely clean scan from one that never looked at any external action.

The unique external refs seen while no client existed are now reported as `external_actions_skipped`, and the human note says how many were skipped rather than describing the reduced scope in the abstract.

Also documents `--no-repo-config` in the README. The scanned repository's own `.pinprick.toml` applies by default, so auditing a repo you do not control needs the opt-out; it was documented on the site but missing from the README, where third-party scanning is a headline use case.
