### PR TITLE
fix(site): align the declared HSTS max-age with the edge baseline

### DIFF
--- a/site/public/_headers
+++ b/site/public/_headers
@@ -3,7 +3,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-XSS-Protection: 0
   Cross-Origin-Embedder-Policy: credentialless
   Cross-Origin-Opener-Policy: same-origin


### PR DESCRIPTION
Sets the declared Strict-Transport-Security max-age to 31536000. Cloudflare's zone-level HSTS setting is the fleet baseline for every starhaven zone and rewrites this header at the edge with a 12-month max-age, so the two-year value declared here never reached a browser; a live header comparison across all six zones showed every one serving the edge value. The domain is on the browser preload lists, whose floor is one year, so enforcement is unchanged. This is the same alignment as starhaven-io/macOSdb#736.

AI disclosure: Claude Fable 5.1 with the repo's header and formatting checks and a live header comparison against every starhaven zone.
