### PR TITLE
chore: release 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps `version` in `Cargo.toml` and the `pinprick` entry in `Cargo.lock` to 0.23.1, cutting the release that ships the dependency updates landed since 0.23.0 (notably h2 0.4.16).

Patch rather than minor: every `src/` change since v0.23.0 lives inside `#[cfg(test)]` modules, so the CLI's behavior is unchanged.

AI disclosure: Claude Opus 5 with cargo check --locked, cargo fmt --check, cargo clippy --all-targets, and the full cargo test suite run locally.