### PR TITLE
test: broaden unit coverage for audit, workflow, config, and output

### DIFF
--- a/src/audit_shell.rs
+++ b/src/audit_shell.rs
@@ -831,4 +831,91 @@ mod tests {
         assert!(joined[0].1.contains("curl"));
         assert!(joined[0].1.contains("| sh"));
     }
+
+    #[test]
+    fn join_continuations_keeps_dangling_continuation() {
+        assert_eq!(
+            join_continuations("echo unfinished \\"),
+            vec![(0, "echo unfinished ".into())]
+        );
+    }
+
+    #[test]
+    fn shell_split_handles_escaped_controls_and_or_operator() {
+        assert_eq!(
+            split_shell_control(r#"printf one\;two || printf 'three;four'"#),
+            vec![r#"printf one\;two"#, "printf 'three;four'"]
+        );
+    }
+
+    #[test]
+    fn shell_words_handles_escaped_whitespace_and_append_redirect() {
+        assert_eq!(
+            shell_words(r#"curl -o tool\ file https://example.com/tool >> download.log"#),
+            vec![
+                "curl",
+                "-o",
+                "tool file",
+                "https://example.com/tool",
+                ">>",
+                "download.log",
+            ]
+        );
+    }
+
+    #[test]
+    fn docker_image_extraction_handles_cli_prefixes_and_options() {
+        for (line, expected) in [
+            ("docker image pull alpine", vec!["alpine"]),
+            (
+                "env DOCKER_HOST=local docker container run --platform=linux alpine",
+                vec!["alpine"],
+            ),
+            ("docker run -e MODE=test alpine", vec!["alpine"]),
+            ("docker run -- alpine", vec!["alpine"]),
+            ("docker pull --platform", vec![]),
+        ] {
+            assert_eq!(docker_unpinned_images(line), expected, "line: {line}");
+        }
+    }
+
+    #[test]
+    fn fetch_output_targets_handles_option_and_redirect_forms() {
+        for (line, expected) in [
+            ("curl --output=tool https://example.com/tool", vec!["tool"]),
+            ("curl -sLo tool https://example.com/tool", vec!["tool"]),
+            (
+                "curl --compressed -otool https://example.com/tool",
+                vec!["tool"],
+            ),
+            (
+                "wget --output-document=tool https://example.com/tool",
+                vec!["tool"],
+            ),
+            ("wget -Otool https://example.com/tool", vec!["tool"]),
+            ("curl https://example.com/tool >> tool", vec!["tool"]),
+        ] {
+            assert_eq!(fetch_output_targets(line), expected, "line: {line}");
+        }
+    }
+
+    #[test]
+    fn git_clone_parses_equals_flags_and_attached_checkout_directory() {
+        let sha = "0123456789abcdef0123456789abcdef01234567";
+        let script = format!(
+            "git clone --depth=1 --quiet https://example.com/o/r.git\ngit -C././r checkout {sha}\n"
+        );
+        let logical = join_continuations(&script);
+
+        assert!(git_clone_has_bound_sha_checkout(&logical, 0));
+    }
+
+    #[test]
+    fn git_command_without_checkout_does_not_bind_clone() {
+        let logical = join_continuations(
+            "git clone --depth=1 --quiet https://example.com/o/r.git\ngit -C r status\n",
+        );
+
+        assert!(!git_clone_has_bound_sha_checkout(&logical, 0));
+    }
 }

--- a/src/audit_source.rs
+++ b/src/audit_source.rs
@@ -621,6 +621,7 @@ runs:
   using: node20
   args:
     - --flag
+    - {cmd: "curl -L https://example.com/unversioned.sh | sh"}
     - curl -L https://example.com/install.sh -o install.sh
 "#,
         )
@@ -745,6 +746,44 @@ runs:
         );
         assert!(normalize_action_entrypoint_path("", "/tmp/runner").is_none());
         assert!(normalize_action_entrypoint_path("", r"dist\\runner").is_none());
