### PR TITLE
docs: point action examples at pinprick-action v0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@a663b6d119c2e5f4ff239bfdf155f50143e67706 # v0.4.2
+        uses: starhaven-io/pinprick-action@475e6e84a584bc6d5d6f65958beff2732905f8a3 # v0.5.3
 ```
 
 The action wraps `pinprick audit` only. Use the CLI directly for `pin`, `update`, and `score`. For console-mode pull request feedback, set `advanced-security: false`; see the action README for the full matrix.

--- a/site/src/content/docs/getting-started/github-action.md
+++ b/site/src/content/docs/getting-started/github-action.md
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@a663b6d119c2e5f4ff239bfdf155f50143e67706 # v0.4.2
+        uses: starhaven-io/pinprick-action@475e6e84a584bc6d5d6f65958beff2732905f8a3 # v0.5.3
 ```
 
 ## Usage without GitHub Advanced Security
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Run pinprick
-        uses: starhaven-io/pinprick-action@a663b6d119c2e5f4ff239bfdf155f50143e67706 # v0.4.2
+        uses: starhaven-io/pinprick-action@475e6e84a584bc6d5d6f65958beff2732905f8a3 # v0.5.3
         with:
           advanced-security: false
 ```
@@ -83,7 +83,7 @@ Each example pins `pinprick-action` to a full commit SHA with the release tag in
 
 ```yaml
 - name: Run pinprick
-  uses: starhaven-io/pinprick-action@a663b6d119c2e5f4ff239bfdf155f50143e67706 # v0.4.2
+  uses: starhaven-io/pinprick-action@475e6e84a584bc6d5d6f65958beff2732905f8a3 # v0.5.3
   with:
     fail-on-findings: true
 ```
@@ -92,7 +92,7 @@ Each example pins `pinprick-action` to a full commit SHA with the release tag in
 
 | Input               | Default  | Meaning                                                                                                                                                                              |
 | ------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `version`           | `0.21.0` | pinprick version to install. The `v0.4.2` action release pins this default for deterministic runs. Use `latest` for the newest pinprick release, or an exact version like `v0.21.0`. |
+| `version`           | `0.23.1` | pinprick version to install. The `v0.5.3` action release pins this default for deterministic runs. Use `latest` for the newest pinprick release, or an exact version like `v0.23.1`. |
 | `path`              | `.`      | Repository path to scan.                                                                                                                                                             |
 | `advanced-security` | `true`   | Upload SARIF results to GitHub code scanning. When `false`, the action prints normal console output.                                                                                 |
 | `fail-on-findings`  | `false`  | Fail the workflow when `pinprick audit` reports findings. Without this, findings are emitted as a warning and the workflow continues.                                                |


### PR DESCRIPTION
The GitHub Action examples in `README.md` and the getting-started doc still pinned `pinprick-action` at v0.4.2 and described a `0.21.0` default `version`, three action releases behind. This retargets all four `uses:` SHA pins at v0.5.3 (`475e6e84a584bc6d5d6f65958beff2732905f8a3`) and updates the inputs table to the 0.23.1 default that release pins.

AI disclosure: Claude Opus 5 with the tag SHA verified against the pinprick-action git ref API and just site-format-check run locally.