### PR TITLE
feat: detect unpinned docker:// container action refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Six categories of runtime fetch detection:
 - **PowerShell:** `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm`, `Start-BitsTransfer`, and `WebClient.DownloadFile` with unversioned URLs
 - **JavaScript:** `fetch()`/`axios`/`got`/`http.get` with unversioned URLs, `exec()`/`child_process` shelling out to curl
 - **Python:** `urllib.request.urlopen`/`requests.get` with unversioned URLs, `subprocess` shelling out to curl/wget
-- **Docker:** `docker pull`/`docker run` with literal images using `:latest` or no tag in shell run blocks, `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell), `ADD` with an `http(s)://` URL source (subject to versioning + data-format exemption via the URL-check path)
+- **Docker:** unpinned `uses: docker://…` container action refs (high for `:latest`/untagged, medium for a mutable named tag; a well-formed `@sha256:` digest passes), `docker pull`/`docker run` with literal images using `:latest` or no tag in shell run blocks, `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell), `ADD` with an `http(s)://` URL source (subject to versioning + data-format exemption via the URL-check path)
 
 Pipe-to-shell pre-empts the other shell/Docker patterns so each line emits a single finding. It also reuses the existing `ShellFetch` SARIF category/rule id to keep downstream configs stable.
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -47,8 +47,12 @@ Each rule has an ID, a category, a severity, a point deduction, and a remediatio
 | `pin.branch`  | `@ref` is a branch name (`main`, `master`, custom) | high     |   15   | live   | Pin to a full 40-char SHA                             |
 | `pin.sliding` | `@ref` is a sliding tag (e.g., `@v4`)              | medium   |    5   | live   | Pin to a full 40-char SHA; keep the tag as a comment  |
 | `pin.full_tag`| `@ref` is a full version tag (e.g., `@v4.2.1`)     | low      |    2   | live   | Pin to a full 40-char SHA                             |
+| `pin.docker_latest` | `uses: docker://image` with `:latest` or no tag | high  |   15   | live   | Pin the container image by digest (`@sha256:…`)       |
+| `pin.docker_tag` | `uses: docker://image:tag` without a digest       | medium   |    5   | live   | Pin the container image by digest (`@sha256:…`)       |
 
 A SHA-pinned reference incurs no pinning deduction.
+
+Container action references (`uses: docker://…`, added in rubric 0.10.0) are the registry-side mirror of the git rules: a `@sha256:` digest is immutable and deducts nothing, a named tag is mutable (the registry can re-push different content under it, like a sliding git tag), and `:latest`/no tag tracks whatever the registry currently serves (like a branch ref). Only a well-formed `sha256:` digest — 64 hex characters — counts as pinned.
 
 `pin.none` is catalogued for completeness but currently unreachable: pinprick's `uses:` parser rejects lines without an `@ref`, so no-ref references never reach the scorer. The rule id is reserved so future parser changes (or other tooling that implements this rubric) can emit it without colliding.
 
@@ -203,7 +207,7 @@ Re-scoring an existing scan against a newer rubric is always explicit in the UI.
 
 ## Changelog
 
-- `0.10.0`: Token-gated runs now also score runtime findings from fetched remote action source (previously deferred). Reports and badges declare incomplete coverage instead of presenting a partial score as final.
+- `0.10.0`: Added container action pinning rules `pin.docker_latest` (high/-15) and `pin.docker_tag` (medium/-5); `uses: docker://…` references were previously invisible to scoring. Digest-pinned images deduct nothing. Token-gated runs now also score runtime findings from fetched remote action source.
 - `0.9.0`: Removed `source.unverified`. `pinprick score --json` no longer emits publisher allowlist notes, and the `trusted-owners` config key has been removed.
 
 ## Worked example

--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -22,6 +22,7 @@ pinprick pin /path/to/repo
 - Already-pinned refs (40-char hex SHAs) are skipped silently
 - Branch refs (e.g., `@main`) are flagged — pin to a SHA manually
 - Annotated tags are followed to their underlying commit SHA
+- `docker://` container references are audited and scored separately; registry tags must be replaced with a reviewed `@sha256:` digest manually
 
 ## Example
 