+        assert!(normalize_action_entrypoint_path("", ".").is_none());
+
+        let no_runs: Value = serde_norway::from_str("name: test\n").unwrap();
+        assert!(action_yml_entrypoint_paths(&no_runs, "").is_empty());
+    }
+
+    #[test]
+    fn force_include_remote_entrypoints_ignores_unavailable_metadata() {
+        for content in [None, Some(Ok("runs: [".to_string()))] {
+            let mut targets = vec![("action.yml".to_string(), SourceFileKind::ActionYml)];
+            force_include_remote_action_entrypoints(&mut targets, &[content]);
+            assert_eq!(targets.len(), 1);
+        }
+    }
+
+    #[test]
+    fn force_include_local_entrypoints_ignores_unavailable_metadata() {
+        let repo = tempfile::TempDir::new().unwrap();
+        let action_dir = repo.path().join("action");
+        std::fs::create_dir(&action_dir).unwrap();
+
+        let missing = action_dir.join("missing.yml");
+        let mut targets = vec![(missing, SourceFileKind::ActionYml)];
+        force_include_local_action_entrypoints(repo.path(), &action_dir, &mut targets);
+        assert_eq!(targets.len(), 1);
+
+        let malformed = action_dir.join("action.yml");
+        std::fs::write(&malformed, "runs: [").unwrap();
+        let mut targets = vec![(malformed, SourceFileKind::ActionYml)];
+        force_include_local_action_entrypoints(repo.path(), &action_dir, &mut targets);
+        assert_eq!(targets.len(), 1);
+
+        let metadata = repo.path().join("metadata.yml");
+        std::fs::write(&metadata, "runs:\n  using: node20\n  main: runner\n").unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let mut targets = vec![(metadata, SourceFileKind::ActionYml)];
+        force_include_local_action_entrypoints(repo.path(), outside.path(), &mut targets);
+        assert_eq!(targets.len(), 1);
     }
 
     #[test]
@@ -772,6 +811,9 @@ runs:
         let js: Value =
             serde_norway::from_str("runs:\n  using: node20\n  main: dist/index.js\n").unwrap();
         assert!(action_yml_dockerfile_path(&js, "").is_none());
+        let js_with_image: Value =
+            serde_norway::from_str("runs:\n  using: node20\n  image: Dockerfile\n").unwrap();
+        assert!(action_yml_dockerfile_path(&js_with_image, "").is_none());
 
         let no_image: Value = serde_norway::from_str("runs:\n  using: docker\n").unwrap();
         assert!(action_yml_dockerfile_path(&no_image, "").is_none());
@@ -907,6 +949,11 @@ runs:
         )
         .unwrap();
         std::fs::write(
+            action_dir.join("setup.py"),
+            "requests.get('https://example.com/x')",
+        )
+        .unwrap();
+        std::fs::write(
             action_dir.join("node_modules/dep/index.js"),
             "fetch('https://evil.example/x')",
         )
@@ -928,8 +975,70 @@ runs:
                 "action.yml",
                 "dist/helper.mjs",
                 "dist/index.js",
+                "setup.py",
                 "src/main.cjs"
             ]
+        );
+    }
+
+    #[test]
+    fn read_local_source_file_returns_none_for_missing_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(
+            read_local_source_file(dir.path(), &dir.path().join("missing.js"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn scan_local_action_source_handles_empty_and_malformed_actions() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let action_dir = dir.path().join("empty");
+        std::fs::create_dir(&action_dir).unwrap();
+        let action = LocalActionRef {
+            path: "./empty".to_string(),
+            line_number: 1,
+        };
+        let mut collector = AuditCollector::new(false);
+
+        assert_eq!(
+            scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).unwrap(),
+            ActionScanStatus::Complete
+        );
+
+        std::fs::write(action_dir.join("action.yml"), "runs: [").unwrap();
+        assert_eq!(
+            scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).unwrap(),
+            ActionScanStatus::Incomplete
+        );
+        assert!(collector.findings.is_empty());
+    }
+
+    #[test]
+    fn scan_local_action_source_scans_python() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let action_dir = dir.path().join("python-action");
+        std::fs::create_dir(&action_dir).unwrap();
+        std::fs::write(
+            action_dir.join("setup.py"),
+            "requests.get('https://example.com/install')\n",
+        )
+        .unwrap();
+        let action = LocalActionRef {
+            path: "./python-action".to_string(),
+            line_number: 1,
+        };
+        let mut collector = AuditCollector::new(false);
+
+        assert_eq!(
+            scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).unwrap(),
+            ActionScanStatus::Complete
+        );
+        assert_eq!(collector.findings.len(), 1);
+        assert_eq!(
+            collector.findings[0].source_file,
+            "./python-action (setup.py)"
         );
     }
 
