### PR TITLE
chore: release 0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps the crate to 0.23.0 so the Release workflow can tag and publish it. No source changes; `Cargo.lock` moves with the manifest.

This release ships scoring rubric 0.10.0. Container action references are parsed and scored for the first time, so a repository using `uses: docker://image:tag` will see `pinprick pin` start failing its dry-run gate, with a manual digest pin as the remedy. Token-gated runs additionally score runtime findings from fetched remote action source, and reports and badges declare incomplete coverage rather than presenting a partial score as final.

Verified with `cargo build --locked` and confirmed the built binary reports `pinprick 0.23.0`.

AI/LLM disclosure: drafted with Claude Code (Opus 5), which made the version edit, refreshed the lockfile, and ran the build verification. Reviewed against the repository release conventions and the diff was checked before commit.