--- a/site/src/content/docs/commands/score.md
+++ b/site/src/content/docs/commands/score.md
@@ -37,24 +37,28 @@ pinprick score --badge > badge.json
 
 The full catalog lives in [`docs/scoring.md`](https://github.com/starhaven-io/pinprick/blob/main/docs/scoring.md). Summary:
 
-| Category   | Rule                              | Severity | Points |
-| ---------- | --------------------------------- | -------- | ------ |
-| `pin`      | `pin.branch` (branch ref)         | high     | 15     |
-| `pin`      | `pin.sliding` (sliding tag `@v4`) | medium   | 5      |
-| `pin`      | `pin.full_tag` (e.g. `@v4.2.1`)   | low      | 2      |
-| `source`   | `source.archived`                 | high     | 10     |
-| `source`   | `source.advisory` (GHSA match)    | high     | 15     |
-| `runtime`  | `runtime.pipe_to_shell`           | high     | 20     |
-| `runtime`  | `runtime.fetch.high`              | high     | 15     |
-| `runtime`  | `runtime.fetch.medium`            | medium   | 8      |
-| `runtime`  | `runtime.fetch.low`               | low      | 3      |
-| `workflow` | `workflow.permissions_write_all`  | high     | 10     |
-| `workflow` | `workflow.pull_request_target`    | high     | 5      |
-| `workflow` | `workflow.workflow_run`           | medium   | 3      |
+| Category   | Rule                                                      | Severity | Points |
+| ---------- | --------------------------------------------------------- | -------- | ------ |
+| `pin`      | `pin.branch` (branch ref)                                 | high     | 15     |
+| `pin`      | `pin.sliding` (sliding tag `@v4`)                         | medium   | 5      |
+| `pin`      | `pin.full_tag` (e.g. `@v4.2.1`)                           | low      | 2      |
+| `pin`      | `pin.docker_latest` (`docker://` image, `:latest`/no tag) | high     | 15     |
+| `pin`      | `pin.docker_tag` (`docker://` image tag, no digest)       | medium   | 5      |
+| `source`   | `source.archived`                                         | high     | 10     |
+| `source`   | `source.advisory` (GHSA match)                            | high     | 15     |
+| `runtime`  | `runtime.pipe_to_shell`                                   | high     | 20     |
+| `runtime`  | `runtime.fetch.high`                                      | high     | 15     |
+| `runtime`  | `runtime.fetch.medium`                                    | medium   | 8      |
+| `runtime`  | `runtime.fetch.low`                                       | low      | 3      |
+| `workflow` | `workflow.permissions_write_all`                          | high     | 10     |
+| `workflow` | `workflow.pull_request_target`                            | high     | 5      |
+| `workflow` | `workflow.workflow_run`                                   | medium   | 3      |
 
 Grade bands: **A** 90–100, **B** 80–89, **C** 70–79, **D** 60–69, **F** 0–59.
 
 Because the scanned repository's own `.pinprick.toml` applies, a third-party repo can shape its own grade (`trusted-hosts`, `extra-data-formats`, `ignore` rules). Whenever a repo-local config changes the score, pinprick prints a note to stderr saying what it changed; pass `--no-repo-config` to ignore the file entirely.
+
+Container-action findings identify `docker://` references that use a tag instead of an immutable digest. `pinprick pin --write` does not resolve registry tags, so replace these references with a reviewed `@sha256:` digest manually.
 
 ## Example
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -220,6 +220,10 @@ pub async fn run(
             }
         }
 