@@ -1012,6 +1121,26 @@ runs:
         assert!(
             scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG).is_err()
         );
+    }
+
+    #[test]
+    fn scan_local_action_source_rejects_invalid_or_missing_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut collector = AuditCollector::new(false);
+
+        for (path, expected) in [
+            ("local", "local action path must start with ./"),
+            ("./missing", "is not a directory"),
+        ] {
+            let action = LocalActionRef {
+                path: path.to_string(),
+                line_number: 1,
+            };
+            let err =
+                scan_local_action_source(dir.path(), &action, &mut collector, &DEFAULT_CONFIG)
+                    .unwrap_err();
+            assert!(err.to_string().contains(expected), "path: {path}: {err}");
+        }
     }
 
     #[test]
@@ -1268,6 +1397,79 @@ runs:
         assert_eq!(status, ActionScanStatus::Complete);
         assert_eq!(collector.findings.len(), 1);
         assert_eq!(collector.findings[0].source_file, "o/r (dist/runner)");
+    }
+
+    #[tokio::test]
+    async fn scan_action_source_routes_python_and_reachable_dockerfile() {
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/repos/o/r/git/trees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "tree": [
+                    { "path": "action.yml", "type": "blob" },
+                    { "path": "sub/action.yml", "type": "blob" },
+                    { "path": "setup.py", "type": "blob" },
+                    { "path": "sub/Dockerfile", "type": "blob" }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        for (source_path, content) in [
+            ("action.yml", "runs: ["),
+            (
+                "sub/action.yml",
+                "runs:\n  using: docker\n  image: Dockerfile\n",
+            ),
+            ("setup.py", "requests.get('https://example.com/install')\n"),
+            (
+                "sub/Dockerfile",
+                "FROM alpine:3.20\nRUN curl https://example.com/install -o tool\n",
+            ),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/o/r/contents/{source_path}")))
+                .respond_with(ResponseTemplate::new(200).set_body_string(content))
+                .mount(&server)
+                .await;
+        }
+
+        let client = GitHubClient::with_base("t".into(), server.uri());
+        let action = ActionRef {
+            owner: "o".into(),
+            repo: "r".into(),
+            subpath: None,
+            ref_string: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+            ref_type: workflow::RefType::Sha,
+            tag_comment: Some("v1.0.0".into()),
+            line_number: 1,
+            raw_line: String::new(),
+        };
+        let mut collector = AuditCollector::new(false);
+
+        let status = scan_action_source(&client, &action, &mut collector, &DEFAULT_CONFIG)
+            .await
+            .unwrap();
+
+        assert_eq!(status, ActionScanStatus::Incomplete);
+        assert_eq!(collector.findings.len(), 2);
+        assert!(
+            collector
+                .findings
+                .iter()
+                .any(|finding| finding.source_file == "o/r (setup.py)")
+        );
+        assert!(
+            collector
+                .findings
+                .iter()
+                .any(|finding| finding.source_file == "o/r (sub/Dockerfile)")
+        );
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -513,6 +513,14 @@ trusted-hosts = ["artifacts.example.com", "releases.example.org"]
         assert!(!high.meets_severity("medium"));
         assert!(!high.meets_severity("low"));
 
+        let medium = Config {
+            severity: SeverityFilter::Medium,
+            ..Config::default()
+        };
+        assert_eq!(medium.severity_threshold(), 1);
+        assert!(medium.meets_severity("medium"));
+        assert!(!medium.meets_severity("low"));
+
         let low = Config::default();
         assert!(low.meets_severity("low"));
         assert!(low.meets_severity("high"));
@@ -568,6 +576,21 @@ trusted-hosts = ["artifacts.example.com", "releases.example.org"]
         };
         assert_eq!(cfg.severity, SeverityFilter::High);
         assert!(cfg.fetch_remote);
+    }
+
+    #[test]
+    fn load_repo_file_treats_missing_root_and_unreadable_file_as_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(matches!(
+            load_repo_file(&dir.path().join("missing"), ".pinprick.toml"),
+            ConfigLoad::Absent
+        ));
+
+        std::fs::create_dir(dir.path().join(".pinprick.toml")).unwrap();
+        assert!(matches!(
+            load_repo_file(dir.path(), ".pinprick.toml"),
+            ConfigLoad::Absent
+        ));
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1083,26 +1083,61 @@ mod audit_summary_tests {
         assert!(out.contains("# v1.2.3\u{fffd}rewrite"));
         assert!(out.contains("skip\u{fffd}action"));
         assert!(out.contains("branch\u{fffd}[31m ref"));
+        assert!(out.contains("(1 skipped)"));
         assert!(!out.contains('\u{7}'));
         assert!(!out.contains('\r'));
         assert!(!out.contains('\u{7f}'));
     }
 
     #[test]
