### PR TITLE
feat(catalog): reject replayed remote catalogs and require prehashed signatures

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "site/**"
       - "audited-actions/**"
+      - "catalog-minisign.pub"
       - "Cargo.toml"
   workflow_dispatch:
 
@@ -65,13 +66,26 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq minisign
           KEYFILE="${RUNNER_TEMP}/catalog.key"
+          trap 'rm -f "${KEYFILE}"' EXIT
           printf '%s\n' "${CATALOG_SIGNING_KEY}" > "${KEYFILE}"
+          # -H (prehashed) pins the signature algorithm regardless of the
+          # installed minisign version; pinprick clients require prehashed
+          # signatures. The default trusted comment embeds `timestamp:<epoch>`,
+          # which clients enforce as the anti-replay freshness signal — never
+          # override it with -t.
           find site/dist -path '*audited-actions*' -name '*.json' -print0 \
             | while IFS= read -r -d '' f; do
-                minisign -S -s "${KEYFILE}" -m "${f}" -x "${f}.minisig"
+                minisign -SH -s "${KEYFILE}" -m "${f}" -x "${f}.minisig"
               done
-          rm -f "${KEYFILE}"
-          COUNT=$(find site/dist -name '*.json.minisig' | wc -l)
+          FIRST_SIGNATURE=$(find site/dist -path '*audited-actions*' -name '*.json.minisig' -print -quit)
+          if [[ -z "${FIRST_SIGNATURE}" ]]; then
+            echo "::error::No audited-actions catalog signatures were produced"
+            exit 1
+          fi
+          minisign -Vm "${FIRST_SIGNATURE%.minisig}" \
+            -x "${FIRST_SIGNATURE}" \
+            -p catalog-minisign.pub
+          COUNT=$(find site/dist -path '*audited-actions*' -name '*.json.minisig' | wc -l)
           echo "Signed ${COUNT} catalog files"
 
       - name: Deploy to Cloudflare Workers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,68 @@ Reports about unsafe runtime fetches performed by third-party GitHub Actions
 should normally be sent to that action's maintainer; report them here when
 pinprick fails to detect or accurately describe the behavior.
 