+        for docker in workflow::scan_docker_refs(&content) {
+            push_docker_ref_result(&docker, &display_name, &mut collector);
+        }
+
         for action in workflow::scan_local_actions(&content) {
             let key = format!("local:{}", action.path);
             if !scanned_actions.insert(key) {
@@ -450,6 +454,51 @@ pub async fn run(
         Ok(ExitCode::from(1))
     } else {
         Ok(ExitCode::SUCCESS)
+    }
+}
+
+/// Surface `uses: docker://…` container refs. A digest-pinned image is the
+/// container analog of a SHA pin and is recorded as an allowed match;
+/// `:latest`/untagged floats with the registry (high), and a named tag is
+/// mutable and can be re-pushed (medium). No token or network is needed —
+/// the classification is purely syntactic.
+fn push_docker_ref_result(
+    docker: &workflow::DockerRef,
+    source_file: &str,
+    collector: &mut AuditCollector,
+) {
+    let action = docker.uses_ref();
+    match docker.pin {
+        workflow::DockerPin::Digest => collector.push_allowed(AuditMatch::new(
+            &audit_patterns::Severity::Low,
+            &audit_patterns::Category::DockerUnpinned,
+            &action,
+            source_file,
+            docker.line_number,
+            &docker.raw_line,
+            "digest-pinned image",
+        )),
+        workflow::DockerPin::Tag => collector.push_finding(AuditFinding::new(
+            &audit_patterns::Severity::Medium,
+            &audit_patterns::Category::DockerUnpinned,
+            &action,
+            source_file,
+            docker.line_number,
+            &docker.raw_line,
+            format!(
+                "container action image `{}` uses a mutable tag, not a digest",
+                docker.image
+            ),
+        )),
+        workflow::DockerPin::Latest => collector.push_finding(AuditFinding::new(
+            &audit_patterns::Severity::High,
+            &audit_patterns::Category::DockerUnpinned,
+            &action,
+            source_file,
+            docker.line_number,
+            &docker.raw_line,
+            format!("container action uses unpinned image `{}`", docker.image),
+        )),
     }
 }
 

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -47,6 +47,27 @@ async fn run_with_client(
         let actions = workflow::scan_content(&content);
         let mut replacements: Vec<(usize, String, String)> = Vec::new();
 
+        // Container refs are report-only: resolving a tag to a registry digest
+        // needs a registry client, so an unpinned image is surfaced as a skip
+        // (and fails a dry-run gate) rather than rewritten. Digest-pinned
+        // images are the container analog of a SHA pin and pass silently.
+        for docker in workflow::scan_docker_refs(&content) {
+            let reason = match docker.pin {
+                workflow::DockerPin::Digest => continue,
+                workflow::DockerPin::Tag => "mutable image tag — pin a digest (@sha256:…) manually",
+                workflow::DockerPin::Latest => {
+                    "floating image ref — pin a digest (@sha256:…) manually"
+                }
+            };
+            unpinnable += 1;
+            report.skipped.push(PinSkip {
+                file: workflow::display_path(file.path(), repo_root),
+                action: docker.uses_ref(),
+                reason: reason.to_string(),
+                line: docker.line_number,
+            });
+        }
+
         for action in &actions {
             match action.ref_type {
                 RefType::Sha => {}

--- a/src/score.rs
+++ b/src/score.rs
@@ -48,6 +48,8 @@ pub enum RuleId {
     PinBranch,
     PinSliding,
     PinFullTag,
+    PinDockerLatest,
+    PinDockerTag,
     SourceAdvisory,
     SourceArchived,
     RuntimePipeToShell,
@@ -65,6 +67,8 @@ impl RuleId {
             Self::PinBranch => "pin.branch",
             Self::PinSliding => "pin.sliding",
             Self::PinFullTag => "pin.full_tag",
+            Self::PinDockerLatest => "pin.docker_latest",
+            Self::PinDockerTag => "pin.docker_tag",
             Self::SourceAdvisory => "source.advisory",
             Self::SourceArchived => "source.archived",
             Self::RuntimePipeToShell => "runtime.pipe_to_shell",
@@ -79,7 +83,11 @@ impl RuleId {
 
     pub fn category(self) -> Category {
         match self {
-            Self::PinBranch | Self::PinSliding | Self::PinFullTag => Category::Pin,
+            Self::PinBranch
+            | Self::PinSliding
+            | Self::PinFullTag
+            | Self::PinDockerLatest
+            | Self::PinDockerTag => Category::Pin,
             Self::SourceAdvisory | Self::SourceArchived => Category::Source,
             Self::RuntimePipeToShell
             | Self::RuntimeFetchHigh
@@ -94,15 +102,17 @@ impl RuleId {
     pub fn severity(self) -> Severity {
         match self {
             Self::PinBranch
+            | Self::PinDockerLatest
             | Self::SourceAdvisory
             | Self::SourceArchived
             | Self::RuntimePipeToShell
             | Self::RuntimeFetchHigh
             | Self::WorkflowPermissionsWriteAll
             | Self::WorkflowPullRequestTarget => Severity::High,
-            Self::PinSliding | Self::RuntimeFetchMedium | Self::WorkflowWorkflowRun => {
-                Severity::Medium
-            }
+            Self::PinSliding
+            | Self::PinDockerTag
+            | Self::RuntimeFetchMedium
+            | Self::WorkflowWorkflowRun => Severity::Medium,
             Self::PinFullTag | Self::RuntimeFetchLow => Severity::Low,
         }
     }
@@ -110,10 +120,13 @@ impl RuleId {
     pub fn points(self) -> u32 {
         match self {
             Self::RuntimePipeToShell => 20,
-            Self::PinBranch | Self::SourceAdvisory | Self::RuntimeFetchHigh => 15,
+            Self::PinBranch
+            | Self::PinDockerLatest
+            | Self::SourceAdvisory
+            | Self::RuntimeFetchHigh => 15,
             Self::SourceArchived | Self::WorkflowPermissionsWriteAll => 10,
             Self::RuntimeFetchMedium => 8,
-            Self::PinSliding | Self::WorkflowPullRequestTarget => 5,
+            Self::PinSliding | Self::PinDockerTag | Self::WorkflowPullRequestTarget => 5,
             Self::RuntimeFetchLow | Self::WorkflowWorkflowRun => 3,
             Self::PinFullTag => 2,
         }
@@ -123,6 +136,9 @@ impl RuleId {
         match self {
             Self::PinBranch | Self::PinSliding | Self::PinFullTag => {
                 "Pin to a full 40-char SHA; keep the tag as a comment"
+            }
+            Self::PinDockerLatest | Self::PinDockerTag => {
+                "Pin the container image by digest (docker://image@sha256:…)"
             }
             Self::SourceAdvisory => {
                 "Update past the vulnerable version range; see the referenced GHSA"
@@ -271,6 +287,26 @@ pub fn score_repo(repo_root: &Path, config: &Config) -> Result<(ScoreReport, Con
                     line: a.line_number,
                 });
             }
+        }
+
+        // Container action pinning findings (`uses: docker://…`). A digest
+        // pin is the container analog of a SHA pin and deducts nothing.
+        for d in workflow::scan_docker_refs(&content) {
+            let action_ref = d.uses_ref();
+            unique_actions.insert(action_ref.clone());
+
+            let rule = match d.pin {
+                workflow::DockerPin::Digest => continue,
+                workflow::DockerPin::Tag => RuleId::PinDockerTag,
+                workflow::DockerPin::Latest => RuleId::PinDockerLatest,
+            };
+            action_findings
+                .entry((rule, action_ref))
+                .or_default()
+                .push(Occurrence {
+                    workflow: display.clone(),
+                    line: d.line_number,
+                });
         }
 
         // Workflow-level findings (workflow.*)

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -156,9 +156,6 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
         return None;
     }
 
-    // `docker://image@sha256:…` is a container reference, not a GitHub repo —
-    // parsing it would misread `docker:` as an owner and a digest-pinned image
-    // as an unpinned branch ref.
     if action_path.contains("://") {
         return None;
     }
@@ -257,36 +254,36 @@ pub fn build_pinned_line(line: &str, sha: &str, original_tag: &str) -> Option<St
     Some(format!("{prefix}{action_path}@{sha} # {original_tag}"))
 }
 
-/// Scan workflow YAML text and return all external action references.
-///
-/// Lines inside block scalars are skipped so that shell heredocs, inline docs,
-/// and `with: script: |` snippets can't false-match on literal `- uses:` text.
-pub fn scan_content(content: &str) -> Vec<ActionRef> {
-    let mut refs = Vec::new();
+/// Iterate the scannable lines of workflow YAML as `(1-based line number,
+/// line)`, skipping the bodies of block scalars so that shell heredocs, inline
+/// docs, and `with: script: |` snippets can't false-match on literal
+/// `- uses:` text.
+fn scannable_lines(content: &str) -> impl Iterator<Item = (usize, &str)> {
     let mut block_parent_col: Option<usize> = None;
 
-    for (i, line) in content.lines().enumerate() {
-        let line_num = i + 1;
-
+    content.lines().enumerate().filter_map(move |(i, line)| {
         if let Some(start_col) = block_parent_col {
             let indent = line.chars().take_while(|c| *c == ' ').count();
             if line.trim().is_empty() || indent > start_col {
-                continue;
+                return None;
             }
             block_parent_col = None;
         }
 
         if let Some(caps) = BLOCK_SCALAR_RE.captures(line) {
             block_parent_col = Some(caps.get(1).unwrap().as_str().len());
-            continue;
+            return None;
         }
 
-        if let Some(r) = parse_uses_line(line, line_num) {
-            refs.push(r);
-        }
-    }
+        Some((i + 1, line))
+    })
+}
 
-    refs
+/// Scan workflow YAML text and return all external action references.
+pub fn scan_content(content: &str) -> Vec<ActionRef> {
+    scannable_lines(content)
+        .filter_map(|(line_num, line)| parse_uses_line(line, line_num))
+        .collect()
 }
 
 /// Scan workflow YAML text and return local action references (`uses: ./path`).
@@ -295,31 +292,9 @@ pub fn scan_content(content: &str) -> Vec<ActionRef> {
 /// references another local action from its own `action.yml` is not followed —
 /// such a nested action is scanned only if a workflow also uses it directly.
 pub fn scan_local_actions(content: &str) -> Vec<LocalActionRef> {
-    let mut refs = Vec::new();
-    let mut block_parent_col: Option<usize> = None;
-
-    for (i, line) in content.lines().enumerate() {
-        let line_num = i + 1;
-
-        if let Some(start_col) = block_parent_col {
-            let indent = line.chars().take_while(|c| *c == ' ').count();
-            if line.trim().is_empty() || indent > start_col {
-                continue;
-            }
-            block_parent_col = None;
-        }
-
-        if let Some(caps) = BLOCK_SCALAR_RE.captures(line) {
-            block_parent_col = Some(caps.get(1).unwrap().as_str().len());
-            continue;
-        }
-
-        if let Some(r) = parse_local_uses_line(line, line_num) {
-            refs.push(r);
-        }
-    }
-
-    refs
+    scannable_lines(content)
+        .filter_map(|(line_num, line)| parse_local_uses_line(line, line_num))
+        .collect()
 }
 
 /// Scan a workflow file and return all external action references.

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -52,6 +52,13 @@ static LOCAL_USES_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"^\s*-?\s*uses:\s*(?:"([^"]+)"|'([^']+)'|([^#\s]+))\s*(?:#.*)?$"#).unwrap()
 });
 
+static DOCKER_USES_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"^\s*-?\s*uses:\s*(?:"docker://([^"]+)"|'docker://([^']+)'|docker://([^#\s]+))\s*(?:#.*)?$"#,
+    )
+    .unwrap()
+});
+
 // YAML block scalar openers (`run: |`, `script: >`, etc.), including
 // indent/chomping indicators (`|2-`, `>+`). Every block body is skipped so
 // literal docs or scripts cannot false-match on `uses:` text.
@@ -70,6 +77,79 @@ static BLOCK_SCALAR_RE: LazyLock<Regex> = LazyLock::new(|| {
 pub struct LocalActionRef {
     pub path: String,
     pub line_number: usize,
+}
+
+/// A container action reference: `uses: docker://image[:tag][@sha256:digest]`.
+#[derive(Debug, Clone)]
+pub struct DockerRef {
+    /// The image reference as written, without the `docker://` scheme
+    /// (e.g. `alpine:3.20`, `ghcr.io/owner/image@sha256:…`).
+    pub image: String,
+    pub pin: DockerPin,
+    pub line_number: usize,
+    pub raw_line: String,
+}
+
+impl DockerRef {
+    pub fn uses_ref(&self) -> String {
+        format!("docker://{}", self.image)
+    }
+}
+
+/// How a container image reference is pinned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DockerPin {
+    /// `@sha256:<64 hex>` digest — immutable, the container analog of a SHA pin.
+    Digest,
+    /// A named tag other than `latest` (e.g. `:3.20`) — mutable; the registry
+    /// can re-push different content under the same tag.
+    Tag,
+    /// `:latest` or no tag at all — tracks whatever the registry currently
+    /// serves, the container analog of a branch ref.
+    Latest,
+}
+
+/// Parse a single line into a container action reference
+/// (`uses: docker://…`), if any.
+pub fn parse_docker_uses_line(line: &str, line_number: usize) -> Option<DockerRef> {
+    let caps = DOCKER_USES_RE.captures(line)?;
+    let image = caps
+        .get(1)
+        .or_else(|| caps.get(2))
+        .or_else(|| caps.get(3))?
+        .as_str();
+    if image.is_empty() {
+        return None;
+    }
+
+    Some(DockerRef {
+        image: image.to_string(),
+        pin: classify_docker_image(image),
+        line_number,
+        raw_line: line.to_string(),
+    })
+}
+
+fn classify_docker_image(image: &str) -> DockerPin {
+    // `image@sha256:<hex>` — only a well-formed digest counts as pinned; a
+    // malformed one would not resolve, and must not read as pinned.
+    if let Some((_, digest)) = image.split_once('@') {
+        if let Some(hex) = digest.strip_prefix("sha256:")
+            && hex.len() == 64
+            && hex.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return DockerPin::Digest;
+        }
+        return DockerPin::Latest;
+    }
+
+    // The tag separator is a `:` after the last `/` — a colon before that is
+    // a registry port (`registry:5000/image`), not a tag.
+    let name_start = image.rfind('/').map_or(0, |i| i + 1);
+    match image[name_start..].split_once(':') {
+        Some((_, tag)) if !tag.is_empty() && tag != "latest" => DockerPin::Tag,
+        _ => DockerPin::Latest,
+    }
 }
 
 #[derive(Debug, Error)]
@@ -156,6 +236,10 @@ pub fn parse_uses_line(line: &str, line_number: usize) -> Option<ActionRef> {
         return None;
     }
 
+    // `docker://image@sha256:…` is a container reference, not a GitHub repo —
+    // parsing it here would misread `docker:` as an owner and a digest-pinned
+    // image as an unpinned branch ref. Container refs are handled by
+    // `parse_docker_uses_line` instead.
     if action_path.contains("://") {
         return None;
     }
@@ -294,6 +378,14 @@ pub fn scan_content(content: &str) -> Vec<ActionRef> {
 pub fn scan_local_actions(content: &str) -> Vec<LocalActionRef> {
     scannable_lines(content)
         .filter_map(|(line_num, line)| parse_local_uses_line(line, line_num))
+        .collect()
+}
+
+/// Scan workflow YAML text and return container action references
+/// (`uses: docker://…`).
+pub fn scan_docker_refs(content: &str) -> Vec<DockerRef> {
+    scannable_lines(content)
+        .filter_map(|(line_num, line)| parse_docker_uses_line(line, line_num))
         .collect()
 }
 
@@ -811,6 +903,91 @@ mod tests {
     #[test]
     fn skip_local_action() {
         assert!(parse_uses_line("      - uses: ./.github/actions/my-action@v1", 1).is_none());
+    }
+
+    // ── parse_docker_uses_line ──────────────────────────────────────────
+
+    #[test]
+    fn parse_docker_digest_pinned() {
+        let digest = "a".repeat(64);
+        let line = format!("      - uses: docker://ghcr.io/owner/image:v1@sha256:{digest}");
+        let r = parse_docker_uses_line(&line, 3).unwrap();
+        assert_eq!(r.pin, DockerPin::Digest);
+        assert_eq!(r.image, format!("ghcr.io/owner/image:v1@sha256:{digest}"));
+        assert_eq!(r.uses_ref(), format!("docker://{}", r.image));
+        assert_eq!(r.line_number, 3);
+    }
+
+    #[test]
+    fn parse_docker_malformed_digest_is_not_pinned() {
+        // A digest that isn't 64 hex chars can't resolve — it must not read
+        // as pinned.
+        let r = parse_docker_uses_line("      - uses: docker://alpine@sha256:abc123", 1).unwrap();
+        assert_eq!(r.pin, DockerPin::Latest);
+        let r = parse_docker_uses_line("      - uses: docker://alpine@md5:abcd", 1).unwrap();
+        assert_eq!(r.pin, DockerPin::Latest);
+    }
+
+    #[test]
+    fn parse_docker_named_tag() {
+        let r = parse_docker_uses_line("      - uses: docker://alpine:3.20", 1).unwrap();
+        assert_eq!(r.pin, DockerPin::Tag);
+        assert_eq!(r.image, "alpine:3.20");
+    }
+
+    #[test]
+    fn parse_docker_latest_and_untagged() {
+        for line in [
+            "      - uses: docker://alpine:latest",
+            "      - uses: docker://alpine",
+            "      - uses: docker://ghcr.io/owner/image",
+        ] {
+            let r = parse_docker_uses_line(line, 1).unwrap();
+            assert_eq!(r.pin, DockerPin::Latest, "line {line:?}");
+        }
+    }
+
+    #[test]
+    fn parse_docker_registry_port_is_not_a_tag() {
+        // The colon before the last `/` is a registry port, not a tag.
+        let r =
+            parse_docker_uses_line("      - uses: docker://registry:5000/team/tool", 1).unwrap();
+        assert_eq!(r.pin, DockerPin::Latest);
+        let r = parse_docker_uses_line("      - uses: docker://registry:5000/team/tool:2.1", 1)
+            .unwrap();
+        assert_eq!(r.pin, DockerPin::Tag);
+    }
+
+    #[test]
+    fn parse_docker_quoted_with_comment() {
+        let r = parse_docker_uses_line("      - uses: \"docker://alpine:3.20\" # pinned-ish", 1)
+            .unwrap();
+        assert_eq!(r.pin, DockerPin::Tag);
+        let r = parse_docker_uses_line("      - uses: 'docker://alpine:latest'", 1).unwrap();
+        assert_eq!(r.pin, DockerPin::Latest);
+    }
+
+    #[test]
+    fn parse_docker_ignores_non_docker_lines() {
+        assert!(parse_docker_uses_line("      - uses: actions/checkout@v4", 1).is_none());
+        assert!(parse_docker_uses_line("      - uses: ./local/action", 1).is_none());
+        assert!(parse_docker_uses_line("      - run: docker://alpine", 1).is_none());
+    }
+
+    #[test]
+    fn scan_docker_refs_skips_block_scalars() {
+        let yaml = "\
+jobs:
+  test:
+    steps:
+      - run: |
+          echo uses: docker://fake:latest
+      - uses: docker://real:latest
+";
+        let refs = scan_docker_refs(yaml);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].image, "real:latest");
+        assert_eq!(refs[0].line_number, 6);
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -984,6 +984,102 @@ fn git_clone_versioned_branch_clean() {
     assert!(findings.is_empty());
 }
 
+// ── docker:// container refs ────────────────────────────────────────────────
+
+#[test]
+fn docker_uses_latest_and_tag_are_findings_digest_is_allowed() {
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:latest
+      - uses: docker://alpine
+      - uses: docker://alpine:3.20
+      - uses: docker://ghcr.io/org/tool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg("--verbose")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 3);
+    // Sorted high before medium.
+    assert_eq!(findings[0]["severity"], "high");
+    assert_eq!(findings[0]["category"], "docker_unpinned");
+    assert_eq!(findings[0]["action"], "docker://alpine:latest");
+    assert_eq!(findings[0]["line"], 7);
+    assert_eq!(findings[1]["severity"], "high");
+    assert_eq!(findings[1]["action"], "docker://alpine");
+    assert_eq!(findings[2]["severity"], "medium");
+    assert_eq!(findings[2]["action"], "docker://alpine:3.20");
+    assert!(
+        findings[2]["description"]
+            .as_str()
+            .unwrap()
+            .contains("mutable tag")
+    );
+
+    // The digest-pinned image is visible as an allowed match under --verbose.
+    let allowed = json["allowed"].as_array().unwrap();
+    assert!(allowed.iter().any(|entry| {
+        entry["reason"] == "digest-pinned image"
+            && entry["action"]
+                .as_str()
+                .unwrap()
+                .starts_with("docker://ghcr.io/org/tool@sha256:")
+    }));
+}
+
+#[test]
+fn docker_uses_digest_pinned_exits_zero() {
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:3.20@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      - run: echo ok
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn docker_uses_inside_run_block_is_not_a_finding() {
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo 'uses: docker://alpine:latest'
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
 #[test]
 fn no_token_reports_external_actions_skipped() {
     let workflow = "\

--- a/tests/pin.rs
+++ b/tests/pin.rs
@@ -82,3 +82,50 @@ fn no_token_json_error() {
             .contains("No GitHub token found")
     );
 }
+
+#[test]
+fn docker_unpinned_ref_is_reported_and_fails_dry_run() {
+    // No network: docker refs are classified syntactically, so a dummy token
+    // suffices. An unpinned container image is exactly what a pin gate exists
+    // to catch — dry-run must exit 1.
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:latest
+      - uses: docker://alpine:3.20
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    common::pinprick_cmd()
+        .env("GITHUB_TOKEN", "dummy")
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("docker://alpine:latest"))
+        .stdout(predicate::str::contains("floating image ref"))
+        .stdout(predicate::str::contains("mutable image tag"));
+}
+
+#[test]
+fn docker_digest_pinned_ref_passes_dry_run() {
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://ghcr.io/org/tool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    common::pinprick_cmd()
+        .env("GITHUB_TOKEN", "dummy")
+        .arg("pin")
+        .arg(dir.path())
+        .assert()
+        .code(0);
+}

--- a/tests/score.rs
+++ b/tests/score.rs
@@ -342,6 +342,70 @@ fn html_output_contains_expected_markers() {
     assert!(html.ends_with("</html>\n"));
 }
 
+const WORKFLOW_DOCKER_REFS: &str = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://alpine:latest
+      - uses: docker://alpine:3.20
+      - uses: docker://ghcr.io/org/tool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+";
+
+#[test]
+fn docker_refs_fire_pin_docker_rules() {
+    let dir = common::repo_with_workflow("ci.yml", WORKFLOW_DOCKER_REFS);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // latest (15) + mutable tag (5); the digest-pinned image deducts nothing.
+    assert_eq!(json["score"], 80);
+    let findings = json["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0]["id"], "pin.docker_latest");
+    assert_eq!(findings[0]["points"], 15);
+    assert_eq!(findings[0]["severity"], "high");
+    assert_eq!(findings[0]["action_ref"], "docker://alpine:latest");
+    assert_eq!(findings[1]["id"], "pin.docker_tag");
+    assert_eq!(findings[1]["points"], 5);
+    assert_eq!(findings[1]["severity"], "medium");
+    assert_eq!(findings[1]["action_ref"], "docker://alpine:3.20");
+    // All three container refs count as unique actions.
+    assert_eq!(json["totals"]["unique_actions"], 3);
+}
+
+#[test]
+fn docker_digest_only_scores_clean() {
+    let workflow = "\
+name: docker
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://ghcr.io/org/tool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+";
+    let dir = common::repo_with_workflow("ci.yml", workflow);
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("score")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["coverage_complete"], true);
+}
+
 #[test]
 fn badge_output_is_shields_endpoint_json() {
     let dir = common::repo_with_workflow("ci.yml", common::WORKFLOW_CLEAN);


### PR DESCRIPTION
`parse_uses_line` returns None for any path containing `://`, so `uses: docker://alpine:latest` was invisible to pin, audit, and score alike. That is a blind spot for a pinning tool, especially since audit already flags `FROM :latest` inside Dockerfiles.

Container refs are parsed into their own class and classified syntactically, so no token or network is needed: a well-formed `@sha256:` digest is the container analog of a SHA pin and passes, a named tag is mutable and can be re-pushed (medium), and `:latest` or no tag floats with the registry (high). A malformed digest reads as unpinned rather than pinned.

audit reports them, score adds `pin.docker_latest` and `pin.docker_tag` (rubric 0.10.0), and pin surfaces them as skips that fail a dry-run gate. pin does not rewrite them: resolving a tag to a registry digest needs a registry client, so the fix stays a documented manual step.

Worth knowing on upgrade: a repository using `uses: docker://image:tag` will see `pinprick pin` start failing its dry-run gate, with a manual digest pin as the remedy.

The first commit is a pure refactor with no behavior change, extracting the shared block-scalar-skipping line iterator that the new scanner reuses.