+    fn pin_human_output_reports_applied_summary() {
+        let report = PinReport {
+            pinned: vec![PinResult {
+                file: ".github/workflows/ci.yml".into(),
+                action: "owner/action".into(),
+                old_ref: "v1".into(),
+                sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                tag: "v1".into(),
+                line: 1,
+            }],
+            skipped: vec![],
+            applied: true,
+        };
+        let mut buf = Vec::new();
+        report.write_human(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("Pinned 1 action across 1 file"));
+        assert!(!out.contains("Would pin"));
+    }
+
+    #[test]
     fn update_human_output_sanitizes_untrusted_fields() {
         let report = UpdateReport {
-            updates: vec![UpdateResult {
-                file: ".github/workflows/ci.yml".into(),
-                action: "evil\u{1b}[2J/action".into(),
-                current_tag: "v1\u{7}".into(),
-                current_sha: "0123456789abcdef0123456789abcdef01234567".into(),
-                latest_tag: "v2\rrewrite".into(),
-                latest_sha: "abcdef0123456789abcdef0123456789abcdef01".into(),
-                line: 1,
-                release_url: Some("https://example.com/release\u{7f}".into()),
-            }],
+            updates: vec![
+                UpdateResult {
+                    file: ".github/workflows/ci.yml".into(),
+                    action: "evil\u{1b}[2J/action".into(),
+                    current_tag: "v1\u{7}".into(),
+                    current_sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                    latest_tag: "v2\rrewrite".into(),
+                    latest_sha: "abcdef0123456789abcdef0123456789abcdef01".into(),
+                    line: 1,
+                    release_url: Some("https://example.com/release\u{7f}".into()),
+                },
+                UpdateResult {
+                    file: ".github/workflows/other.yml".into(),
+                    action: "other/action".into(),
+                    current_tag: "v1".into(),
+                    current_sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                    latest_tag: "v2".into(),
+                    latest_sha: "abcdef0123456789abcdef0123456789abcdef01".into(),
+                    line: 2,
+                    release_url: None,
+                },
+            ],
             up_to_date: 0,
-            applied: false,
+            applied: true,
         };
         let mut buf = Vec::new();
         report.write_human(&mut buf).unwrap();
@@ -1112,9 +1147,49 @@ mod audit_summary_tests {
         assert!(out.contains("v1\u{fffd}"));
         assert!(out.contains("v2\u{fffd}rewrite"));
         assert!(out.contains("https://example.com/release\u{fffd}"));
+        assert!(out.contains("2 updates applied."));
         assert!(!out.contains('\u{7}'));
         assert!(!out.contains('\r'));
         assert!(!out.contains('\u{7f}'));
+    }
+
+    #[test]
+    fn update_human_output_reports_empty_summary() {
+        let empty = UpdateReport {
+            updates: vec![],
+            up_to_date: 1,
+            applied: false,
+        };
+        let mut buf = Vec::new();
+        empty.write_human(&mut buf).unwrap();
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            "All pinned actions are up to date.\n"
+        );
+    }
+
+    #[test]
+    fn update_human_output_reports_dry_run_summary() {
+        let dry_run = UpdateReport {
+            updates: vec![UpdateResult {
+                file: ".github/workflows/ci.yml".into(),
+                action: "owner/action".into(),
+                current_tag: "v1".into(),
+                current_sha: "0123456789abcdef0123456789abcdef01234567".into(),
+                latest_tag: "v2".into(),
+                latest_sha: "abcdef0123456789abcdef0123456789abcdef01".into(),
+                line: 1,
+                release_url: None,
+            }],
+            up_to_date: 0,
+            applied: false,
+        };
+        let mut buf = Vec::new();
+        dry_run.write_human(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("1 update available."));
+        assert!(out.contains("--write"));
     }
 
     #[test]

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -268,10 +268,10 @@ mod tests {
             .mount(&server)
             .await;
 
-        let original = "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4\n";
+        let original = "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4\n      - uses: actions/checkout@v4\n";
         let (dir, file) = repo_with_workflow(original);
 
-        let code = run_with_client(dir.path(), true, false, &client_for(&server))
+        let code = run_with_client(dir.path(), false, false, &client_for(&server))
             .await
             .unwrap();
 
@@ -330,7 +330,7 @@ mod tests {
         let original = "jobs:\n  test:\n    steps:\n      - uses: o/r@v9\n";
         let (dir, file) = repo_with_workflow(original);
 
-        let code = run_with_client(dir.path(), true, false, &client_for(&server))
+        let code = run_with_client(dir.path(), false, false, &client_for(&server))
             .await
             .unwrap();
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -595,11 +595,11 @@ mod tests {
             mount_tag_resolution(&server, "actions/checkout", "v1.1.0", NEW_SHA).await;
 
             let original = format!(
-                "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@{OLD_SHA} # v1.0.0\n"
+                "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@{OLD_SHA} # v1.0.0\n      - uses: actions/checkout@{OLD_SHA} # v1.0.0\n"
             );
             let (dir, file) = repo_with_workflow(&original);
 
-            let code = run_with_client(dir.path(), false, true, None, &client_for(&server))
+            let code = run_with_client(dir.path(), false, false, None, &client_for(&server))
                 .await
                 .unwrap();
 
@@ -625,17 +625,19 @@ mod tests {
             mount_tag_resolution(&server, "o/r", "v2.0.0", NEW_SHA).await;
 
             let (dir, file) = repo_with_workflow(&format!(
-                "jobs:\n  test:\n    steps:\n      - uses: o/r@{OLD_SHA} # v1.0.0\n"
+                "jobs:\n  test:\n    steps:\n      - uses: o/r@{OLD_SHA} # v1.0.0\n      - uses: o/r@{OLD_SHA} # v1.0.0\n"
             ));
 
-            let code = run_with_client(dir.path(), true, true, None, &client_for(&server))
+            let code = run_with_client(dir.path(), true, false, None, &client_for(&server))
                 .await
                 .unwrap();
 
             assert_code(code, 0);
             assert_eq!(
                 std::fs::read_to_string(&file).unwrap(),
-                format!("jobs:\n  test:\n    steps:\n      - uses: o/r@{NEW_SHA} # v2.0.0\n")
+                format!(
+                    "jobs:\n  test:\n    steps:\n      - uses: o/r@{NEW_SHA} # v2.0.0\n      - uses: o/r@{NEW_SHA} # v2.0.0\n"
+                )
             );
         }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1015,6 +1015,7 @@ jobs:
         assert!(parse_uses_line("      - run: echo hello", 1).is_none());
         assert!(parse_uses_line("name: CI", 1).is_none());
         assert!(parse_uses_line("", 1).is_none());
+        assert!(parse_uses_line("      - uses: checkout@v4", 1).is_none());
     }
 
     #[test]
@@ -1428,6 +1429,22 @@ jobs:
     }
 
     #[test]
+    fn find_workflows_skips_forge_root_without_workflows_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join(".github")).unwrap();
+        let workflows = dir.path().join(".gitea/workflows");
+        std::fs::create_dir_all(&workflows).unwrap();
+        std::fs::write(workflows.join("ci.yml"), "").unwrap();
+
+        let files = find_workflows(dir.path()).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            display_path(files[0].path(), dir.path()),
+            ".gitea/workflows/ci.yml"
+        );
+    }
+
+    #[test]
     fn find_workflows_error_lists_all_forge_roots() {
         // With no workflow directory anywhere, the error names every root tried
         // so the user knows a Forgejo/Gitea layout is also supported.
@@ -1465,6 +1482,57 @@ jobs:
         let err = read_workflow(&file).unwrap_err();
         assert!(is_unsafe_workflow_path(&err));
         assert!(err.to_string().contains("symlinked workflow file"));
+    }
+
+    #[test]
+    fn read_workflow_reports_file_removed_after_discovery() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = write_temp_workflow(&dir, "ci.yml", "name: safe\n");
+        std::fs::remove_file(file.path()).unwrap();
+
+        let err = read_workflow(&file).unwrap_err();
+        assert!(!is_unsafe_workflow_path(&err));
+        assert!(err.to_string().contains("reading"));
+    }
+
+    #[test]
+    fn child_path_helpers_reject_escaping_and_missing_paths() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        assert!(open_child_dir_path(dir.path(), Path::new("../outside")).is_err());
+        assert!(open_child_file_path(dir.path(), Path::new("../outside")).is_err());
+        assert!(
+            open_child_dir_path(dir.path(), Path::new("missing/child"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            open_child_file_path(dir.path(), Path::new("missing/child"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            open_child_file_path(dir.path(), Path::new(""))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_path_helpers_reject_non_utf8_and_symlinked_file() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let invalid = PathBuf::from(std::ffi::OsString::from_vec(vec![0xff]));
+        assert!(open_child_dir_path(dir.path(), &invalid).is_err());
+        assert!(open_child_file_path(dir.path(), &invalid).is_err());
+
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), dir.path().join("linked.yml")).unwrap();
+        let err = open_child_file_path(dir.path(), Path::new("linked.yml")).unwrap_err();
+        assert!(is_unsafe_workflow_path(&err));
+        assert!(err.to_string().contains("symlinked file"));
     }
 
     // ── rewrite_actions ────────────────────────────────────────────────
@@ -1527,6 +1595,16 @@ jobs:
         let err =
             rewrite_actions(&file, &[(99, "old".to_string(), "nope".to_string())]).unwrap_err();
         assert!(err.to_string().contains("line 99 no longer exists"));
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), "line1\n");
+    }
+
+    #[test]
+    fn rewrite_rejects_zero_line_number() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = write_temp_workflow(&dir, "test.yml", "line1\n");
+        let err =
+            rewrite_actions(&file, &[(0, "line1".to_string(), "nope".to_string())]).unwrap_err();
+        assert!(err.to_string().contains("invalid line number 0"));
         assert_eq!(std::fs::read_to_string(file.path()).unwrap(), "line1\n");
     }
 


### PR DESCRIPTION
Test-only change that broadens unit coverage across the audit, workflow, config, and output modules. No production code is modified; every hunk falls inside a `#[cfg(test)]` module.

New tests cover shell tokenization and the fetch-target extraction layer, including line continuations, escaped control operators, Docker CLI prefix and option parsing, curl and wget output targets, and git clone to SHA-checkout binding. On the action-source side they cover selection and its fail-closed behavior when action metadata is missing or malformed, routing of Python sources, and the invariant that a Dockerfile is scanned only when a container action's `runs.image` names it. The workflow tests cover discovery across forge roots, path-traversal and non-UTF-8 rejection, symlink refusal, removal of a file after discovery, and the rewrite line-number guard. The remainder cover configuration severity thresholds and unreadable repository configuration, and the human-readable pin and update summaries.

Coverage moves from 95.53% to 96.81%, with missed lines down from 550 to 404.

AI disclosure: Claude Opus 5 with mutation testing of each added assertion against the branch it covers, plus cargo test, clippy, rustfmt, and npm policy checks.