+## Audited-actions catalog trust
+
+pinprick ships a catalog of pre-audited action SHAs (`audited-actions/`)
+whose clean verdicts suppress scanning. The catalog reaches users two ways,
+with different trust anchors:
+
+- **Bundled** — compiled into the binary at build time; trusted exactly as
+  hard as the binary itself (releases carry build provenance attestations).
+  Because a detection-rule improvement can invalidate a verdict recorded
+  under older rules, CI re-verifies entries whenever the rules change and a
+  scheduled workflow re-scans a rotating weekly shard until the full catalog
+  has been covered (`scripts/verify-audited-actions.sh`).
+- **Remote** (`https://pinprick.rs/audited-actions/`, opt-in via
+  `fetch-remote = true`) — every served file is signed with
+  [minisign](https://jedisct1.github.io/minisign/) during deploy, and the
+  binary verifies the signature against the public key committed at
+  `catalog-minisign.pub` and embedded at build time. Verification is
+  fail-closed: an unsigned, tampered, legacy-format (non-prehashed),
+  timestamp-less, or stale catalog is ignored with a warning and the action
+  is scanned normally. Freshness is judged by minisign's signed `timestamp:`
+  trusted comment — a catalog signed more than 30 days ago is rejected, so a
+  compromised CDN cannot replay a superseded-but-validly-signed catalog
+  indefinitely. Timestamps more than 10 minutes in the future are also
+  rejected: legitimate runner and client clock drift is expected to stay
+  within minutes, and a far-future timestamp would otherwise stay inside the
+  staleness window until it plus 30 days — turning one signing-clock fault (or
+  a compromised signer) into an extended replay horizon. TLS alone is
+  deliberately not trusted.
+
+### Signing key custody
+
+The catalog signing key (`CATALOG_SIGNING_KEY`) must be stored as a
+passwordless minisign secret key in the GitHub `cloudflare` environment.
+Only `deploy-site.yml` reads it, on pushes to `main` that touch `site/**`,
+`audited-actions/**`, `catalog-minisign.pub`, or `Cargo.toml`. The workflow
+writes a temporary runner copy and removes it on step exit; maintainers must
+not retain additional copies. A compromise of that workflow or environment
+is a catalog compromise. Signing the catalog offline
+(committing `.minisig` files next to each JSON and serving them verbatim)
+would take the key out of CI at the cost of maintainer friction on every
+catalog change; that trade-off remains under consideration.
+
+### Key rotation
+
+To rotate the key (or respond to a suspected compromise):
+
+1. Generate a new keypair: `minisign -G -p catalog-minisign.pub -s catalog.key -W`.
+2. In a maintenance window, replace the `CATALOG_SIGNING_KEY` secret in the
+   `cloudflare` environment with the new secret key.
+3. Commit the matching `catalog-minisign.pub` and merge. That path triggers a
+   deployment which re-signs every served catalog file and verifies a produced
+   signature against the committed public key before publishing.
+4. Confirm the deployment succeeded, then delete every local secret-key copy.
+5. Cut a release. The public key is embedded at build time, so binaries built
+   before the rotation reject the newly signed catalog — fail-closed: they
+   warn and fall back to fresh scans until users upgrade.
+
+A wrongly-vouched bundled entry follows the binary, not the site: removing
+it from `audited-actions/` stops vouching in future builds and (within the
+freshness window) in the remote layer, but already-shipped binaries keep
+their bundled copy until upgraded.
+
 ## Supported versions
 
 Only the latest released version of pinprick is supported with security fixes.

--- a/audited-actions/README.md
+++ b/audited-actions/README.md
@@ -52,7 +52,9 @@ Each file is named `{owner}/{repo}.json` and contains an array of audited SHAs w
 These files reach users two ways with different trust anchors:
 
 - **Bundled**: compiled into the pinprick binary at build time — same trust as the binary itself (which ships with build provenance attestations).
-- **Remote** (`https://pinprick.rs/audited-actions/`, opt-in): each served file is signed with [minisign](https://jedisct1.github.io/minisign/) during deploy, and the binary verifies the signature against a public key (`catalog-minisign.pub` at the repo root) embedded at build time. Verification is fail-closed: a missing or invalid signature means the remote entry is ignored and the action is scanned normally. TLS alone is deliberately not trusted — a catalog entry suppresses scanning, so a compromised CDN must not be able to forge one.
+- **Remote** (`https://pinprick.rs/audited-actions/`, opt-in): each served file is signed with [minisign](https://jedisct1.github.io/minisign/) during deploy, and the binary verifies the signature against a public key (`catalog-minisign.pub` at the repo root) embedded at build time. Verification is fail-closed: a missing, invalid, timestamp-less, stale (signed more than 30 days ago, judged by minisign's signed `timestamp:` trusted comment), or future-dated (more than 10 minutes ahead — a far-future timestamp would otherwise extend the replay window) signature means the remote entry is ignored and the action is scanned normally. TLS alone is deliberately not trusted — a catalog entry suppresses scanning, so a compromised CDN must not be able to forge one, nor replay a superseded one indefinitely.
+
+See [SECURITY.md](../SECURITY.md) for key custody and rotation.
 
 ## Contributing
 

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -12,3 +12,10 @@
 
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
+
+# Catalog files and their .minisig signatures share this prefix, so one rule
+# gives both the same short lifetime. After a deploy the pair could otherwise
+# be cached from different generations, making clients (fail-closed) warn
+# about signature mismatches for up to the cache TTL.
+/audited-actions/*
+  Cache-Control: public, max-age=300, must-revalidate

--- a/site/src/pages/audited-actions/[owner]/[repo].json.ts
+++ b/site/src/pages/audited-actions/[owner]/[repo].json.ts
@@ -27,7 +27,10 @@ export const GET: APIRoute = ({ params }) => {
     return new Response(data, {
       headers: {
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=3600',
+        // Keep in sync with public/_headers (/audited-actions/*): the catalog
+        // and its .minisig must age out together or clients see transient
+        // signature mismatches after a deploy.
+        'Cache-Control': 'public, max-age=300, must-revalidate',
       },
     });
   } catch {

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -2,9 +2,48 @@ use minisign_verify::{PublicKey, Signature};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const BUNDLED_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/bundled_audited_actions.json"));
 const REMOTE_URL: &str = "https://pinprick.rs/audited-actions";
+
+/// Reject a remote catalog whose signed `timestamp:` trusted comment is older
+/// than this. The site re-signs every catalog file on each deploy, and deploys
+/// fire on every main push touching `site/**`, `audited-actions/**`, or
+/// `Cargo.toml` (weekly catalog PRs, dependency bumps, releases), so
+/// production signatures refresh far more often than monthly. A signature
+/// past this window therefore strongly suggests a replayed, superseded
+/// catalog; the cost of a false positive is only a warning and a fresh scan.
+const MAX_REMOTE_CATALOG_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Tolerated clock skew for a signed timestamp that sits in the future.
+/// Deploy runners and clients are NTP-synced, so minutes cover legitimate
+/// drift; anything beyond is a signing-system clock fault or a forged
+/// far-future timestamp — which would otherwise stay "fresh" until
+/// `timestamp + MAX_REMOTE_CATALOG_AGE` and defeat the replay window.
+const MAX_CLOCK_SKEW: Duration = Duration::from_secs(10 * 60);
+
+/// Freshness verdict for a signed catalog timestamp.
+#[derive(Debug, PartialEq, Eq)]
+enum CatalogFreshness {
+    Fresh,
+    /// Older than [`MAX_REMOTE_CATALOG_AGE`] — a superseded catalog being
+    /// replayed, or serving infrastructure gone stale.
+    Stale,
+    /// More than [`MAX_CLOCK_SKEW`] in the future — never legitimate, since
+    /// a real signature cannot predate its own signing by more than drift.
+    FutureDated,
+}
+
+fn catalog_freshness(signed_at: u64, now: u64) -> CatalogFreshness {
+    if signed_at > now + MAX_CLOCK_SKEW.as_secs() {
+        CatalogFreshness::FutureDated
+    } else if now.saturating_sub(signed_at) > MAX_REMOTE_CATALOG_AGE.as_secs() {
+        CatalogFreshness::Stale
+    } else {
+        CatalogFreshness::Fresh
+    }
+}
 
 /// Minisign public key for the remote catalog, committed at the repo root and
 /// embedded at compile time. The remote layer is fail-closed: without a valid
@@ -244,11 +283,46 @@ impl AuditedActions {
             }
         };
         let sig_text = String::from_utf8_lossy(&sig_bytes);
-        if !verify_catalog_signature(key, &bytes, &sig_text) {
+        let Some(trusted_comment) = verify_catalog_signature(key, &bytes, &sig_text) else {
             eprintln!(
                 "warning: remote catalog for {action_key} failed signature verification — ignoring it"
             );
             return None;
+        };
+
+        // Anti-replay: minisign's default trusted comment carries the signing
+        // time (`timestamp:<epoch>`), and the verified global signature covers
+        // it. A CDN (or a MITM on a downgraded path) could otherwise serve a
+        // validly signed but superseded catalog forever — keeping an entry
+        // vouched-for after its audit was found wrong and it was removed.
+        // A missing timestamp cannot satisfy the replay bound. Accepting it
+        // would turn a valid signature into an indefinitely reusable verdict.
+        let Some(signed_at) = trusted_comment_timestamp(&trusted_comment) else {
+            eprintln!(
+                "warning: remote catalog for {action_key} has no signed timestamp — ignoring it"
+            );
+            return None;
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        match catalog_freshness(signed_at, now) {
+            CatalogFreshness::Fresh => {}
+            CatalogFreshness::Stale => {
+                eprintln!(
+                    "warning: remote catalog for {action_key} was signed more than {} days ago — ignoring it (possible replay of a superseded catalog)",
+                    MAX_REMOTE_CATALOG_AGE.as_secs() / 86_400
+                );
+                return None;
+            }
+            CatalogFreshness::FutureDated => {
+                eprintln!(
+                    "warning: remote catalog for {action_key} claims to be signed more than {} minutes in the future — ignoring it (check the signing system's clock; if your own clock is correct this may indicate a compromised or faulty signer)",
+                    MAX_CLOCK_SKEW.as_secs() / 60
+                );
+                return None;
+            }
         }
 
         Some(parse_entries(&String::from_utf8_lossy(&bytes)))
@@ -291,12 +365,27 @@ fn parse_catalog_key(content: &str) -> Option<PublicKey> {
     PublicKey::from_base64(line).ok()
 }
 
-fn verify_catalog_signature(key: &PublicKey, data: &[u8], sig_text: &str) -> bool {
-    match Signature::decode(sig_text) {
-        // true: also accept legacy (non-prehashed) signatures.
-        Ok(sig) => key.verify(data, &sig, true).is_ok(),
-        Err(_) => false,
-    }
+/// Verify `sig_text` over `data`. On success, returns the signature's trusted
+/// comment — which is authenticated: minisign's global signature covers the
+/// signature bytes plus the trusted comment, and `verify` checks it.
+///
+/// `allow_legacy` is `false`: the project controls the only signer (the
+/// deploy pipeline signs prehashed — enforced with `minisign -SH`), so
+/// legacy non-prehashed signatures are refused outright.
+fn verify_catalog_signature(key: &PublicKey, data: &[u8], sig_text: &str) -> Option<String> {
+    let sig = Signature::decode(sig_text).ok()?;
+    key.verify(data, &sig, false).ok()?;
+    Some(sig.trusted_comment().to_string())
+}
+
+/// Extract the `timestamp:<epoch seconds>` token that minisign embeds in its
+/// default trusted comment (`timestamp:1700000000\tfile:…\thashed`).
+/// `None` when the comment carries no parsable token.
+fn trusted_comment_timestamp(comment: &str) -> Option<u64> {
+    comment
+        .split(['\t', ' '])
+        .find_map(|token| token.strip_prefix("timestamp:"))
+        .and_then(|value| value.parse().ok())
 }
 
 fn load_bundled() -> HashMap<String, HashSet<String>> {
@@ -663,6 +752,177 @@ mod tests {
                 .respond_with(ResponseTemplate::new(200).set_body_string(sig.to_string()))
                 .mount(server)
                 .await;
+        }
+
+        /// Like `test_identity`, but the signer takes an explicit trusted
+        /// comment — for forging old or odd `timestamp:` tokens.
+        fn test_identity_with_trusted_comment() -> (PublicKey, impl Fn(&[u8], &str) -> String) {
+            let minisign::KeyPair { pk, sk } =
+                minisign::KeyPair::generate_unencrypted_keypair().unwrap();
+            let verify_key = parse_catalog_key(&pk.to_box().unwrap().to_string())
+                .expect("generated public key must parse");
+            let signer = move |data: &[u8], trusted: &str| {
+                minisign::sign(None, &sk, std::io::Cursor::new(data), Some(trusted), None)
+                    .unwrap()
+                    .to_string()
+            };
+            (verify_key, signer)
+        }
+
+        fn now_epoch() -> u64 {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        }
+
+        #[test]
+        fn catalog_freshness_boundaries() {
+            let now = 2_000_000_000u64;
+            let skew = MAX_CLOCK_SKEW.as_secs();
+            let max_age = MAX_REMOTE_CATALOG_AGE.as_secs();
+
+            assert_eq!(catalog_freshness(now, now), CatalogFreshness::Fresh);
+            // Future timestamps: fresh up to exactly the skew bound, rejected
+            // one second past it — a far-future timestamp must not buy an
+            // extended replay window.
+            assert_eq!(catalog_freshness(now + skew, now), CatalogFreshness::Fresh);
+            assert_eq!(
+                catalog_freshness(now + skew + 1, now),
+                CatalogFreshness::FutureDated
+            );
+            assert_eq!(
+                catalog_freshness(now + max_age, now),
+                CatalogFreshness::FutureDated
+            );
+            // Past timestamps: fresh up to exactly the staleness window,
+            // rejected one second past it.
+            assert_eq!(
+                catalog_freshness(now - max_age, now),
+                CatalogFreshness::Fresh
+            );
+            assert_eq!(
+                catalog_freshness(now - max_age - 1, now),
+                CatalogFreshness::Stale
+            );
+            assert_eq!(catalog_freshness(0, now), CatalogFreshness::Stale);
+        }
+
+        #[test]
+        fn trusted_comment_timestamp_parses_minisign_default_format() {
+            assert_eq!(
+                trusted_comment_timestamp("timestamp:1700000000\tfile:x.json\thashed"),
+                Some(1_700_000_000)
+            );
+            assert_eq!(
+                trusted_comment_timestamp("timestamp:1700000000"),
+                Some(1_700_000_000)
+            );
+            // Space-separated variants and no-token comments.
+            assert_eq!(
+                trusted_comment_timestamp("file:x.json timestamp:42"),
+                Some(42)
+            );
+            assert_eq!(trusted_comment_timestamp("no clock here"), None);
+            assert_eq!(trusted_comment_timestamp("timestamp:not-a-number"), None);
+            assert_eq!(trusted_comment_timestamp(""), None);
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_stale_signature_is_rejected() {
+            // A validly signed catalog whose signed timestamp is past the
+            // freshness window must be ignored — that is the replay defense:
+            // an old signature stays valid forever, but not fresh forever.
+            let (key, sign) = test_identity_with_trusted_comment();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+            let stale = now_epoch() - MAX_REMOTE_CATALOG_AGE.as_secs() - 86_400;
+            let sig = sign(
+                body.as_bytes(),
+                &format!("timestamp:{stale}\tfile:replayed.json\thashed"),
+            );
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/replayed", &body, &sig).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/replayed").await.is_none());
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_fresh_and_within_skew_timestamps_are_accepted() {
+            // Fresh: inside the window. Slightly future: NTP drift, not replay.
+            let (key, sign) = test_identity_with_trusted_comment();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+
+            let server = MockServer::start().await;
+            for (action_key, timestamp) in [
+                ("actions/fresh", now_epoch() - 60),
+                ("actions/skewed", now_epoch() + MAX_CLOCK_SKEW.as_secs() / 2),
+            ] {
+                let sig = sign(body.as_bytes(), &format!("timestamp:{timestamp}"));
+                mount_signed(&server, action_key, &body, &sig).await;
+            }
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(
+                aa.fetch_remote_list("actions/fresh")
+                    .await
+                    .unwrap()
+                    .contains("aaa")
+            );
+            assert!(
+                aa.fetch_remote_list("actions/skewed")
+                    .await
+                    .unwrap()
+                    .contains("aaa")
+            );
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_far_future_signature_is_rejected() {
+            // A validly signed catalog claiming to be signed well in the
+            // future must be ignored: it would otherwise stay "fresh" until
+            // its timestamp plus the staleness window, so one signing-clock
+            // fault (or a compromised signer) would grant a CDN an extended
+            // replay horizon for a later-revoked entry.
+            let (key, sign) = test_identity_with_trusted_comment();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+            let future = now_epoch() + MAX_CLOCK_SKEW.as_secs() + 3_600;
+            let sig = sign(
+                body.as_bytes(),
+                &format!("timestamp:{future}\tfile:fromthefuture.json\thashed"),
+            );
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/fromthefuture", &body, &sig).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(
+                aa.fetch_remote_list("actions/fromthefuture")
+                    .await
+                    .is_none()
+            );
+        }
+
+        #[tokio::test]
+        async fn fetch_remote_list_signature_without_timestamp_is_rejected() {
+            let (key, sign) = test_identity_with_trusted_comment();
+            let body = serde_json::to_string(&json!([{ "sha": "aaa", "tag": "v1" }])).unwrap();
+            let sig = sign(body.as_bytes(), "no clock here");
+
+            let server = MockServer::start().await;
+            mount_signed(&server, "actions/untimed", &body, &sig).await;
+
+            let mut aa = AuditedActions::new(true);
+            aa.catalog_key = Some(key);
+            aa.remote_url = server.uri();
+            assert!(aa.fetch_remote_list("actions/untimed").await.is_none());
         }
 
         #[tokio::test]


### PR DESCRIPTION
The remote catalog was verified for content only, so a CDN or a MITM on a downgraded path could serve an older but validly signed catalog forever. If an entry is ever withdrawn because its audit proved wrong, replaying the old file keeps vouching for it.

minisign's default trusted comment already carries the signing time, and the verified global signature covers it, so no catalog format change is needed. A catalog signed more than 30 days ago is rejected, and so is one dated more than ten minutes ahead: a far-future timestamp would otherwise stay inside the staleness window until it plus 30 days, turning a single signing-clock fault into an extended replay horizon. A catalog carrying no signed timestamp cannot satisfy the bound at all, so it is refused rather than trusted.

Signatures are now prehashed-only. The deploy signs with `minisign -SH` and verifies a produced signature against the committed public key before publishing, so a key mismatch fails the deploy instead of shipping. Serving the catalog and its signature with one cache lifetime keeps a deploy from leaving the pair straddling two generations.

SECURITY.md gains the matching documentation: the two trust anchors, what fail-closed actually guarantees, that the signing key is a passwordless CI secret whose workflow compromise is a catalog compromise, and the offline signing trade-off that remains open. The rotation runbook commits the new public key at the repository root, which is now a deploy trigger path, so the deployment that re-signs production content actually fires.
