### PR TITLE
feat: honor XDG_CACHE_HOME and XDG_CONFIG_HOME

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ pinprick/
 │   ├── audit_source.rs      # Action source selection and fetch (remote trees API, local ./ actions)
 │   ├── audited_actions.rs   # Layered lookup: bundled → local cache → remote → GitHub API
 │   ├── auth.rs              # GitHub token resolution (GITHUB_TOKEN/GH_TOKEN env → gh auth token fallback)
-│   ├── config.rs            # TOML config file loading (.pinprick.toml, ~/.config/pinprick/)
+│   ├── config.rs            # TOML config loading (repo-local or XDG config directory)
 │   ├── github.rs            # GitHub API client (tag→SHA, releases, file trees)
 │   ├── output.rs            # Human-readable (colored) and --json output formatting
 │   ├── pin.rs               # Pin command: resolve tags to SHAs, rewrite files
@@ -52,7 +52,7 @@ pinprick/
 - `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
 - `pinprick audit [PATH] [--verbose] [--sarif] [--no-audited-catalog]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans local `run:` blocks and local actions referenced with `uses: ./...`. With a token, also fetches and scans remote action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning.
 - `pinprick score [PATH] [--html]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md` (rubric v0.9.0). The offline rules (`pin.*`, `workflow.*`, `runtime.*`) need no token; with a token it additionally emits the token-gated `source.archived` and `source.advisory` rules. `runtime.*` rules reuse the `audit` shell pipeline against each workflow's `run:` blocks, distinguishing pipe-to-shell (-20) from severity-graded fetches (-15/-8/-3). Exits 1 when any finding deducts points (matches `audit` for CI gating); outputs JSON with `--json` or a self-contained HTML report with `--html` (mutually exclusive with `--json`).
-- `pinprick clean` — Remove locally cached audit results (`~/.cache/pinprick/audited/`).
+- `pinprick clean` — Remove locally cached audit results (`$XDG_CACHE_HOME/pinprick/audited/`, default `~/.cache/pinprick/audited/`).
 - `pinprick completions <SHELL>` — Generate shell completions for bash, zsh, fish, etc.
 
 ### Global flags
@@ -84,7 +84,7 @@ Rate-limit handling: `github::get` retries once on network/5xx errors and sleeps
 
 ### Configuration
 
-A `.pinprick.toml` at the repo root (or `~/.config/pinprick/config.toml`) customizes behavior. Keys are all optional: `severity`, `fetch-remote`, `trusted-hosts`, `extra-data-formats`, `ignore.actions`, `ignore.patterns`. Per-repo wholly overrides global (no field-level merge). Because the scanned repo's own config applies, `audit`/`score` print a stderr notice whenever a repo-local config suppressed findings or extended runtime/data-format trust, and accept `--no-repo-config` to ignore the repo's file (for scanning repositories you don't control).
+A `.pinprick.toml` at the repo root (or `$XDG_CONFIG_HOME/pinprick/config.toml`, default `~/.config/pinprick/config.toml`) customizes behavior. Keys are all optional: `severity`, `fetch-remote`, `trusted-hosts`, `extra-data-formats`, `ignore.actions`, `ignore.patterns`. Per-repo wholly overrides global (no field-level merge). Because the scanned repo's own config applies, `audit`/`score` print a stderr notice whenever a repo-local config suppressed findings or extended runtime/data-format trust, and accept `--no-repo-config` to ignore the repo's file (for scanning repositories you don't control).
 
 ### Audit patterns
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ pinprick score  v0.9.0 rubric
 
 ### Configuration
 
-A `.pinprick.toml` at the repo root (or `~/.config/pinprick/config.toml` globally) customizes behavior. All keys are optional:
+A `.pinprick.toml` at the repo root (or `$XDG_CONFIG_HOME/pinprick/config.toml`, default `~/.config/pinprick/config.toml`, globally) customizes behavior. All keys are optional:
 
 ```toml
 # Minimum severity to report: "low" (default), "medium", or "high"
@@ -227,7 +227,7 @@ patterns = []
 
 ### Clean
 
-Remove locally cached audit results (`~/.cache/pinprick/audited/`):
+Remove locally cached audit results (`$XDG_CACHE_HOME/pinprick/audited/`, default `~/.cache/pinprick/audited/`):
 
 ```
 $ pinprick clean

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -26,7 +26,7 @@ For the full list of every rule, including examples and severity, see the [Detec
 pinprick skips actions whose `owner/repo@sha` is already known to be clean. The check consults three sources, in order, and reports which one answered:
 
 - `bundled` — ships with the pinprick binary from `audited-actions/` in the repo
-- `local cache` — written to `~/.cache/pinprick/audited/` after a successful live scan on this machine
+- `local cache` — written to `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`) after a successful live scan on this machine
 - `pinprick.rs` — fetched from the public audited-actions list (opt-in via `fetch-remote = true` in `.pinprick.toml`)
 
 See [Audited Actions](/configuration/audited-actions) for details on how the list works and how to contribute.

--- a/site/src/content/docs/commands/clean.md
+++ b/site/src/content/docs/commands/clean.md
@@ -3,7 +3,7 @@ title: clean
 description: Remove locally cached audit results.
 ---
 
-Remove the local audit cache at `~/.cache/pinprick/audited/`. This directory stores results from previous `pinprick audit` runs so that already-scanned action SHAs can be skipped on future runs.
+Remove the local audit cache at `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`). This directory stores results from previous `pinprick audit` runs so that already-scanned action SHAs can be skipped on future runs.
 
 ```bash
 pinprick clean

--- a/site/src/content/docs/configuration/audited-actions.md
+++ b/site/src/content/docs/configuration/audited-actions.md
@@ -8,7 +8,7 @@ pinprick maintains a list of GitHub Actions that have been scanned and confirmed
 ## Lookup order
 
 1. **Bundled** — compiled into the binary at build time. Same trust as the binary itself.
-2. **Local cache** — `~/.cache/pinprick/audited/`. Populated automatically when you scan an action and it comes back clean.
+2. **Local cache** — `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`). Populated automatically when you scan an action and it comes back clean.
 3. **Remote** — `https://pinprick.rs/audited-actions/`. Opt-in via `fetch-remote = true` in your [config file](/configuration/config-file).
 4. **GitHub API** — full source fetch and scan as last resort.
 

--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -5,7 +5,7 @@ description: Configure pinprick behavior with .pinprick.toml.
 
 pinprick reads configuration from TOML files in two locations:
 
-1. **Global** — `~/.config/pinprick/config.toml`
+1. **Global** — `$XDG_CONFIG_HOME/pinprick/config.toml` (default `~/.config/pinprick/config.toml`)
 2. **Per-repo** — `.pinprick.toml` in the repository root
 
 Per-repo config overrides global config as a whole file; fields are not merged. Both are optional — pinprick uses sensible defaults.

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -68,7 +68,7 @@ const LOCAL_CACHE_PINPRICK_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub enum AuditSource {
     /// Compiled into the pinprick binary from `audited-actions/`.
     Bundled,
-    /// Read from `~/.cache/pinprick/audited/` (populated by previous scans).
+    /// Read from the XDG cache directory (populated by previous scans).
     LocalCache,
     /// Fetched from `https://pinprick.rs/audited-actions/`.
     Remote,
@@ -88,7 +88,7 @@ impl AuditSource {
 ///
 /// Resolution order:
 /// 1. **Bundled** — compiled into the binary from `audited-actions/`
-/// 2. **Local cache** — `~/.cache/pinprick/audited/{owner}/{repo}.json`
+/// 2. **Local cache** — `$XDG_CACHE_HOME/pinprick/audited/{owner}/{repo}.json`
 /// 3. **Remote** — `https://pinprick.rs/audited-actions/{owner}/{repo}.json` (opt-in)
 ///
 /// Misses are silent — "not audited" just means the action is scanned via
@@ -421,8 +421,13 @@ fn render_entries(entries: &[serde_json::Value]) -> Option<String> {
 }
 
 pub fn cache_dir() -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
-    Some(PathBuf::from(home).join(".cache/pinprick/audited"))
+    // XDG_CACHE_HOME wins when set to an absolute path; the spec says a
+    // relative value must be ignored.
+    let base = match std::env::var("XDG_CACHE_HOME") {
+        Ok(dir) if dir.starts_with('/') => PathBuf::from(dir),
+        _ => PathBuf::from(std::env::var("HOME").ok()?).join(".cache"),
+    };
+    Some(base.join("pinprick/audited"))
 }
 
 /// Build the on-disk cache path for an action, returning `None` if either
@@ -1090,7 +1095,7 @@ mod tests {
             let mut aa = AuditedActions::new(true);
             aa.catalog_key = Some(key);
             aa.remote_url = server.uri();
-            aa.cache_dir = None; // don't consult the real ~/.cache during the test
+            aa.cache_dir = None; // don't consult the real user cache during the test
             // Not bundled, no local cache hit → resolved by the remote layer.
             assert_eq!(
                 aa.check("some", "action", None, "feedface").await,

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,7 +77,7 @@ pub struct IgnoreConfig {
 }
 
 impl Config {
-    /// Load config from global (~/.config/pinprick/config.toml) and per-repo (.pinprick.toml).
+    /// Load config from the XDG global path and per-repo `.pinprick.toml`.
     /// Per-repo overrides global. Missing files are fine — defaults are used.
     /// With `use_repo_config` false the per-repo file is ignored entirely —
     /// the right mode when scanning a repository you don't control, whose
@@ -203,14 +203,21 @@ enum ConfigLoad {
 }
 
 fn load_global() -> ConfigLoad {
-    let Ok(home) = std::env::var("HOME") else {
-        return ConfigLoad::Absent;
+    // XDG_CONFIG_HOME wins when set to an absolute path; the spec says a
+    // relative value must be ignored.
+    let base = match std::env::var("XDG_CONFIG_HOME") {
+        Ok(dir) if dir.starts_with('/') => std::path::PathBuf::from(dir),
+        _ => {
+            let Ok(home) = std::env::var("HOME") else {
+                return ConfigLoad::Absent;
+            };
+            Path::new(&home).join(".config")
+        }
     };
-    let path = Path::new(&home)
-        .join(".config")
-        .join("pinprick")
-        .join("config.toml");
-    load_file(&path, ParseWarning::Detailed)
+    load_file(
+        &base.join("pinprick").join("config.toml"),
+        ParseWarning::Detailed,
+    )
 }
 
 fn load_local(repo_root: &Path) -> ConfigLoad {

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -25,12 +25,51 @@ fn reports_cache_cleaned_when_present() {
         .env("GITHUB_TOKEN", "")
         .env("GH_TOKEN", "")
         .env("HOME", home.path())
+        .env_remove("XDG_CACHE_HOME")
         .arg("--color")
         .arg("never")
         .arg("clean")
         .assert()
         .success()
         .stdout(predicate::str::contains("Cache cleaned."));
+}
+
+#[test]
+fn xdg_cache_home_is_honored() {
+    let home = tempfile::TempDir::new().unwrap();
+    let xdg = tempfile::TempDir::new().unwrap();
+    let cache = xdg.path().join("pinprick/audited");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(cache.join("actions.json"), "[]").unwrap();
+
+    assert_cmd::Command::cargo_bin("pinprick")
+        .unwrap()
+        .env("GITHUB_TOKEN", "")
+        .env("GH_TOKEN", "")
+        .env("HOME", home.path())
+        .env("XDG_CACHE_HOME", xdg.path())
+        .arg("--color")
+        .arg("never")
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cache cleaned."));
+
+    assert!(!cache.exists());
+    // A relative XDG value is ignored per the spec — nothing to clean under
+    // the fallback HOME.
+    assert_cmd::Command::cargo_bin("pinprick")
+        .unwrap()
+        .env("GITHUB_TOKEN", "")
+        .env("GH_TOKEN", "")
+        .env("HOME", home.path())
+        .env("XDG_CACHE_HOME", "relative/path")
+        .arg("--color")
+        .arg("never")
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Nothing to clean."));
 }
 
 #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,10 +32,9 @@ pub fn repo_with_config(filename: &str, workflow: &str, config: &str) -> TempDir
 }
 
 /// Build an `assert_cmd::Command` for pinprick with the token stripped, colors
-/// off, and HOME pointed at a unique temp path per invocation. The per-call HOME
-/// isolates the audit cache (`~/.cache/pinprick`) and global config
-/// (`~/.config/pinprick`) so parallel test processes can't race on, or poison,
-/// a shared directory.
+/// off, and HOME pointed at a unique temp path per invocation. Clearing the XDG
+/// variables alongside it pins the audit cache and global config to that HOME,
+/// so parallel test processes can't race on, or poison, a shared directory.
 pub fn pinprick_cmd() -> assert_cmd::Command {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let mut cmd = assert_cmd::Command::cargo_bin("pinprick").unwrap();
@@ -44,6 +43,10 @@ pub fn pinprick_cmd() -> assert_cmd::Command {
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let home = std::env::temp_dir().join(format!("pinprick-test-{}-{n}", std::process::id()));
     cmd.env("HOME", &home);
+    // The developer's own XDG dirs must never leak into (or be touched by) a
+    // test run — fall back to the per-test HOME.
+    cmd.env_remove("XDG_CACHE_HOME");
+    cmd.env_remove("XDG_CONFIG_HOME");
     cmd.arg("--color").arg("never");
     cmd
 }


### PR DESCRIPTION
The audit cache and the global config were hardcoded to `~/.cache/pinprick` and `~/.config/pinprick`, which ignores the base-directory spec and puts the files in the wrong place on NixOS and on CI images that set the variables.

Both are honored when set to an absolute path; per the spec a relative value is ignored and the HOME-relative default applies. Tests isolate the variables alongside HOME so a developer's own directories can never be read or written by a test run.
