### PR TITLE
fix(audit): preserve trust and findings across incomplete scans

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -32,6 +32,7 @@ permissions: {}
 jobs:
   scan:
     name: Scan
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
@@ -156,11 +157,16 @@ jobs:
                 TAG_SHA="${TAG_SHAS["${TAG}"]}"
               fi
 
+              if [[ ! "${TAG_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                echo "  Ref did not resolve to a full SHA, skipping ${TAG}"
+                continue
+              fi
+
               echo "  New release: ${TAG} (${TAG_SHA:0:7})"
 
-              TMPDIR=$(mktemp -d)
-              mkdir -p "${TMPDIR}/.github/workflows"
-              cat > "${TMPDIR}/.github/workflows/test.yml" <<YAML
+              SCAN_DIR=$(mktemp -d)
+              mkdir -p "${SCAN_DIR}/.github/workflows"
+              cat > "${SCAN_DIR}/.github/workflows/test.yml" <<YAML
           name: test
           on: push
           jobs:
@@ -171,17 +177,16 @@ jobs:
           YAML
 
               AUDIT_STATUS=0
-              AUDIT_JSON=$(./target/debug/pinprick --json audit "${TMPDIR}" 2>/dev/null) || AUDIT_STATUS=$?
+              AUDIT_JSON=$(XDG_CONFIG_HOME="${SCAN_DIR}/config" ./target/debug/pinprick --json audit --no-repo-config --no-audited-catalog "${SCAN_DIR}") || AUDIT_STATUS=$?
               if [[ "${AUDIT_STATUS}" -eq 0 ]]; then
                 if jq -e '
-                  (.audited_bundled + .audited_local_cache + .audited_remote + .scanned_fresh) == 1
-                  and .ignored == 0
+                  .scanned_fresh == 1 and .coverage_complete == true and .ignored == 0
                 ' <<< "${AUDIT_JSON}" > /dev/null; then
                   echo "  Clean — adding ${TAG}"
                   jq -r --arg sha "${TAG_SHA}" --arg tag "${TAG}" '
                     (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end)
                     | sort_by([(.tag | ltrimstr("v") | split(".") | map(tonumber? // 0)), .tag]) | reverse
-                    | "[\n" + ([.[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
+                    | "[\n" + ([.[] | "  { \"sha\": \(.sha | tojson), \"tag\": \(.tag | tojson) }"] | join(",\n")) + "\n]"
                   ' "${JSON_FILE}" > "${JSON_FILE}.tmp"
                   mv "${JSON_FILE}.tmp" "${JSON_FILE}"
                   UPDATED=1
@@ -193,7 +198,7 @@ jobs:
               else
                 echo "  Audit failed (exit ${AUDIT_STATUS}) — skipping ${TAG}"
               fi
-              rm -rf "${TMPDIR}"
+              rm -rf "${SCAN_DIR}"
             done
             unset TAG_SHAS
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
           persist-credentials: false
 
 
+      - name: Test release tooling
+        if: matrix.check == 'lint'
+        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
+
       - name: Restore cargo build cache
         id: cargo-build-cache
         if: matrix.check == 'lint' || matrix.check == 'test' || matrix.check == 'coverage'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,8 @@ jobs:
           persist-credentials: false
 
 
-      - name: Test release tooling
-        if: matrix.check == 'lint'
+      - name: Test workflow tooling
+        if: matrix.check == 'lint' || matrix.check == 'site'
         run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
 
       - name: Restore cargo build cache

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -136,15 +136,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 26
+          package-manager-cache: false
+      - name: Check npm install-script policy
+        run: node scripts/check-npm-install-policy.mjs site
+      - name: Install deployment dependencies
+        working-directory: site
+        run: npm ci --strict-allow-scripts
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: signed-site
           path: site/dist
-      - name: Deploy immutable build to Cloudflare Workers
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: site
-          wranglerVersion: 4.127.0
-          command: deploy --config wrangler.jsonc
+      - name: Deploy signed site to Cloudflare Workers
+        working-directory: site
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_SEND_METRICS: "false"
+        # Direct invocation cannot run npm lifecycle hooks that rebuild signed assets.
+        run: |
+          ./node_modules/.bin/wrangler deploy --config wrangler.jsonc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,7 @@ jobs:
           codesign --sign "Developer ID Application: Patrick Linnane (${DEVELOPMENT_TEAM})" \
             --options runtime \
             "target/${TARGET}/release/pinprick"
+          codesign --verify --strict --verbose=2 "target/${TARGET}/release/pinprick"
 
       - name: Notarize binary
         if: matrix.sign
@@ -212,6 +213,19 @@ jobs:
             --team-id "${DEVELOPMENT_TEAM}" \
             --password "${NOTARIZATION_PASSWORD}" \
             --wait
+          for attempt in 1 2 3; do
+            if codesign --verify --strict -R='notarized' --check-notarization --verbose=4 "target/${TARGET}/release/pinprick"; then
+              break
+            else
+              status=$?
+            fi
+            if (( status != 3 || attempt == 3 )); then
+              echo "::error::Notarization requirement verification failed after ${attempt} attempt(s)."
+              exit "${status}"
+            fi
+            echo "::warning::Notarization ticket verification failed; retrying in 10 seconds (${attempt}/3)."
+            sleep 10
+          done
 
       - name: Clean up temporary keychain
         if: always() && matrix.sign
@@ -219,6 +233,8 @@ jobs:
           if [[ -f "${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}" ]]; then
             security delete-keychain "${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"
           fi
+          rm -f "${RUNNER_TEMP}/certificate.p12" "${RUNNER_TEMP}/pinprick-notarize.zip"
+          rm -rf "${RUNNER_TEMP}/notarize-staging"
 
       - name: Package
         env:
@@ -693,6 +709,38 @@ jobs:
           export HOMEBREW_GIT_EMAIL="${BOT_ID}+${BOT_USER}@users.noreply.github.com"
           brew tap starhaven-io/tap
           brew trust starhaven-io/tap
+          # Homebrew supplies the subject; prepare its DCO trailer before commit-msg validation.
+          TAP_ROOT="$(cd "$(brew --repo starhaven-io/tap)" && pwd -P)"
+          HOOKS_DIR=$(git -C "${TAP_ROOT}" rev-parse --path-format=absolute --git-path hooks)
+          HOOKS_DIR=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve())' "${HOOKS_DIR}")
+          case "${HOOKS_DIR}" in
+            "${TAP_ROOT}/"*) ;;
+            *) echo "::error::Tap hooks directory is outside the fresh checkout."; exit 1 ;;
+          esac
+          mkdir -p "${HOOKS_DIR}"
+          DCO_DIR=$(mktemp -d "${RUNNER_TEMP}/cask-dco.XXXXXX")
+          DCO_HOOK="${DCO_DIR}/prepare-commit-msg"
+          PREPARE_HOOK="${HOOKS_DIR}/prepare-commit-msg"
+          cleanup_dco_hook() {
+            if [[ -L "${PREPARE_HOOK}" ]] && [[ "$(readlink "${PREPARE_HOOK}")" == "${DCO_HOOK}" ]]; then
+              rm -- "${PREPARE_HOOK}"
+            fi
+            rm -rf -- "${DCO_DIR}"
+          }
+          trap cleanup_dco_hook EXIT
+          cat > "${DCO_HOOK}" <<'HOOK'
+          #!/bin/sh
+          set -eu
+          author=$(git var GIT_AUTHOR_IDENT)
+          author="${author%> *}>"
+          git interpret-trailers --in-place --where end --if-exists addIfDifferent --if-missing add \
+            --trailer "Signed-off-by: ${author}" "$1"
+          HOOK
+          chmod +x "${DCO_HOOK}"
+          if ! python3 -c 'import os, sys; os.symlink(sys.argv[1], sys.argv[2])' "${DCO_HOOK}" "${PREPARE_HOOK}"; then
+            echo "::error::Cannot install the DCO hook; an existing prepare-commit-msg hook must be preserved."
+            exit 1
+          fi
           brew bump-cask-pr --no-fork --version "${VERSION}" starhaven-io/tap/pinprick
 
           BRANCH_VERSION="${VERSION//,/-}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,156 +1,43 @@
 # Agent Instructions for pinprick
 
-pinprick is a CLI tool for GitHub Actions supply chain security. It pins action references to full SHAs, checks for updates, and audits pinned actions for runtime fetch patterns that bypass pinning (e.g., `curl ... latest`).
+Pinprick is a Rust CLI for GitHub Actions supply-chain pinning, updates, runtime-fetch auditing, and posture scoring. `site/` contains its Astro Starlight documentation and signed catalog endpoints. GitHub Actions is the supported target; Forgejo/Gitea workflow discovery is additive, best-effort compatibility. API resolution remains github.com-only.
 
-## Project overview
+## Sources of truth
 
-- **Language:** Rust (2024 edition)
-- **Platform:** macOS, Linux
-- **Architecture:** Single binary CLI with six subcommands (`audit`, `clean`, `completions`, `pin`, `score`, `update`)
-- **License:** AGPL-3.0-only
-- **Dependencies:** clap/clap_complete (CLI), tokio (async), reqwest (HTTP), serde/serde_norway (parsing), regex (pattern matching), colored (terminal output), toml (config parsing)
+- `src/main.rs` defines command flags and dispatch. Public command/configuration documentation lives in `site/src/content/docs/`.
+- `src/workflow.rs` owns workflow discovery, read-only YAML extraction, and format-preserving pin edits; `pin.rs` and `update.rs` resolve their API results before writing.
+- `src/audit.rs`, `audit_patterns.rs`, `audit_shell.rs`, and `audit_source.rs` own bounded source traversal and detection. `site/src/content/docs/reference/detections.md` documents the rules and heuristic limits.
+- `src/audited_actions.rs` and `build.rs` own catalog lookup, verification, caching, and embedding. `audited-actions/README.md` defines exact action identities; `SECURITY.md` covers signing custody and rotation.
+- `src/score.rs` implements the versioned public contract in `docs/scoring.md`.
+- `src/config.rs`, `auth.rs`, `github.rs`, and `output.rs` own configuration, token resolution, API transport, and output boundaries.
+- `Cargo.toml`, `Cargo.lock`, and `rust-toolchain.toml` define Rust requirements. `site/package.json`, its lockfile, and Wrangler config define the independent site root.
 
-## Repository structure
+## Behavioral boundaries
 
-```
-pinprick/
-├── Cargo.toml
-├── build.rs                  # Embeds audited-actions/ into binary at compile time
-├── src/
-│   ├── main.rs              # Entry point, clap CLI definition, command dispatch
-│   ├── audit.rs             # Audit command: scan workflows + action source for runtime fetches
-│   ├── audit_patterns.rs    # Compiled regex patterns for shell/JS/Docker fetch detection
-│   ├── audit_shell.rs       # Shell tokenizer + fetch-target extraction for the audit scanners
-│   ├── audit_source.rs      # Action source selection and fetch (remote trees API, local ./ actions)
-│   ├── audited_actions.rs   # Layered lookup: bundled → local cache → remote → GitHub API
-│   ├── auth.rs              # GitHub token resolution (GITHUB_TOKEN/GH_TOKEN env → gh auth token fallback)
-│   ├── config.rs            # TOML config loading (repo-local or XDG config directory)
-│   ├── github.rs            # GitHub API client (tag→SHA, releases, file trees)
-│   ├── output.rs            # Human-readable (colored) and --json output formatting
-│   ├── pin.rs               # Pin command: resolve tags to SHAs, rewrite files
-│   ├── score.rs             # Score command: compute a posture grade per docs/scoring.md
-│   ├── update.rs            # Update command: check pinned actions for newer releases
-│   └── workflow.rs           # Regex-based uses: line scanning, ActionRef types
-├── audited-actions/          # Pre-audited action SHAs (bundled into binary)
-├── docs/                     # Specs (scoring rubric, etc.) — source of truth for behaviors
-├── scripts/                  # Helper scripts (release notes formatting)
-├── site/                     # Astro Starlight docs site (pinprick.rs)
-├── justfile                  # Task runner (build, test, lint, check)
-├── rustfmt.toml              # Rustfmt configuration (2024 style edition)
-├── .github/
-│   ├── workflows/           # CI, CodeQL, zizmor, release, deploy-site, pinprick-audit, audit-actions
-│   ├── dependabot.yml       # Dependabot for GitHub Actions, Cargo, and npm
-│   └── FUNDING.yml
-└── .gitignore
-```
+1. Never execute fetched action code. Remote JavaScript, Python, shell, Dockerfiles, and metadata are untrusted inputs to static analysis.
+2. Never round-trip workflow files through a YAML serializer for writes. Rewrite supported block-style, single-line `uses:` values while preserving comments and formatting. Unsupported syntax and required resolution failures block all pending pin/update writes. Best-effort tag comments and manual branch/container skips are separate; per-file write failures are not a cross-file transaction.
+3. Scan every supported forge root. Repository configuration must not redirect discovery. Preserve directory-handle containment and symlink refusal for local reads and writes.
+4. Keep action identities exact: a root action verdict does not cover subpaths or siblings. Local cache verdicts require the current scanner version and default runtime trust policy; configured host/data exemptions must not become reusable default-policy verdicts.
+5. Repository config wholly replaces global config. Keep effective suppressions visible and preserve `--no-repo-config`. Canonical catalog verification must also isolate global config and disable all catalog reuse.
+6. Incomplete audit coverage exits 2 in every output format. Score completeness is independent of deductions and must remain visible in human, JSON, HTML, and badge output. Retain findings already collected when a later API request fails.
+7. Keep SARIF rule IDs stable. Change rubric versions deliberately when adjusting scoring semantics; document the contract alongside implementation.
+8. Preserve pipe-to-shell precedence and the distinction between a detected finding, a heuristic allowed match, and missing source coverage. A nearby checksum command qualifies only when its target and independently trusted verification material can be bound.
 
-## Project-specific notes
+Prefer flat modules and direct control flow. Use `LazyLock` for compiled patterns, typed errors for transport, and contextual command errors. Comments should explain constraints or non-obvious rationale; keep command lists and detection details in their public documentation.
 
-### Commands
+## Local checks
 
-- `pinprick pin [PATH] [--write]` — Scan workflow files, resolve action tag refs to full SHAs via GitHub API. Dry-run by default (exits 1 when there are unpinned actions). `--write` rewrites files with `@sha # tag` format. Skips already-pinned (SHA) refs. Warns on branch refs (`@main`) and sliding tags (`@v4`), resolving sliding tags to exact versions.
-- `pinprick update [PATH] [--write] [--only PATTERN]` — Check SHA-pinned actions for newer releases. Dry-run by default, `--write` to apply changes. `--only` restricts the check to actions whose `owner/repo` contains the given substring.
-- `pinprick audit [PATH] [--verbose] [--sarif] [--no-audited-catalog]` — Scan for runtime fetch patterns that bypass pinning. Without a GitHub token, scans local `run:` blocks and local actions referenced with `uses: ./...` or `uses: $/...`. With a token, also fetches and scans remote action source code (JS/TS, Python, Dockerfiles, action.yml). `--verbose` shows allowed matches. `--sarif` outputs SARIF 2.1.0 for GitHub code scanning. Incomplete coverage exits 2 in every output mode.
-- `pinprick score [PATH] [--html] [--badge]` — Compute a supply-chain posture score (0–100, letter grade A–F) for a repository's workflows. Implements the public rubric in `docs/scoring.md` (rubric v0.11.0). The offline rules (`pin.*`, `workflow.*`, `runtime.*`) need no token and include local `./...` and `$/...` action source; with a token it additionally emits the token-gated `source.archived` and `source.advisory` rules and scans fetched remote action source for `runtime.*` findings. Catalog-vouched and `ignore.actions` entries are skipped. JSON and HTML reports expose incomplete coverage, and badges render an error state rather than an unqualified grade when token-gated scans did not run, source fetching was incomplete, or configuration suppressed coverage. Exits 1 when any finding deducts points; incomplete coverage is represented in every output format but does not independently change the score exit status. `--json`, `--html`, and `--badge` are mutually exclusive.
-- `pinprick clean` — Remove locally cached audit results (`$XDG_CACHE_HOME/pinprick/audited/`, default `~/.cache/pinprick/audited/`).
-- `pinprick completions <SHELL>` — Generate shell completions for bash, zsh, fish, etc.
+Read the complete `justfile` before changing gates. Use focused tests while iterating, then run `just check` once the change is stable. It covers Rust clippy/format/tests, typos, dependency policy, workflow security analysis, and site format/build/deployment dry-run. Run `git diff --check` before handoff. A missing tool or failed gate is unverified, not a pass.
 
-### Global flags
+`rust-toolchain.toml` pins the reviewed Rust toolchain. Homebrew's standalone Rust does not honor it, so compare `rustc --version` with `channel`. Install site dependencies with `npm ci --strict-allow-scripts`; preserve package-level allowScripts decisions. Use local mocks for API regressions. No live catalog refresh, release, or deployment is implied by a code review.
 
-- `--json` — Output as JSON for CI integration
-- `--color auto|always|never` — Control color output
-- `--version` / `-V` — Print version
+## Ownership and release operation
 
-### YAML handling
+Fleet-managed files, fenced blocks, and first-party reusable-workflow pins belong to `../dot_github/fleet`; never hand-edit consumer copies. Keep the always-reporting `conclusion` CI job. Repo-owned workflow orchestration stays here.
 
-**Critical design decision:** workflow files are never round-tripped through a YAML parser for writing. Supported writable `uses:` entries use block-style, single-line mappings — regex capture groups replace the ref while preserving leading whitespace, indentation, and surrounding comments. Flow mappings, escaped keys, and multiline values fail closed instead of being rewritten without full structural context. `serde_norway` is only used for read-only extraction of `run:` block contents during audit.
+`release.yml` is a trusted-main manual workflow. It embeds the checked-in catalog, validates crate packaging, builds supported macOS/Linux artifacts, verifies macOS signing/notarization, attaches build provenance, publishes the crate, and opens distribution updates. `pinprick-action` is the separate released adapter: the engine release must open its bot-authored version bump with the existing action/README count assertions. Review and merge that bump to trigger the adapter release; never manually update those version references. The fleet consumes the released adapter, and the Homebrew cask bump must merge separately.
 
-That read-only `run:` extraction (`extract_run_blocks` for workflows and `scan_action_yml_runs` for composite actions) recurses into `parallel:` step groups. GitHub's parallel-steps feature models a `parallel:` step as a sequence of nested steps, so `run:` blocks inside a parallel group (including `parallel:` nested in `parallel:`) are scanned by both `audit` and `score`. A `background:`/`wait:`/`cancel:` step carries no nested `run:` and needs no special handling; line anchoring still walks blocks in document order.
-
-### Workflow discovery
-
-`workflow::find_workflows` scans every forge root in `DEFAULT_FORGE_ROOTS` (`.github`, `.forgejo`, `.gitea`) for a `workflows/` subdirectory. Forgejo and Gitea use GitHub-compatible workflow syntax. Discovery is **purely additive**: each root that exists is scanned and the files are unioned, so extra roots only widen coverage. The list is a compile-time constant and is deliberately *not* configurable via `.pinprick.toml`: a scanned repo (which may be hostile, hence `--no-repo-config`) must never be able to redirect the scan to a decoy directory while real workflows hide in `.github/workflows`. Every root goes through the same symlink-refusing `open_child_dir` path, so a symlinked forge root is refused, never followed. GitLab is out of scope: `.gitlab-ci.yml` is a single file with a different schema and no `uses:` references.
-
-**Support tiers.** GitHub Actions is the first-class, fully supported target. Forgejo/Gitea support is incidental to GHA compatibility and best-effort: don't intentionally break it, but don't constrain a GitHub Actions improvement to preserve forge behavior either. When the two conflict, GHA wins. (Example: tag/release resolution is hardcoded to the github.com API, so `pin`/`update` only resolve github.com-hosted actions; that's an accepted limitation, not a bug to fix at GHA's expense.)
-
-### GitHub auth
-
-1. `GITHUB_TOKEN` environment variable (checked first)
-2. `GH_TOKEN` environment variable (the variable the `gh` CLI itself honors)
-3. `gh auth token` CLI fallback
-4. Graceful degradation: `pin` and `update` require a token; `audit` works without one (reduced coverage)
-
-Rate-limit handling: `github::get` retries once on network/5xx errors and sleeps through `x-ratelimit-reset` when the reset is within 60 s; longer waits bail with `RateLimit`.
-
-### Configuration
-
-A `.pinprick.toml` at the repo root (or `$XDG_CONFIG_HOME/pinprick/config.toml`, default `~/.config/pinprick/config.toml`) customizes behavior. Keys are all optional: `severity`, `fetch-remote`, `trusted-hosts`, `extra-data-formats`, `ignore.actions`, `ignore.patterns`. Per-repo wholly overrides global (no field-level merge). Because the scanned repo's own config applies, `audit`/`score` print a stderr notice whenever a repo-local config suppressed findings or extended runtime/data-format trust, and accept `--no-repo-config` to ignore the repo's file (for scanning repositories you don't control).
-
-### Audit patterns
-
-Six categories of runtime fetch detection:
-- **Pipe-to-shell:** `curl`/`wget` piped into `sh`/`bash`/`python`, `bash <(curl …)` process substitution, `bash -c "$(curl …)"` / `eval "$(…)"` command substitution, PowerShell `iex (iwr …)` / `Invoke-Expression (… DownloadString …)`. Flagged high severity regardless of URL versioning.
-- **Shell:** `curl`/`wget`/`gh release download` with unversioned URLs, non-literal `curl`/`wget` executable outputs, `deno run`/`install` from unversioned URLs, `git clone` without a pinned ref, `go install @latest`, unpinned `pip`/`pipx`/`npm`/`npx`/`cargo install`/`gem install`/`uv tool install`/`uvx` installs
-- **PowerShell:** `Invoke-WebRequest`/`iwr`/`Invoke-RestMethod`/`irm`, `Start-BitsTransfer`, and `WebClient.DownloadFile` with unversioned URLs
-- **JavaScript:** `fetch()`/`axios`/`got`/`http.get` with unversioned URLs, `exec()`/`child_process` shelling out to curl
-- **Python:** `urllib.request.urlopen`/`requests.get` with unversioned URLs, `subprocess` shelling out to curl/wget
-- **Docker:** unpinned `uses: docker://…` container action refs (high for `:latest`/untagged, medium for a mutable named tag; a well-formed `@sha256:` digest passes), `docker pull`/`docker run` with literal images using `:latest` or no tag in shell run blocks, `FROM :latest` or no tag, `curl`/`wget` in `RUN` instructions (escalated to high when piped to a shell), `ADD` with an `http(s)://` URL source (subject to versioning + data-format exemption via the URL-check path)
-
-Pipe-to-shell pre-empts the other shell/Docker patterns so each line emits a single finding. It also reuses the existing `ShellFetch` SARIF category/rule id to keep downstream configs stable.
-
-URL "versioned" heuristic: a URL is considered versioned if any path segment matches `v?\d+(\.\d+)+`; Deno-style `@v1.2.3` path pins count.
-
-Data-format exemption: unversioned-URL rules (shell, JS, Python) do **not** fire when the URL's path ends in a data-format extension (`.json`/`.jsonl`/`.ndjson`, `.yaml`/`.yml`/`.toml`, `.csv`/`.tsv`/`.xml`, `.txt`/`.md`/`.rst`). Matches are recorded as allowed (visible under `--verbose`) with reason `data format URL`. Applies only to the unversioned-URL rules — `/latest/` URLs, pipe-to-shell, and `gh release download` without a tag still fire regardless of extension. `.html` and `.svg` are intentionally excluded because both can carry embedded scripts.
-
-Piped-to-jq exemption: an unversioned-URL fetch whose line pipes into `jq` is recorded as allowed with reason `piped to jq` — the same data-not-code rationale as the data-format exemption, but for JSON API endpoints that carry no file extension (e.g. `curl …/api/v1/crates/<x> | jq …`). The `jq\b` match keeps `jqfoo` from qualifying. Pipe-to-shell matches and pre-empts the URL rules, so `curl … | jq … | bash` is flagged high, never exempted.
-
-Checksum verification: findings followed within 3 lines by `sha256sum`, `shasum`, `openssl dgst`, `gpg --verify`, or `Get-FileHash` are suppressed only when the command performs an actual check or signature verification, does not mask failure with `||`, and binds every downloaded target to independently trusted material. Accepted evidence is an inline literal digest or a signature checked with independently supplied key material. A sidecar, key, or signature downloaded at runtime is not trusted merely because its filename is target-specific. `Get-FileHash` comparisons require a literal 64- or 128-hex digest. Merely calculating a hash, checking an unrelated file, or using a generic manifest whose contents cannot be inspected does not suppress the finding. Verified matches are recorded as allowed (visible under `--verbose`). Pipe-to-shell findings are exempt — the piped payload is never written to disk, so a nearby checksum command cannot verify it.
-
-Git clone ref pinning: `git clone` without `--branch`/`-b` or with a branch name (main, develop, feature/foo) is flagged medium severity. `--branch v1.2.3` (version-like ref) suppresses the finding. A `git checkout <40-char-SHA>` within 3 lines fully suppresses the finding (recorded as allowed, visible under `--verbose`), since the SHA checkout deterministically pins the repo content.
-
-### Exit codes
-
-- `0` — clean (no findings, no pending updates)
-- `1` — findings present (audit) or updates available (update dry-run)
-- `2` — error; also incomplete coverage for `audit`, `pin`, or `update` (`score` reports completeness separately and keeps finding-based exit status)
-
-### CI workflows (`.github/workflows/`)
-
-- **audit-actions.yml** — Weekly scan of tracked actions for new releases, automated PRs for clean entries
-- **cargo-deny.yml** — Weekly `cargo deny check` to catch advisories, yanks, and unmaintained flags that turn an unchanged `Cargo.lock` red; opens or closes a tracking issue as the scan flips
-- **ci.yml** — Dynamic PR checks: conventional commits, clippy + rustfmt + typos, cargo test, coverage, site format + build, audited-actions verification, and a separate zizmor job with `security-events: write`
-- **codeql.yml** — CodeQL security analysis (actions queries) on push to main
-- **deploy-site.yml** — Build and deploy Astro site to Cloudflare Workers
-- **link-check.yml** — Weekly lychee broken-link check across the built site and README
-- **pinprick-audit.yml** — Run pinprick audit on its own workflows with SARIF upload
-- **release.yml** — Manual dispatch: dry-run crate publishing, build cross-platform binaries (linux-amd64 and linux-arm64, each in glibc and static musl variants, plus darwin-arm64), create GitHub release with build provenance attestations, publish the crate to crates.io, open a pinprick-action default-version bump PR, and bump the Homebrew cask (glibc/macOS only)
-- **verify-audited-actions.yml** — Weekly sharded re-verification of audited-actions catalog entries against the current detection rules (`scripts/verify-audited-actions.sh`), with a tracking issue on failure
-- **zizmor.yml** — GitHub Actions security audit on push to main
-
-## Safety / do-not-touch rules
-
-1. Do not round-trip workflow files through a YAML parser when writing pins or
-   updates; preserve the single-line `uses:` replacement model.
-2. Keep repo-local config suppressions visible on stderr, and preserve
-   `--no-repo-config` for scanning repositories the caller does not control.
-3. Treat remote action source as untrusted input. Audit may inspect fetched
-   JavaScript, Python, Docker, and action metadata, but it must not execute
-   fetched action code.
-4. Keep SARIF rule IDs stable when refining detections so downstream code
-   scanning configuration keeps working.
-
-## Required checks
-
-`rust-toolchain.toml` pins CI and rustup-based workstations to the reviewed
-stable toolchain. Homebrew's standalone Rust does not honor that file, so verify
-`rustc --version` matches its `channel` before running the required checks.
-
-- `cargo clippy` with zero warnings
-- `cargo fmt` for formatting
-- `just npm-policy` for the site dependency install-script policy
-- No unnecessary abstractions — flat module structure, no nested directories
-- `thiserror` for typed errors in library code, `anyhow` for context-rich error propagation in commands
-- `LazyLock` for compiled regex constants
+`deploy-site.yml` separates unprivileged build, canonical-byte validation/signing, and deployment. Preserve that credential boundary. Weekly catalog verification and cargo-deny workflows retain failures as tracking issues. Local tests do not prove hosted environment protections, signing credentials, Linux execution, or publication readiness.
 
 <!-- fleet:block commit-and-pr-conventions -->
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo install --git https://github.com/starhaven-io/pinprick
 
 ### GitHub Action
 
-For CI audit runs, use the shipped [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). It installs a pinned pinprick release, verifies the archive checksum, runs `pinprick audit`, and can upload SARIF:
+For CI audit runs, use the shipped [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). It installs a pinned pinprick release, verifies the archive checksum and GitHub build provenance, runs `pinprick audit`, and can upload SARIF:
 
 ```yaml
 name: GitHub Actions supply chain audit
@@ -81,7 +81,7 @@ The action wraps `pinprick audit` only. Use the CLI directly for `pin`, `update`
 
 All commands default to the current directory. Pass a path to target a different repository root. Use `--json` for machine-readable output.
 
-> **Forge support.** GitHub Actions is pinprick's first-class, fully supported target. Forgejo and Gitea run GitHub-compatible Actions, so workflows under `.forgejo/workflows/` and `.gitea/workflows/` are discovered and scanned alongside `.github/workflows/` (whichever exist are all scanned). That support is incidental to GHA compatibility and best-effort: we won't intentionally break it, but we also won't hold back a GitHub Actions improvement to preserve forge behavior. When the two conflict, GHA wins. Concretely today, `pin` and `update` resolve through the github.com API, so they handle github.com-hosted actions (the common case) but not actions hosted on a Forgejo or Gitea instance; `audit` and `score` need no network for their local rules.
+> **Forge support.** GitHub Actions is pinprick's first-class, fully supported target. Forgejo and Gitea run GitHub-compatible Actions, so workflows under `.forgejo/workflows/` and `.gitea/workflows/` are discovered and scanned alongside `.github/workflows/` (whichever exist are all scanned). That support is incidental to GHA compatibility and best-effort: we won't intentionally break it, but we also won't hold back a GitHub Actions improvement to preserve forge behavior. When the two conflict, GHA wins. `pin` and `update` resolve through the github.com API, so they handle github.com-hosted actions (the common case) but not actions hosted on a Forgejo or Gitea instance; `audit` and `score` need no network for their local rules.
 
 ```bash
 # Pin action tags to full SHAs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,11 +38,13 @@ with different trust anchors:
   trusted comment — a catalog signed more than 30 days ago is rejected, so a
   compromised CDN cannot replay a superseded-but-validly-signed catalog
   indefinitely. Timestamps more than 10 minutes in the future are also
-  rejected: legitimate runner and client clock drift is expected to stay
-  within minutes, and a far-future timestamp would otherwise stay inside the
-  staleness window until it plus 30 days — turning one signing-clock fault (or
-  a compromised signer) into an extended replay horizon. TLS alone is
+  rejected to prevent a signing-clock fault from extending that replay window. TLS alone is
   deliberately not trusted.
+
+Local cache entries require the current scanner version and default runtime
+trust policy. Scans using configured trusted hosts or extra data formats cannot
+populate reusable clean verdicts. Catalog verification isolates global and
+repository configuration and bypasses all catalog layers.
 
 ### Signing key custody
 
@@ -53,10 +55,7 @@ Only `deploy-site.yml` reads it. Every build job is explicitly restricted to
 refreshes signatures before their 30-day expiry. Relevant pushes to `main`
 also deploy immediately. The workflow writes a temporary runner copy and
 removes it on step exit; maintainers must not retain additional copies. A
-compromise of that workflow or environment is a catalog compromise. Signing the catalog offline
-(committing `.minisig` files next to each JSON and serving them verbatim)
-would take the key out of CI at the cost of maintainer friction on every
-catalog change; that trade-off remains under consideration.
+compromise of that workflow or environment is a catalog compromise.
 
 ### Key rotation
 

--- a/audited-actions/README.md
+++ b/audited-actions/README.md
@@ -62,7 +62,7 @@ See [SECURITY.md](../SECURITY.md) for key custody and rotation.
 
 To add a new entry:
 
-1. Run `pinprick audit` against a repository using the action at the SHA you want to add
-2. Confirm zero findings for that action
-3. Add the SHA and tag to the appropriate JSON file (or create a new one)
-4. Open a PR
+1. Run `just add-action owner/repo` from a Pinprick checkout (include the subpath when applicable).
+2. The recipe resolves a full SHA and requires a fresh, complete scan with zero ignored actions under isolated default configuration.
+3. Inspect the generated entry and build the current scanner with `cargo build --locked --release`, then run `scripts/verify-audited-actions.sh target/release/pinprick files <entry-file>` with a GitHub token.
+4. Open a PR with the verification result.

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -6,7 +6,7 @@ fn main() {
     println!("cargo:rerun-if-changed=audited-actions");
 
     let dir = Path::new("audited-actions");
-    let mut data: HashMap<String, Vec<String>> = HashMap::new();
+    let mut data: BTreeMap<String, Vec<String>> = BTreeMap::new();
 
     assert!(dir.is_dir(), "audited-actions directory is missing");
     walk_dir(dir, dir, &mut data).unwrap_or_else(|error| panic!("{error}"));
@@ -20,7 +20,7 @@ fn main() {
 fn walk_dir(
     base: &Path,
     dir: &Path,
-    data: &mut HashMap<String, Vec<String>>,
+    data: &mut BTreeMap<String, Vec<String>>,
 ) -> Result<(), String> {
     let entries =
         fs::read_dir(dir).map_err(|error| format!("could not read {}: {error}", dir.display()))?;

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -4,16 +4,16 @@
 
 This document defines how pinprick computes a single score for a GitHub repository's Actions supply chain posture. It is the public specification that the `pinprick score` CLI subcommand implements against, and that any downstream tool wrapping the engine (dashboards, CI plugins, reporting pipelines) should implement against so scores stay portable and comparable.
 
-Keeping this document public and versioned is deliberate: security scoring is only trustworthy if anyone can re-derive the score from the raw findings. Vendors that hide the rubric behind "proprietary algorithms" end up being distrusted by the security teams they want as customers.
+Every deduction is public so a reader can re-derive the score from the reported findings. Coverage notes qualify what was actually evaluated.
 
 ## Design principles
 
 1. **Transparent.** Every point deducted is tied to an explicit rule and finding. Given the raw findings, a third party can re-compute the score by hand.
 2. **Actionable.** Every rule maps to a concrete remediation. The score is always accompanied by a prioritized fix list.
-3. **Deterministic.** The same inputs always produce the same score. No stochastic inputs, no ML models, no "confidence-weighted" signals in v1.
+3. **Deterministic.** The same inputs always produce the same score. Inputs include source content, configuration, catalog verdicts, and observed GitHub metadata.
 4. **Versioned.** The rubric has a semantic version. Every scan records the rubric version used. Re-scoring is always explicit — we never silently mutate historical scores.
 5. **Unique-finding basis.** Action pinning and source rules (`pin.*`, `source.*`) fire once per unique `(rule, action_ref)` across the repo, with an `occurrences` list recording every `(workflow, line)` where the action is used. Runtime rules fire once per distinct detected source location, including workflow run blocks and action source. Workflow-level rules (`workflow.*`) fire once per `(rule, workflow_path)`. A repo with 20 workflows that all call `actions/checkout@main` has one pinning fix to make, so the score reflects one pinning finding.
-6. **Absolute before relative.** v1 is an absolute rubric ("47/100"). Percentile scoring across a corpus is a later feature and needs real data first.
+6. **Absolute score.** The score is independent of any comparison corpus.
 
 ## Score formula
 
@@ -33,7 +33,7 @@ Grade bands (absolute):
 | D     | 60 – 69  |
 | F     |  0 – 59  |
 
-Rationale for the flat deduction model: it's trivial to explain, easy to audit, and composes cleanly across rules. Weighted-average models require calibrating weights against each other, which invites arguments that nobody can win. We can always move to a more nuanced formula later; we cannot retroactively earn back trust lost to an opaque one.
+Flat deductions make the result reproducible directly from the finding list.
 
 ## Rule catalog
 
@@ -112,7 +112,7 @@ These are deliberately out of scope for v1 to keep the initial rubric defensible
 
 ## Output
 
-`pinprick score <path>` produces a stable JSON document. A static HTML report is generated from the same JSON.
+`pinprick score <path>` prints a human-readable report by default. `--json` and `--html` render the same report model in machine-readable and standalone HTML formats.
 
 ### JSON schema (sketch)
 
@@ -178,7 +178,7 @@ A single self-contained HTML file with:
 - Score + grade banner
 - Incomplete-coverage warning and reasons, when applicable
 - Prioritized finding list (sorted by points recovered)
-- Remediation text and occurrence locations for each finding
+- Finding details, remediation text, and occurrence locations for each finding
 
 No JavaScript frameworks; plain HTML + a little CSS. The HTML report is shareable as a static artifact.
 
@@ -204,7 +204,7 @@ The rubric version is semver-ish:
 - **Minor** (`0.1.0 → 0.2.0`): new rules added, or point values adjusted. Existing repos may score differently; scans are re-labeled with the new version. Historical scans retain their original rubric version.
 - **Major** (`0.x → 1.0`): structural change to the formula or output schema. Requires a migration note.
 
-Re-scoring an existing scan against a newer rubric is always explicit in the UI. We never silently change a score.
+Saved reports retain their rubric version. Running the CLI again evaluates a new report with the installed rubric and available inputs.
 
 ## Changelog
 

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ clean:
 test:
     cargo test --locked
 
+# Check release tooling using local stubs
+script-tests:
+    PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
+
 # Lint
 
 # fleet:block audit
@@ -79,12 +83,16 @@ add-action action_key:
     if [[ "$OBJ_TYPE" == "tag" ]]; then
         LATEST_SHA=$(gh api "repos/${OWNER}/${REPO}/git/tags/${LATEST_SHA}" --jq '.object.sha')
     fi
+    if [[ ! "${LATEST_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        echo "error: release did not resolve to a full SHA" >&2
+        exit 1
+    fi
     echo "  resolved sha: ${LATEST_SHA:0:8}"
 
-    TMPDIR=$(mktemp -d)
-    trap 'rm -rf "$TMPDIR"' EXIT
-    mkdir -p "$TMPDIR/.github/workflows"
-    cat > "$TMPDIR/.github/workflows/test.yml" <<YAML
+    SCAN_DIR=$(mktemp -d)
+    trap 'rm -rf "$SCAN_DIR"' EXIT
+    mkdir -p "$SCAN_DIR/.github/workflows"
+    cat > "$SCAN_DIR/.github/workflows/test.yml" <<YAML
     name: test
     on: push
     jobs:
@@ -94,14 +102,15 @@ add-action action_key:
           - uses: ${ACTION_KEY}@${LATEST_SHA} # ${LATEST}
     YAML
 
-    cargo run --locked --release --quiet -- --json audit "$TMPDIR"
+    AUDIT_JSON=$(XDG_CONFIG_HOME="${SCAN_DIR}/config" cargo run --locked --release --quiet -- --json audit --no-repo-config --no-audited-catalog "$SCAN_DIR")
+    jq -e '.scanned_fresh == 1 and .coverage_complete == true and .ignored == 0' <<< "$AUDIT_JSON" >/dev/null
 
     FILE="audited-actions/${ACTION_KEY}.json"
     mkdir -p "$(dirname "$FILE")"
     [[ -f "$FILE" ]] || echo "[]" > "$FILE"
     jq -r --arg sha "$LATEST_SHA" --arg tag "$LATEST" '
       (if any(.[]; .sha == $sha) then . else [{sha: $sha, tag: $tag}] + . end) as $u |
-      "[\n" + ([$u[] | "  { \"sha\": \"\(.sha)\", \"tag\": \"\(.tag)\" }"] | join(",\n")) + "\n]"
+      "[\n" + ([$u[] | "  { \"sha\": \(.sha | tojson), \"tag\": \(.tag | tojson) }"] | join(",\n")) + "\n]"
     ' "$FILE" > "$FILE.tmp"
     command mv "$FILE.tmp" "$FILE"
     echo "  wrote ${FILE}"
@@ -179,6 +188,7 @@ check:
         skip audit zizmor zizmor
     fi
     run cargo test --locked
+    run env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
     echo "--- site-format-check ---"
     (cd site && npm run format:check) || failed=1
     echo "--- site-build ---"

--- a/scripts/format-release-notes.py
+++ b/scripts/format-release-notes.py
@@ -31,7 +31,7 @@ SKIP_SCOPES = {"audit-actions", "audited-actions"}
 #   * feat(scope): description by @user in https://...
 PR_RE = re.compile(
     r"^\*\s+"
-    r"(?:(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?:\s*)?"
+    r"(?:(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<breaking>!)?:\s*)?"
     r"(?P<desc>.+?)"
     r"(?:\s+by\s+@[\w-]+)?"
     r"(?:\s+in\s+https?://\S+)?"
@@ -62,10 +62,11 @@ def parse_notes(raw: str) -> tuple[dict[str, list[str]], str | None]:
         pr_scope = pr_match.group("scope") or ""
         desc = pr_match.group("desc").strip()
 
-        if pr_type in SKIP_TYPES or pr_scope in SKIP_SCOPES:
+        breaking = pr_match.group("breaking") is not None
+        if not breaking and (pr_type in SKIP_TYPES or pr_scope in SKIP_SCOPES):
             continue
 
-        section = SECTIONS.get(pr_type, "Other")
+        section = "Breaking Changes" if breaking else SECTIONS.get(pr_type, "Other")
         sections.setdefault(section, []).append(desc)
 
     return sections, changelog_url
@@ -75,7 +76,7 @@ def format_markdown(tag: str, sections: dict[str, list[str]], changelog_url: str
     """Render categorized notes as markdown."""
     lines = [f"## pinprick {tag}", ""]
 
-    ordered_keys = list(dict.fromkeys(SECTIONS.values()))
+    ordered_keys = ["Breaking Changes", *dict.fromkeys(SECTIONS.values())]
     ordered_keys.append("Other")
 
     for heading in ordered_keys:

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Exercise release/catalog shell steps with local command stubs only."""
+"""Exercise workflow shell steps with local command stubs only."""
 
 import importlib.util
 import json
@@ -23,6 +23,44 @@ def workflow_step(workflow: str, name: str) -> str:
 
 
 class ReleaseToolsTests(unittest.TestCase):
+    def test_site_deploy_preserves_signed_output_and_uses_locked_tool(self):
+        deploy = (ROOT / '.github/workflows/deploy-site.yml').read_text().split('\n  deploy:\n', 1)[1]
+        setup, publish = deploy.split('      - name: Deploy signed site to Cloudflare Workers\n', 1)
+        self.assertIn('    needs: sign\n', setup)
+        self.assertIn("    if: github.ref == 'refs/heads/main'\n", setup)
+        self.assertIn('run: node scripts/check-npm-install-policy.mjs site', setup)
+        self.assertLess(setup.index('run: npm ci --strict-allow-scripts'), setup.index('name: signed-site'))
+        self.assertNotIn('CLOUDFLARE_API_TOKEN', setup)
+        self.assertNotIn('CATALOG_SIGNING_KEY', deploy)
+        self.assertNotIn('npm run build', deploy)
+        self.assertIn('        working-directory: site\n', publish)
+        self.assertIn('CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}', publish)
+        self.assertIn('CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}', publish)
+
+        with tempfile.TemporaryDirectory() as temp:
+            site = Path(temp)
+            tool = site / 'node_modules/.bin/wrangler'
+            tool.parent.mkdir(parents=True)
+            tool.write_text('#!/bin/sh\nset -eu\n'
+                            '[ "$#" = 3 ] && [ "$1" = deploy ] && [ "$2" = --config ] && [ "$3" = wrangler.jsonc ]\n'
+                            '[ "$CLOUDFLARE_API_TOKEN" = fixture-token ]\n'
+                            'printf deployed > invocation\n')
+            tool.chmod(0o755)
+            (site / 'package.json').write_text(json.dumps({'scripts': {
+                'predeploy': 'exit 97', 'deploy': 'exit 98', 'postdeploy': 'exit 99',
+            }}))
+            signed = site / 'dist/client/catalog.json.minisig'
+            signed.parent.mkdir(parents=True)
+            signed.write_bytes(b'signed fixture bytes\n')
+            result = subprocess.run(
+                ['bash', '-euo', 'pipefail', '-c', workflow_step('deploy-site.yml', 'Deploy signed site to Cloudflare Workers')],
+                cwd=site, env=dict(os.environ, CLOUDFLARE_API_TOKEN='fixture-token'),
+                capture_output=True, text=True, timeout=10,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((site / 'invocation').read_text(), 'deployed')
+            self.assertEqual(signed.read_bytes(), b'signed fixture bytes\n')
+
     def test_breaking_changes_survive_internal_change_filter(self):
         spec = importlib.util.spec_from_file_location('notes', ROOT / 'scripts/format-release-notes.py')
         notes = importlib.util.module_from_spec(spec)

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Exercise release/catalog shell steps with local command stubs only."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def workflow_step(workflow: str, name: str) -> str:
+    content = (ROOT / '.github/workflows' / workflow).read_text()
+    step = content.split(f'      - name: {name}\n', 1)[1]
+    step = step.split('\n      - ', 1)[0]
+    return textwrap.dedent(step.split('        run: |\n', 1)[1].split('\n        id:', 1)[0])
+
+
+class ReleaseToolsTests(unittest.TestCase):
+    def test_breaking_changes_survive_internal_change_filter(self):
+        spec = importlib.util.spec_from_file_location('notes', ROOT / 'scripts/format-release-notes.py')
+        notes = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(notes)
+        sections, _ = notes.parse_notes(
+            '* feat!: new report schema by @author in https://example.com/1\n'
+            '* build(runtime)!: require a newer runtime by @author in https://example.com/2\n'
+            '* fix(cli): preserve details by @author in https://example.com/3\n'
+            '* chore: refresh tooling by @author in https://example.com/4\n'
+        )
+        self.assertEqual(sections, {
+            'Breaking Changes': ['new report schema', 'require a newer runtime'],
+            'Fixes': ['preserve details'],
+        })
+        rendered = notes.format_markdown('v1.0.0', sections, None)
+        self.assertLess(rendered.index('Breaking Changes'), rendered.index('Fixes'))
+
+    def test_notarization_requirement_and_bounded_retry(self):
+        script = '''set -euo pipefail
+count=0
+mkdir() { :; }
+cp() { :; }
+ditto() { :; }
+sleep() { :; }
+xcrun() { return "$SUBMIT_STATUS"; }
+codesign() {
+  [[ "$*" == *"-R=notarized"* && "$*" == *"--check-notarization"* && "$*" == *"--strict"* ]] || return 97
+  count=$((count + 1))
+  if (( count <= FAILURES )); then return "$VERIFY_STATUS"; fi
+}
+''' + workflow_step('release.yml', 'Notarize binary') + '\nprintf "verified:%s\\n" "$count"\n'
+        for submit, status, failures, expected, attempts in [
+            (0, 0, 0, 0, 1), (0, 3, 2, 0, 3), (0, 3, 3, 3, None),
+            (0, 1, 1, 1, None), (5, 0, 0, 5, None),
+        ]:
+            with self.subTest(submit=submit, status=status, failures=failures):
+                env = dict(os.environ, TARGET='test', RUNNER_TEMP='/unused', APPLE_ID='test',
+                           NOTARIZATION_PASSWORD='test', DEVELOPMENT_TEAM='test',
+                           SUBMIT_STATUS=str(submit), VERIFY_STATUS=str(status), FAILURES=str(failures))
+                result = subprocess.run(['bash', '-c', script], env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode, expected, result.stderr + result.stdout)
+                if attempts:
+                    self.assertIn(f'verified:{attempts}', result.stdout)
+                else:
+                    self.assertNotIn('verified:', result.stdout)
+
+    def test_catalog_scan_keeps_exported_tmpdir_and_requires_fresh_coverage(self):
+        bash = shutil.which('bash')
+        version = subprocess.check_output([bash, '-c', 'echo "${BASH_VERSINFO[0]}"'], text=True)
+        if int(version) < 4:
+            self.skipTest('catalog workflow requires Bash 4+ (provided by its Linux runner)')
+        self.assertIsNotNone(shutil.which('jq'), 'jq is required for catalog workflow tests')
+        for fresh, expected_entries in [(1, 2), (0, 0)]:
+            with self.subTest(fresh=fresh), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                (root / 'bin').mkdir()
+                (root / 'scratch').mkdir()
+                (root / 'target/debug').mkdir(parents=True)
+                (root / 'bin/gh').write_text('''#!/usr/bin/env bash
+set -euo pipefail
+case "$2" in
+  */releases*) printf 'v1.0.0\\nv2.0.0\\n' ;;
+  */git/ref/tags/*)
+    if [[ "$4" == '.object.type' ]]; then echo commit
+    elif [[ "$2" == */v1.0.0 ]]; then printf '%040d\\n' 1
+    else printf '%040d\\n' 2; fi ;;
+  *) exit 9 ;;
+esac
+''')
+                # BSD mktemp ignores TMPDIR without a template; model the Linux runner's
+                # TMPDIR behavior explicitly while keeping all writes in this test directory.
+                if sys.platform == 'darwin':
+                    (root / 'bin/mktemp').write_text('#!/usr/bin/env bash\nexec /usr/bin/mktemp -d "$TMPDIR/scan.XXXXXXXX"\n')
+                    (root / 'bin/mktemp').chmod(0o755)
+                (root / 'target/debug/pinprick').write_text('''#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == *"--no-repo-config --no-audited-catalog"* ]]
+[[ "$XDG_CONFIG_HOME" == "${@: -1}/config" ]]
+printf '{"scanned_fresh":%s,"coverage_complete":true,"ignored":0}\\n' "$FRESH"
+''')
+                for executable in [root / 'bin/gh', root / 'target/debug/pinprick']:
+                    executable.chmod(0o755)
+                env = dict(os.environ, PATH=f'{root / "bin"}{os.pathsep}{os.environ["PATH"]}',
+                           TMPDIR=str(root / 'scratch'), INPUT_ACTION='example/action', INPUT_REF='',
+                           GITHUB_OUTPUT=str(root / 'output'), FRESH=str(fresh))
+                result = subprocess.run([bash, '-euo', 'pipefail', '-c', workflow_step('audit-actions.yml', 'Scan for new releases')],
+                                        cwd=root, env=env, text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+                entries = json.loads((root / 'audited-actions/example/action.json').read_text())
+                self.assertEqual(len(entries), expected_entries)
+                self.assertEqual(list((root / 'scratch').iterdir()), [])
+
+
+class CaskDCOTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.tap = self.root / "tap checkout"
+        self.runner = self.root / "runner temp"
+        self.bin = self.root / "bin"
+        for directory in (self.tap, self.runner, self.bin):
+            directory.mkdir()
+        self.env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+        self.env.update({
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_NAME": "Fixture Author",
+            "GIT_AUTHOR_EMAIL": "author@example.test",
+            "PATH": str(self.bin) + os.pathsep + os.environ["PATH"],
+            "RUNNER_TEMP": str(self.runner),
+            "TAP_ROOT": str(self.tap),
+            "APP_SLUG": "fixture-bot",
+            "VERSION": "1.2.3",
+        })
+        self.git("init", "-q")
+        self.git("config", "user.name", "Fixture Committer")
+        self.git("config", "user.email", "committer@example.test")
+        self.git("config", "core.hooksPath", ".githooks")
+        self.hooks = self.tap / ".githooks"
+        self.hooks.mkdir()
+        self.write_executable(self.hooks / "commit-msg", (ROOT / ".githooks/commit-msg").read_text())
+        self.write_executable(self.hooks / "pre-push", "#!/bin/sh\nexit 1\n")
+        self.write_executable(self.bin / "gh", '#!/bin/sh\nif [ "$1" = api ]; then printf "42\\n"; fi\n')
+        self.write_executable(self.bin / "brew", '''#!/bin/sh
+set -eu
+case "$1" in
+  --repo) printf '%s\n' "$TAP_ROOT" ;;
+  tap|trust) ;;
+  bump-cask-pr)
+    if [ "${REPLACE_HOOK:-0}" = 1 ]; then
+      rm "$TAP_ROOT/.githooks/prepare-commit-msg"
+      ln -s "$TAP_ROOT/keep-this-link" "$TAP_ROOT/.githooks/prepare-commit-msg"
+      exit 9
+    fi
+    [ "${FAIL_BREW:-0}" = 0 ] || exit 9
+    printf 'update\n' >> "$TAP_ROOT/cask.rb"
+    git -C "$TAP_ROOT" add cask.rb
+    message='pinprick 1.2.3'
+    if [ "${EXISTING_SIGNOFF:-0}" = 1 ]; then
+      message="$(printf '%s\n\nSigned-off-by: Fixture Author <author@example.test>\n' "$message")"
+    fi
+    git -C "$TAP_ROOT" -c commit.gpgSign=false commit --no-edit --verbose --message="$message" -- cask.rb
+    ;;
+  *) exit 8 ;;
+esac
+''')
+        self.script = workflow_step('release.yml', 'Bump Homebrew cask')
+
+    @staticmethod
+    def write_executable(path, contents):
+        path.write_text(contents)
+        path.chmod(0o755)
+
+    def git(self, *args):
+        return subprocess.check_output(["git", "-C", str(self.tap), *args], env=self.env, text=True).strip()
+
+    def run_bump(self):
+        return subprocess.run(
+            ["/bin/bash", "-eu", "-o", "pipefail", "-c", self.script],
+            cwd=self.root, env=self.env, capture_output=True, text=True, timeout=20,
+        )
+
+    def assert_cleaned(self):
+        self.assertFalse((self.hooks / "prepare-commit-msg").is_symlink())
+        self.assertEqual(list(self.runner.iterdir()), [])
+        self.assertEqual(self.git("config", "--local", "core.hooksPath"), ".githooks")
+
+    def test_actual_author_is_signed_once_and_existing_hooks_are_preserved(self):
+        original = (self.hooks / "commit-msg").read_bytes()
+        for duplicate in ("0", "1"):
+            self.env["EXISTING_SIGNOFF"] = duplicate
+            result = self.run_bump()
+            self.assertEqual(result.returncode, 0, result.stderr)
+            message = self.git("log", "-1", "--format=%B")
+            author = self.git("log", "-1", "--format=%an <%ae>")
+            self.assertEqual(message.splitlines()[0], "pinprick 1.2.3")
+            self.assertEqual(message.count("Signed-off-by:"), 1)
+            self.assertIn("Signed-off-by: " + author, message)
+            self.assertNotEqual(author, self.git("log", "-1", "--format=%cn <%ce>"))
+            self.assertEqual((self.hooks / "commit-msg").read_bytes(), original)
+            self.assertEqual((self.hooks / "pre-push").read_text(), "#!/bin/sh\nexit 1\n")
+            self.assert_cleaned()
+
+    def test_existing_validator_still_blocks_commit(self):
+        self.write_executable(self.hooks / "commit-msg", "#!/bin/sh\nexit 1\n")
+        self.assertNotEqual(self.run_bump().returncode, 0)
+        self.assert_cleaned()
+
+    def test_failure_cleans_hook_for_retry(self):
+        self.env["FAIL_BREW"] = "1"
+        self.assertEqual(self.run_bump().returncode, 9)
+        self.assert_cleaned()
+        self.env["FAIL_BREW"] = "0"
+        self.assertEqual(self.run_bump().returncode, 0)
+        self.assert_cleaned()
+
+    def test_existing_prepare_hook_is_preserved(self):
+        prepare = self.hooks / "prepare-commit-msg"
+        self.write_executable(prepare, "#!/bin/sh\nexit 0\n")
+        before = prepare.read_bytes()
+        result = self.run_bump()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("existing prepare-commit-msg", result.stdout)
+        self.assertEqual(prepare.read_bytes(), before)
+        self.assertEqual(list(self.runner.iterdir()), [])
+
+    def test_external_hook_directory_is_not_modified(self):
+        external = self.root / "outside hooks"
+        external.mkdir()
+        link = self.tap / "outside-link"
+        link.symlink_to(external, target_is_directory=True)
+        for location in (external, link):
+            self.git("config", "core.hooksPath", str(location))
+            result = self.run_bump()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("outside the fresh checkout", result.stdout)
+            self.assertEqual(list(external.iterdir()), [])
+            self.assertEqual(list(self.runner.iterdir()), [])
+
+    def test_inherited_global_hook_directory_is_not_modified(self):
+        external = self.root / "global hooks"
+        external.mkdir()
+        global_config = self.root / "gitconfig"
+        self.env["GIT_CONFIG_GLOBAL"] = str(global_config)
+        self.git("config", "--global", "core.hooksPath", str(external))
+        self.git("config", "--local", "--unset", "core.hooksPath")
+        before = global_config.read_bytes()
+        self.assertNotEqual(self.run_bump().returncode, 0)
+        self.assertEqual(global_config.read_bytes(), before)
+        self.assertEqual(list(external.iterdir()), [])
+        self.assertEqual(list(self.runner.iterdir()), [])
+
+    def test_cleanup_preserves_a_substituted_link(self):
+        self.env["REPLACE_HOOK"] = "1"
+        self.assertEqual(self.run_bump().returncode, 9)
+        self.assertEqual(os.readlink(self.hooks / "prepare-commit-msg"), str(self.tap / "keep-this-link"))
+        self.assertEqual(list(self.runner.iterdir()), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/verify-audited-actions.sh
+++ b/scripts/verify-audited-actions.sh
@@ -132,7 +132,7 @@ jobs:
 YAML
 
     set +e
-    OUTPUT=$("${BIN}" --json audit --no-audited-catalog "${SCAN_DIR}")
+    OUTPUT=$(XDG_CONFIG_HOME="${SCAN_DIR}/config" "${BIN}" --json audit --no-repo-config --no-audited-catalog "${SCAN_DIR}")
     STATUS=$?
     set -e
     rm -rf "${SCAN_DIR}"

--- a/site/src/components/ThemeSelect.astro
+++ b/site/src/components/ThemeSelect.astro
@@ -1,6 +1,3 @@
 ---
-// Pinprick uses dark-by-default with light as an alternate via
-// prefers-color-scheme. Starlight's ThemeProvider still reads that OS
-// preference and sets data-theme accordingly; this override just hides
-// the toggle UI.
+// Keep Starlight's OS preference handling while hiding the theme selector.
 ---

--- a/site/src/content/docs/commands/audit.md
+++ b/site/src/content/docs/commands/audit.md
@@ -26,7 +26,7 @@ For the full list of every rule, including examples and severity, see the [Detec
 pinprick skips exact action identities whose `owner/repo[/subpath]@sha` is already known to be clean. The check consults three sources, in order, and reports which one answered:
 
 - `bundled` — ships with the pinprick binary from `audited-actions/` in the repo
-- `local cache` — written to `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`) after a successful live scan on this machine
+- `local cache` — written to `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`) after a complete, clean live scan under the default runtime trust policy; entries from other scanner versions are ignored
 - `pinprick.rs` — fetched from the public audited-actions list (opt-in via `fetch-remote = true` in `.pinprick.toml`)
 
 See [Audited Actions](/configuration/audited-actions) for details on how the list works and how to contribute.
@@ -81,7 +81,7 @@ If the workflow uses sliding tags like `@v4` instead of branch refs, the summary
 
 Per-action status is colored by semantic category, not by source, so a clean audit looks like a wall of uniform green with only the exceptions popping out:
 
-- **`audited`** — green. Matched an entry in the bundled list, local cache, or `pinprick.rs` list. No network work needed.
+- **`audited`** — green. Matched an entry in the bundled list, local cache, or `pinprick.rs` list. Remote catalog lookups still use the network.
 - **`Fetching`** / **`scanned fresh`** — blue. pinprick fetched the action source over the network and scanned it fresh this run.
 - **`(unpinned)`** / **`unpinned ref scanned`** — yellow. The ref is a branch (`@main`) or sliding tag (`@v4`) — pinprick scans the current tip but the trust does not carry across runs because the content can change.
 - **`ignored`** — dimmed. Skipped per `ignore.actions` in `.pinprick.toml`.

--- a/site/src/content/docs/commands/clean.md
+++ b/site/src/content/docs/commands/clean.md
@@ -11,7 +11,7 @@ pinprick clean
 
 ## When to use
 
-- After updating pinprick to a version with new or changed detection rules — clearing the cache forces a fresh scan of all actions
+- To discard local verdicts and repeat source scans. Entries from older scanner versions are already ignored automatically; `--no-audited-catalog` also bypasses bundled and remote verdicts for a single audit
 - To reclaim disk space from accumulated cache entries
 - To troubleshoot unexpected audit results
 
@@ -28,3 +28,5 @@ If there is nothing to clean:
 $ pinprick clean
 Nothing to clean.
 ```
+
+A filesystem error exits 2 and is reported on stderr; a failed removal is never reported as a successful cleanup.

--- a/site/src/content/docs/commands/completions.md
+++ b/site/src/content/docs/commands/completions.md
@@ -16,6 +16,7 @@ pinprick completions <SHELL>
 ### zsh
 
 ```bash
+mkdir -p ~/.zfunc
 pinprick completions zsh > ~/.zfunc/_pinprick
 ```
 
@@ -37,6 +38,7 @@ pinprick completions bash > ~/.local/share/bash-completion/completions/pinprick
 ### fish
 
 ```bash
+mkdir -p ~/.config/fish/completions
 pinprick completions fish > ~/.config/fish/completions/pinprick.fish
 ```
 

--- a/site/src/content/docs/commands/pin.md
+++ b/site/src/content/docs/commands/pin.md
@@ -17,6 +17,7 @@ pinprick pin /path/to/repo
 
 - Dry-run by default — shows what would change without writing files, exits 1 when there are unpinned actions (useful for CI gating)
 - `--write` rewrites files in-place with `@sha # tag` format, preserving all comments and formatting
+- A tag-resolution failure with `--write` exits 2 and leaves all workflows unchanged. Dry-run lookup failures exit 1. This pre-write gate does not make later filesystem writes a cross-file transaction
 - Tag refs (e.g., `@v7.0.0`) are resolved to their commit SHA via the GitHub API
 - Sliding tags (e.g., `@v7`) are resolved to the exact release version — `@v7` becomes `# v7.0.0`, not `# v7`
 - Already-pinned refs (40-char hex SHAs) are skipped silently

--- a/site/src/content/docs/configuration/audited-actions.md
+++ b/site/src/content/docs/configuration/audited-actions.md
@@ -8,7 +8,7 @@ pinprick maintains a list of GitHub Actions that have been scanned and confirmed
 ## Lookup order
 
 1. **Bundled** — compiled into the binary at build time. Same trust as the binary itself.
-2. **Local cache** — `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`). Populated automatically when you scan an action and it comes back clean.
+2. **Local cache** — `$XDG_CACHE_HOME/pinprick/audited/` (default `~/.cache/pinprick/audited/`). Populated after a complete, clean scan under the default runtime trust policy. Entries are tied to the scanner version; scans using `trusted-hosts` or `extra-data-formats` do not populate this cache.
 3. **Remote** — `https://pinprick.rs/audited-actions/`. Opt-in via `fetch-remote = true` in your [config file](/configuration/config-file).
 4. **GitHub API** — full source fetch and scan as last resort.
 
@@ -42,18 +42,18 @@ This is not a full security review. An action listed as audited may still:
 
 For static analysis of workflow files — permissions, template injection, credential handling — use [zizmor](https://github.com/zizmorcore/zizmor).
 
-## Why the SHA is permanent
+## Scope and freshness
 
-A SHA is a commit hash. If any file in the commit changes — including `dist/index.js` — the hash changes. So an audit result for a SHA is deterministic and permanent.
+A commit SHA binds the action source, including bundled entrypoints. The verdict also depends on the scanner rules and trust policy. Local cache entries require the current scanner version and default runtime trust policy. Pull-request CI re-verifies entries selected by its change routing; scheduled verification scans catalog shards. Release packaging embeds the checked-in catalog without an additional fresh scan. The remote catalog requires a fresh signed timestamp. Use `--no-audited-catalog` to inspect source with the current scanner instead of accepting an existing verdict.
 
 ## Contributing
 
 To add a new entry to the audited-actions list:
 
-1. Run `pinprick audit` against a repository using the action at the SHA you want to add
-2. Confirm zero findings
-3. Add the SHA and tag to the exact identity file: `audited-actions/{owner}/{repo}.json` for a root action or `audited-actions/{owner}/{repo}/{subpath}.json` for a subpath action
-4. Open a PR
+1. In a Pinprick checkout, run `just add-action owner/repo` (include the subpath for a subpath action).
+2. The recipe resolves a full SHA and requires a fresh, complete scan with zero ignored actions under isolated default configuration.
+3. Inspect the generated exact-identity entry and build the current scanner with `cargo build --locked --release`, then run `scripts/verify-audited-actions.sh target/release/pinprick files <entry-file>` with a GitHub token.
+4. Open a PR with the verification result.
 
 Each file is a JSON array:
 

--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -84,7 +84,7 @@ To suppress a specific pattern that `trusted-hosts` doesn't cover, use [`ignore.
 
 ### `ignore.actions`
 
-Skip scanning specific actions entirely. Useful for actions you've reviewed manually or that produce known false positives. Matches by prefix — `"actions/checkout"` matches `actions/checkout` at any SHA.
+Skip scanning specific actions entirely. Useful for actions you've reviewed manually or that produce known false positives. Matching is case-insensitive and respects path boundaries: `"actions/checkout"` matches that repository at any SHA, while `"actions"` or `"actions/"` matches the owner. Partial repository names do not match.
 
 ### `ignore.patterns`
 

--- a/site/src/content/docs/getting-started/github-action.md
+++ b/site/src/content/docs/getting-started/github-action.md
@@ -3,7 +3,7 @@ title: GitHub Action
 description: Run pinprick audit in GitHub Actions.
 ---
 
-[`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action) is the shipped composite action for CI audit runs. It installs a pinprick release, verifies the downloaded archive checksum, runs `pinprick audit`, and optionally uploads SARIF to GitHub code scanning.
+[`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action) is the shipped composite action for CI audit runs. It installs a pinprick release, verifies the downloaded archive checksum and GitHub build provenance, runs `pinprick audit`, and optionally uploads SARIF to GitHub code scanning.
 
 The action runs `audit` only. Use the CLI directly for `pin`, `update`, and `score`.
 
@@ -127,6 +127,6 @@ In Advanced Security mode, SARIF upload happens before optional `fail-on-finding
 
 ## Runner support
 
-The action supports Linux x64, Linux ARM64, and macOS ARM64 runners. On Linux, it downloads the `gnu` release assets, so self-hosted Linux runners need a compatible glibc for the selected pinprick release. Use a direct CLI install on musl/Alpine runners.
+The action supports GitHub-hosted Linux x64, Linux ARM64, and macOS ARM64 runners. It rejects self-hosted runners. On Linux, it downloads the `gnu` release assets. Use a direct CLI install for self-hosted or musl/Alpine environments.
 
 Windows and macOS x64 runners are not supported by the wrapper.

--- a/site/src/content/docs/getting-started/installation.md
+++ b/site/src/content/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ The musl binaries are statically linked, but pinprick makes HTTPS calls to the G
 
 ## GitHub Action
 
-For CI audit runs without hand-rolling the install step, use [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). The action installs a pinned pinprick release, verifies the downloaded archive checksum, runs `pinprick audit`, and can upload SARIF to GitHub code scanning.
+For CI audit runs without hand-rolling the install step, use [`starhaven-io/pinprick-action`](https://github.com/starhaven-io/pinprick-action). The action installs a pinned pinprick release, verifies the downloaded archive checksum and GitHub build provenance, runs `pinprick audit`, and can upload SARIF to GitHub code scanning.
 
 See [GitHub Action](/getting-started/github-action/) for a SHA-pinned workflow example and input reference.
 
@@ -47,11 +47,7 @@ See [GitHub Action](/getting-started/github-action/) for a SHA-pinned workflow e
 
 Generate completions for your shell:
 
-```bash
-pinprick completions zsh > ~/.zfunc/_pinprick
-pinprick completions bash > /etc/bash_completion.d/pinprick
-pinprick completions fish > ~/.config/fish/completions/pinprick.fish
-```
+See the [completions command](/commands/completions/) for shell-specific installation paths and setup.
 
 ## GitHub authentication
 

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -13,7 +13,7 @@ This is the canonical list of every rule `pinprick audit` checks. All rules emit
 
 ## How matches are scored
 
-pinprick scans line by line. Each rule is an anchored regex, compiled once at startup.
+pinprick uses bounded source traversal, logical-command parsing, literal propagation, and precompiled patterns. It does not execute workflow or action code.
 
 - **Pipe-to-shell pre-empts other shell rules.** If a line matches a pipe-to-shell rule, no other shell or Docker rule fires on that line. So `curl ... | sh` produces a single high-severity finding instead of one medium (unversioned URL) plus one high (pipe-to-shell).
 - **Versioned-URL downgrade.** Non-pipe shell, JavaScript, and Python fetch rules only fire if the URL is _unversioned_. A URL is versioned if any path segment matches `v?\d+(\.\d+)+` — e.g. `/v1.2.3/`, `/0.55.8/`. See [Versioned URL heuristic](#versioned-url-heuristic).
@@ -365,19 +365,19 @@ uvx --from black@24.10.0 black --check .
 
 **Severity:** Medium
 
-Triggers on `pip install git+https://…` (or `git+http://…`) where the VCS URL has no `@<ref>` suffix. Without a ref, pip installs from the repo's default branch at HEAD, which silently changes over time. Any ref — tag, branch name, or full SHA — suppresses the finding (mirrors `git clone --branch` handling: branch refs are accepted here rather than requiring a SHA).
+Triggers on `pip install git+https://…` (or `git+http://…`) where the VCS URL has no `@<ref>` suffix. Without a ref, pip installs from the repository default branch. A version-like tag or full commit SHA suppresses the finding; branch refs such as `main` remain findings.
 
 ```bash
 pip install git+https://github.com/owner/repo.git
 pip install --user git+https://github.com/owner/repo.git
 pip3 install git+https://gitlab.example.com/team/tool.git
+pip install git+https://github.com/owner/repo.git@main
 ```
 
 Not flagged:
 
 ```bash
 pip install git+https://github.com/owner/repo.git@v1.2.3
-pip install git+https://github.com/owner/repo.git@main
 pip install git+https://github.com/owner/repo.git@abc1234567890abcdef1234567890abcdef123456
 ```
 
@@ -699,7 +699,7 @@ Not flagged:
 
 ## Versioned URL heuristic
 
-A URL is considered _versioned_ if it contains a path segment matching `v?\d+(\.\d+)+` between `/`, `=`, or `@` boundaries:
+A URL is considered _versioned_ if it contains a path segment matching `v?\d+(\.\d+)+` at a path boundary or in a versioned filename (for example `tool-1.2.3.tar.gz`). Hostnames, query strings, and fragments do not qualify:
 
 | URL                                                        | Versioned?                         |
 | ---------------------------------------------------------- | ---------------------------------- |
@@ -716,7 +716,7 @@ This is intentionally strict — `v4` alone is a sliding major-version alias, no
 
 Unversioned URL rules (`curl`/`wget` to an unversioned URL, `fetch()`/`axios` to an unversioned URL, `urllib`/`requests` to an unversioned URL) are **not** emitted as findings when the URL's path ends in a known data-format extension. Instead, the match is recorded as an _allowed_ match with reason `data format URL` and is only visible under `--verbose`.
 
-Rationale: a workflow fetching JSON for `jq` or YAML for parsing is a different risk class from fetching an install script. The payload is consumed as data, never executed. Homebrew/core's `curl -s https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json` is a real example — the JSON is assigned to a shell variable and parsed, never run.
+Rationale: a workflow fetching JSON for `jq` or YAML for parsing is a different risk class from fetching an install script. The extension is a heuristic for intended data use; it does not prove how a later step consumes the bytes. Homebrew/core's `curl -s https://formulae.brew.sh/api/analytics/install/homebrew-core/30d.json` is a real example — the JSON is assigned to a shell variable and parsed, never run.
 
 **Extensions considered data formats:**
 
@@ -739,7 +739,7 @@ The list can be extended via `extra-data-formats` in [`.pinprick.toml`](/configu
 
 ## Piped-to-`jq` exemption
 
-A `curl`/`wget` whose output is piped into `jq` is recorded as an allowed match with reason `piped to jq` rather than emitted as a finding — even when the URL has no data-format extension. `jq` parses JSON and errors on anything else, so the fetched bytes are consumed as data, never executed.
+A `curl`/`wget` whose output is piped into `jq` is recorded as an allowed match with reason `piped to jq` rather than emitted as a finding — even when the URL has no data-format extension. `jq` parses JSON and errors on other formats. This heuristic describes the observed pipeline; it cannot prove how later commands consume saved output.
 
 This covers the case the [data-format exemption](#data-format-exemption) misses: a REST API endpoint that returns JSON but carries no `.json` in its path. Resolving the latest release of a crate from the registry API is a real example:
 
@@ -825,7 +825,7 @@ actions = [
 ]
 ```
 
-Matches by prefix against `owner/repo`, so `"actions/checkout"` matches every `actions/checkout@anything`. Use this when you've manually reviewed an action and decided it's out of scope — e.g. an action maintained by your own org that you already security-review separately. The blast radius is the entire action, so use sparingly.
+Matching is case-insensitive and respects path boundaries. `"actions/checkout"` matches that repository at any ref; `"actions"` or `"actions/"` matches the owner. Use this when you've manually reviewed an action and decided it's out of scope — e.g. an action maintained by your own org that you already security-review separately. The blast radius is the entire action, so use sparingly.
 
 ### `severity` threshold
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -22,7 +22,7 @@ use crate::audit_shell::{
     docker_unpinned_images, fetch_output_targets, file_artifact_events,
     git_clone_has_bound_sha_checkout, imports_runtime_gpg_key_at, is_shell_comment_line,
     join_continuations, mutates_curl_config, mutates_wget_config, mutates_wget_config_file,
-    url_piped_to_jq,
+    shell_urls_are_literal, url_piped_to_jq,
 };
 use crate::audit_source::{
     ActionScanStatus, remote_action_scan_key, scan_action_source, scan_local_action_source_graph,
@@ -403,12 +403,6 @@ pub async fn run(
                                 action.full_name()
                             ));
                         }
-                        // Anchor remote-scan findings to the loading `uses:` line
-                        // so SARIF results land inside the scanning repo.
-                        for finding in collector.findings.iter_mut().skip(findings_before) {
-                            finding.workflow_file = Some(display_name.clone());
-                            finding.workflow_line = Some(action.line_number);
-                        }
                         // Only cache clean verdicts for SHA refs — tag and branch
                         // contents can move after the verdict.
                         if scan_status == ActionScanStatus::Complete
@@ -422,6 +416,7 @@ pub async fn run(
                                 action.subpath.as_deref(),
                                 &action.ref_string,
                                 tag,
+                                config,
                             );
                         }
                     }
@@ -438,6 +433,11 @@ pub async fn run(
                             action.full_name()
                         ));
                     }
+                }
+                // Partial graph failures still carry findings from inspected nodes.
+                for finding in collector.findings.iter_mut().skip(findings_before) {
+                    finding.workflow_file = Some(display_name.clone());
+                    finding.workflow_line = Some(action.line_number);
                 }
             }
         } else {
@@ -3096,44 +3096,46 @@ fn check_url_patterns(
     // Check EVERY URL, not just the first: a versioned/trusted decoy before
     // the real fetch must not suppress the finding. Allowed only if all URLs
     // are exempt; any unexempt one is a finding.
-    let mut allowed_reason: Option<&str> = None;
+    let shell_url_ambiguous = matches!(pattern.category, audit_patterns::Category::ShellFetch)
+        && (audit_patterns::SH_CURL_UNVERSIONED.is_match(line)
+            || audit_patterns::SH_WGET_UNVERSIONED.is_match(line)
+            || audit_patterns::SH_DENO_URL.is_match(line))
+        && !shell_urls_are_literal(line);
+    let mut allowed_reasons = Vec::new();
     let mut dangerous = false;
     for url in extract_urls(line) {
-        if url_has_version(url) {
-            allowed_reason.get_or_insert("versioned URL");
+        if url.contains('\\') {
+            dangerous = true;
+            continue;
+        }
+        let reason = if shell_url_ambiguous {
+            // jq classifies the response as data independently of URL components.
+            if url_piped_to_jq(line, url) {
+                "piped to jq"
+            } else {
+                dangerous = true;
+                continue;
+            }
+        } else if url_has_version(url) {
+            "versioned URL"
         } else if config.is_host_trusted(url) {
-            allowed_reason.get_or_insert(REASON_TRUSTED_HOST);
+            REASON_TRUSTED_HOST
         } else if config.is_extra_data_format_exempt(url) {
-            allowed_reason.get_or_insert(REASON_EXTRA_DATA_FORMAT);
+            REASON_EXTRA_DATA_FORMAT
         } else if config.is_data_format_exempt(url) {
-            allowed_reason.get_or_insert("data format URL");
+            "data format URL"
         } else if url_piped_to_jq(line, url) {
-            allowed_reason.get_or_insert("piped to jq");
+            "piped to jq"
         } else {
             dangerous = true;
-            break;
+            continue;
+        };
+        if !allowed_reasons.contains(&reason) {
+            allowed_reasons.push(reason);
         }
     }
 
-    if dangerous {
-        if let Some(reason) = allowed_reason {
-            collector.push_allowed(AuditMatch::from_pattern(
-                pattern,
-                action_name,
-                source_file,
-                line_num,
-                line,
-                reason,
-            ));
-        }
-        collector.push_finding(AuditFinding::from_pattern(
-            pattern,
-            action_name,
-            source_file,
-            line_num,
-            line,
-        ));
-    } else if let Some(reason) = allowed_reason {
+    for reason in allowed_reasons {
         collector.push_allowed(AuditMatch::from_pattern(
             pattern,
             action_name,
@@ -3141,6 +3143,15 @@ fn check_url_patterns(
             line_num,
             line,
             reason,
+        ));
+    }
+    if dangerous {
+        collector.push_finding(AuditFinding::from_pattern(
+            pattern,
+            action_name,
+            source_file,
+            line_num,
+            line,
         ));
     }
     // No URL on the line: nothing to record.
@@ -5074,6 +5085,34 @@ const d = require("node:https").get("https://example.com/install.sh", cb);
     }
 
     #[test]
+    fn shell_url_exemptions_require_literal_word_boundaries() {
+        let config = Config {
+            trusted_hosts: vec!["example.com".into()],
+            ..Config::default()
+        };
+        for line in [
+            "curl 'https://example.com/data.json'",
+            "curl 'https://example.com/$CHANNEL/data.json?limit=1&offset=0'",
+        ] {
+            let mut literal = AuditCollector::new(true);
+            scan_shell_content(line, "test.sh", 1, "", &mut literal, &config);
+            assert!(literal.findings.is_empty(), "{line}");
+            assert_eq!(literal.trusted_host_allowed, 1, "{line}");
+        }
+        for line in [
+            "curl 'https://example.com/data.json'suffix",
+            "curl https://example.com/$CHANNEL/data.json",
+            "curl \"https://example.com/${CHANNEL}/data.json\"",
+        ] {
+            let mut combined = AuditCollector::new(true);
+            scan_shell_content(line, "test.sh", 1, "", &mut combined, &config);
+            assert_eq!(combined.findings.len(), 1, "{line}");
+            assert!(combined.allowed.is_empty(), "{line}");
+            assert_eq!(combined.trusted_host_allowed, 0, "{line}");
+        }
+    }
+
+    #[test]
     fn shell_scan_data_format_url_is_allowed_not_finding() {
         // Real Homebrew/core workflow line — regression anchor.
         let mut c = AuditCollector::new(true);
@@ -5361,6 +5400,28 @@ const d = require("node:https").get("https://example.com/install.sh", cb);
         assert_eq!(c.allowed.len(), 1);
         assert_eq!(c.allowed[0].reason, "trusted host");
         assert_eq!(c.trusted_host_allowed, 1);
+    }
+
+    #[test]
+    fn mixed_url_reasons_preserve_config_impact() {
+        let config = Config {
+            trusted_hosts: vec!["artifacts.example.com".into()],
+            extra_data_formats: vec!["proto".into()],
+            ..Config::default()
+        };
+        let mut collector = AuditCollector::new(true);
+        scan_shell_content(
+            "curl https://example.com/v1.2.3/file https://artifacts.example.com/file https://example.com/schema.proto",
+            "test.sh",
+            1,
+            "",
+            &mut collector,
+            &config,
+        );
+        assert!(collector.findings.is_empty());
+        assert_eq!(collector.trusted_host_allowed, 1);
+        assert_eq!(collector.extra_data_format_allowed, 1);
+        assert_eq!(collector.allowed.len(), 3);
     }
 
     #[test]

--- a/src/audit_patterns.rs
+++ b/src/audit_patterns.rs
@@ -575,11 +575,17 @@ fn url_path(url: &str) -> &str {
     else {
         return url;
     };
+    if url.contains('\\') {
+        return "";
+    }
     // The path starts at the first `/`, which also ends the authority. Any
     // `user@host` userinfo and any `@` in a later path segment or query are
     // therefore excluded without special-casing `@`.
-    match rest.find('/') {
-        Some(i) => rest[i..].split(['?', '#']).next().unwrap_or_default(),
+    match rest.find(['/', '?', '#']) {
+        Some(i) if rest.as_bytes()[i] == b'/' => {
+            rest[i..].split(['?', '#']).next().unwrap_or_default()
+        }
+        Some(_) => "",
         None => "",
     }
 }
@@ -593,7 +599,7 @@ const DATA_FORMAT_EXTENSIONS: &[&str] = &[
 /// Extract the filename extension from a URL's path. Query strings and
 /// fragments are stripped. Returns `None` if the final path segment has no dot.
 pub fn url_extension(url: &str) -> Option<&str> {
-    let path = url.split(['?', '#']).next().unwrap_or(url);
+    let path = url_path(url).split(['?', '#']).next().unwrap_or_default();
     let last = path.rsplit('/').next().unwrap_or("");
     let dot = last.rfind('.')?;
     Some(&last[dot + 1..])
@@ -603,10 +609,18 @@ pub fn url_extension(url: &str) -> Option<&str> {
 /// optional `user@` prefix, and trailing port/path/query/fragment. Returns
 /// `None` if the URL does not start with `http://` or `https://`.
 pub fn url_host(url: &str) -> Option<&str> {
+    // Shell and HTTP clients disagree on backslashes; do not grant an exemption.
+    if url.contains('\\') {
+        return None;
+    }
     let rest = url
         .strip_prefix("https://")
         .or_else(|| url.strip_prefix("http://"))?;
-    let after_userinfo = rest.split_once('@').map(|(_, r)| r).unwrap_or(rest);
+    let authority = rest.split(['/', '?', '#']).next()?;
+    let after_userinfo = authority
+        .rsplit_once('@')
+        .map(|(_, r)| r)
+        .unwrap_or(authority);
     let end = after_userinfo
         .find(['/', ':', '?', '#'])
         .unwrap_or(after_userinfo.len());
@@ -625,7 +639,8 @@ pub fn url_is_data_format(url: &str) -> bool {
 
 // URLs end at whitespace, quotes, backticks, `)`, or `>` so string-literal and
 // markdown-link syntax never rides into the version/extension/host checks.
-static URL_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"https?://[^\s"'`)>]+"#).unwrap());
+pub(crate) static URL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"https?://[^\s"'`)>]+"#).unwrap());
 
 /// Extract every URL from a line, in order of appearance.
 pub fn extract_urls(line: &str) -> impl Iterator<Item = &str> {
@@ -819,6 +834,45 @@ pub fn category_str(c: &Category) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn url_components_stay_within_their_boundaries() {
+        assert_eq!(
+            url_host("https://example.com/docs/@reference"),
+            Some("example.com")
+        );
+        assert_eq!(
+            url_host("https://example.com?email=reader@example.org"),
+            Some("example.com")
+        );
+        assert_eq!(url_extension("https://example.json"), None);
+        assert_eq!(url_extension("config.json"), Some("json"));
+        assert!(!url_has_version(
+            "https://example.com?redirect=/v1.2.3/tool"
+        ));
+        assert!(!url_has_version("https://example.com#/v1.2.3/tool"));
+        assert!(url_has_version("https://example.com/v1.2.3/tool?cache=1"));
+    }
+
+    #[test]
+    fn backslash_urls_receive_no_component_exemptions() {
+        for url in [
+            r"https://example.com\folder",
+            r"https://example.com\v1.2.3/tool.json",
+            r"https://example.com/path\config.json",
+        ] {
+            assert_eq!(url_host(url), None);
+            assert!(!url_has_version(url));
+            assert_eq!(url_extension(url), None);
+            assert!(!url_is_data_format(url));
+        }
+        assert_eq!(url_extension("config.json"), Some("json"));
+        assert_eq!(url_extension(r"C:\data\config.json"), Some("json"));
+        assert_eq!(
+            url_host("https://reader@example.com:8080/path"),
+            Some("example.com")
+        );
+    }
 
     // ── url_has_version ─────────────────────────────────────────────────
 
@@ -2084,7 +2138,7 @@ mod tests {
 
     #[test]
     fn pip_install_git_url_versioned_or_sha_is_pinned() {
-        // Version-like tag and a full 40-char SHA are immutable pins.
+        // Version-like tags and full commit SHAs qualify under the pinning heuristic.
         assert!(pip_git_url_has_ref(
             "pip install git+https://github.com/owner/repo.git@v1.2.3"
         ));

--- a/src/audit_shell.rs
+++ b/src/audit_shell.rs
@@ -6,7 +6,7 @@
 //! whether a `git clone` is bound to a SHA checkout, and whether a fetch is
 //! piped into `jq`.
 
-use crate::audit_patterns::{git_clone_has_pinned_ref, has_checksum_verify};
+use crate::audit_patterns::{URL_RE, git_clone_has_pinned_ref, has_checksum_verify};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -198,14 +198,6 @@ fn split_shell_control_parts(line: &str) -> Vec<(String, Option<ShellControl>)> 
 }
 
 fn split_shell_pipeline(line: &str) -> Vec<String> {
-    split_shell(line, SplitMode::Pipeline)
-}
-
-enum SplitMode {
-    Pipeline,
-}
-
-fn split_shell(line: &str, mode: SplitMode) -> Vec<String> {
     let mut out = Vec::new();
     let mut current = String::new();
     let mut chars = line.chars().peekable();
@@ -236,11 +228,10 @@ fn split_shell(line: &str, mode: SplitMode) -> Vec<String> {
             continue;
         }
 
-        match mode {
-            SplitMode::Pipeline if ch == '|' && chars.peek() != Some(&'|') => {
-                push_shell_part(&mut out, &mut current);
-            }
-            _ => current.push(ch),
+        if ch == '|' && chars.peek() != Some(&'|') {
+            push_shell_part(&mut out, &mut current);
+        } else {
+            current.push(ch);
         }
     }
 
@@ -341,6 +332,48 @@ fn push_shell_word(words: &mut Vec<String>, current: &mut String) {
     if !current.is_empty() {
         words.push(std::mem::take(current));
     }
+}
+
+/// Whether raw URL components are complete, literal shell argument text.
+pub(crate) fn shell_urls_are_literal(line: &str) -> bool {
+    URL_RE.find_iter(line).all(|found| {
+        let prefix = &line[..found.start()];
+        let suffix = &line[found.end()..];
+        let quote = prefix
+            .chars()
+            .next_back()
+            .filter(|c| matches!(c, '\'' | '"'));
+        let before = if quote.is_some() {
+            &prefix[..prefix.len() - 1]
+        } else {
+            prefix
+        };
+        let begins_word = before.is_empty()
+            || before.ends_with(|c: char| c.is_whitespace() || matches!(c, '(' | '='));
+        if !begins_word || before.ends_with("\\ ") || before.ends_with("\\\t") {
+            return false;
+        }
+        let token = found.as_str();
+        if quote != Some('\'') && token.contains(['$', '`', '\\']) {
+            return false;
+        }
+        if quote.is_none()
+            && token.trim_end_matches([';', '|', '&']).contains([
+                ';', '|', '&', '<', '>', '(', ')', '{', '}', '[', ']', '*', '?',
+            ])
+        {
+            return false;
+        }
+        match quote {
+            Some(quote) => suffix.strip_prefix(quote).is_some_and(|after| {
+                after.is_empty()
+                    || after.starts_with(|c: char| {
+                        c.is_whitespace() || matches!(c, ')' | ';' | '|' | '&' | '<' | '>')
+                    })
+            }),
+            None => !suffix.starts_with(['\'', '"', '`']),
+        }
+    })
 }
 
 pub(crate) fn url_piped_to_jq(line: &str, url: &str) -> bool {
@@ -1986,6 +2019,33 @@ mod tests {
             split_shell_control(r#"printf one\;two || printf 'three;four'"#),
             vec![r#"printf one\;two"#, "printf 'three;four'"]
         );
+    }
+
+    #[test]
+    fn literal_url_words_require_complete_tokens() {
+        for line in [
+            "curl https://example.com/data.json",
+            "wget 'https://example.com/data.json'",
+            "curl --url=\"https://example.com/data.json\" | jq .",
+            "curl https://a.example/file https://b.example/file",
+            r#"DATA="$(curl https://example.com/data.json)""#,
+            "curl 'https://example.com/$CHANNEL/data.json?limit=1&offset=0'",
+            "curl --url=\"https://example.com/data.json?limit=1&offset=0\"",
+        ] {
+            assert!(shell_urls_are_literal(line), "{line}");
+        }
+        for line in [
+            "curl 'https://example.com/'suffix",
+            "curl https://example.com/'suffix'",
+            "curl 'https://example.com/'\"suffix\"",
+            "curl https://example.com/ https://example.com/'suffix'",
+            "curl https://example.com/$CHANNEL/data.json",
+            "curl \"https://example.com/${CHANNEL}/data.json\"",
+            "curl https://example.com/data.json;printf done",
+            "curl https://example.com/data*.json",
+        ] {
+            assert!(!shell_urls_are_literal(line), "{line}");
+        }
     }
 
     #[test]

--- a/src/audited_actions.rs
+++ b/src/audited_actions.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::output::sanitize_for_terminal;
 use minisign_verify::{PublicKey, Signature};
 use serde::Deserialize;
@@ -8,20 +9,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const BUNDLED_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/bundled_audited_actions.json"));
 const REMOTE_URL: &str = "https://pinprick.rs/audited-actions";
 
-/// Reject a remote catalog whose signed `timestamp:` trusted comment is older
-/// than this. The site re-signs every catalog file on each deploy, and deploys
-/// fire on every main push touching `site/**`, `audited-actions/**`, or
-/// `Cargo.toml` (weekly catalog PRs, dependency bumps, releases), so
-/// production signatures refresh far more often than monthly. A signature
-/// past this window therefore strongly suggests a replayed, superseded
-/// catalog; the cost of a false positive is only a warning and a fresh scan.
+/// Bound replay of a superseded signed catalog. Deployments refresh signatures;
+/// an expired catalog produces a warning and falls back to a fresh scan.
 const MAX_REMOTE_CATALOG_AGE: Duration = Duration::from_secs(30 * 24 * 60 * 60);
 
-/// Tolerated clock skew for a signed timestamp that sits in the future.
-/// Deploy runners and clients are NTP-synced, so minutes cover legitimate
-/// drift; anything beyond is a signing-system clock fault or a forged
-/// far-future timestamp — which would otherwise stay "fresh" until
-/// `timestamp + MAX_REMOTE_CATALOG_AGE` and defeat the replay window.
+/// Bound future timestamps so a faulty signing clock cannot extend the replay
+/// window indefinitely. Larger client clock drift also requires a fresh scan.
 const MAX_CLOCK_SKEW: Duration = Duration::from_secs(10 * 60);
 
 /// Freshness verdict for a signed catalog timestamp.
@@ -60,9 +53,13 @@ struct AuditedEntry {
     sha: String,
     #[serde(default)]
     pinprick_version: Option<String>,
+    #[serde(default)]
+    policy_version: Option<u8>,
 }
 
 const LOCAL_CACHE_PINPRICK_VERSION: &str = env!("CARGO_PKG_VERSION");
+// Only verdicts produced without custom runtime trust can outlive their config.
+const LOCAL_CACHE_POLICY_VERSION: u8 = 1;
 
 /// Which layer in the lookup satisfied an audited-action check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,8 +184,12 @@ impl AuditedActions {
         subpath: Option<&str>,
         sha: &str,
         tag: &str,
+        config: &Config,
     ) {
-        if !is_full_sha(sha) {
+        if !is_full_sha(sha)
+            || !config.trusted_hosts.is_empty()
+            || !config.extra_data_formats.is_empty()
+        {
             return;
         }
         let Some(cache_dir) = &self.cache_dir else {
@@ -214,6 +215,8 @@ impl AuditedActions {
         // the file from accumulating dead entries.
         entries.retain(|e| {
             e.get("pinprick_version").and_then(|v| v.as_str()) == Some(LOCAL_CACHE_PINPRICK_VERSION)
+                && e.get("policy_version").and_then(|v| v.as_u64())
+                    == Some(u64::from(LOCAL_CACHE_POLICY_VERSION))
                 && e.get("action").and_then(|v| v.as_str()).is_some()
         });
 
@@ -228,7 +231,8 @@ impl AuditedActions {
             "action": key,
             "sha": sha,
             "tag": tag,
-            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION
+            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION,
+            "policy_version": LOCAL_CACHE_POLICY_VERSION
         }));
 
         if std::fs::create_dir_all(&dir).is_ok()
@@ -434,6 +438,7 @@ fn parse_local_cache_entries(json: &str, key: &str) -> HashSet<String> {
     entries
         .into_iter()
         .filter(|e| e.pinprick_version.as_deref() == Some(LOCAL_CACHE_PINPRICK_VERSION))
+        .filter(|e| e.policy_version == Some(LOCAL_CACHE_POLICY_VERSION))
         .filter(|e| e.action.as_deref() == Some(key))
         .filter_map(|entry| is_full_sha(&entry.sha).then(|| entry.sha.to_ascii_lowercase()))
         .collect()
@@ -585,7 +590,7 @@ mod tests {
         let mut aa = AuditedActions::new(false);
         aa.bundled.clear();
         aa.cache_dir = Some(dir.path().to_path_buf());
-        aa.cache_clean("owner", "repo", None, SHA_A, "v1");
+        aa.cache_clean("owner", "repo", None, SHA_A, "v1", &Config::default());
 
         assert_eq!(
             aa.check("owner", "repo", Some("restore"), SHA_A).await,
@@ -658,7 +663,8 @@ mod tests {
         let rendered = serde_json::to_string(&vec![serde_json::json!({
             "sha": SHA_A,
             "tag": "v1",
-            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION
+            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION,
+            "policy_version": LOCAL_CACHE_POLICY_VERSION
         })])
         .unwrap();
         assert!(!parse_local_cache_entries(&rendered, "owner/repo").contains(SHA_A));
@@ -670,11 +676,39 @@ mod tests {
             "action": "owner/repo",
             "sha": SHA_A,
             "tag": "v1",
-            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION
+            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION,
+            "policy_version": LOCAL_CACHE_POLICY_VERSION
         })])
         .unwrap();
         assert!(parse_local_cache_entries(&rendered, "owner/repo").contains(SHA_A));
         assert!(!parse_local_cache_entries(&rendered, "owner/repo/subdir").contains(SHA_A));
+    }
+
+    #[test]
+    fn local_cache_requires_default_policy_provenance() {
+        let legacy = serde_json::json!([{
+            "action": "owner/repo",
+            "sha": SHA_A,
+            "pinprick_version": LOCAL_CACHE_PINPRICK_VERSION
+        }]);
+        assert!(parse_local_cache_entries(&legacy.to_string(), "owner/repo").is_empty());
+
+        for config in [
+            Config {
+                trusted_hosts: vec!["example.com".into()],
+                ..Config::default()
+            },
+            Config {
+                extra_data_formats: vec!["bin".into()],
+                ..Config::default()
+            },
+        ] {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut audited = AuditedActions::new(false);
+            audited.cache_dir = Some(dir.path().to_path_buf());
+            audited.cache_clean("owner", "repo", None, SHA_A, "v1", &config);
+            assert!(!cache_path(dir.path(), "owner", "repo").unwrap().exists());
+        }
     }
 
     #[test]
@@ -683,7 +717,7 @@ mod tests {
         let mut aa = AuditedActions::new(false);
         aa.cache_dir = Some(dir.path().to_path_buf());
 
-        aa.cache_clean("owner", "repo", Some("a"), SHA_A, "v1");
+        aa.cache_clean("owner", "repo", Some("a"), SHA_A, "v1", &Config::default());
 
         assert!(
             aa.load_local_cache("owner", "repo", "owner/repo/a")
@@ -694,7 +728,7 @@ mod tests {
                 .contains(SHA_A)
         );
 
-        aa.cache_clean("owner", "repo", Some("b"), SHA_A, "v1");
+        aa.cache_clean("owner", "repo", Some("b"), SHA_A, "v1", &Config::default());
         assert!(
             aa.load_local_cache("owner", "repo", "owner/repo/b")
                 .contains(SHA_A)
@@ -725,7 +759,7 @@ mod tests {
                 .contains(SHA_A)
         );
 
-        aa.cache_clean("owner", "repo", None, SHA_A, "v1");
+        aa.cache_clean("owner", "repo", None, SHA_A, "v1", &Config::default());
 
         // The SHA is now cached under the current version…
         assert!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,11 +249,14 @@ fn load_repo_file(repo_root: &Path, name: &str) -> ConfigLoad {
     let mut file = match openat_file(
         &root,
         name,
-        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
     ) {
         Ok(file) => file,
         Err(_) => return ConfigLoad::Absent,
     };
+    if !file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return ConfigLoad::Absent;
+    }
 
     let mut content = String::new();
     if file.read_to_string(&mut content).is_err() {
@@ -542,6 +545,22 @@ trusted-hosts = ["artifacts.example.com", "releases.example.org"]
     }
 
     // ── load_file: warn vs silent ──────────────────────────────────────
+
+    #[test]
+    fn repo_config_requires_regular_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir(dir.path().join(".pinprick.toml")).unwrap();
+        assert!(matches!(
+            load_repo_file(dir.path(), ".pinprick.toml"),
+            ConfigLoad::Absent
+        ));
+        std::fs::remove_dir(dir.path().join(".pinprick.toml")).unwrap();
+        std::fs::write(dir.path().join(".pinprick.toml"), "severity = \"high\"\n").unwrap();
+        assert!(matches!(
+            load_repo_file(dir.path(), ".pinprick.toml"),
+            ConfigLoad::Loaded(_)
+        ));
+    }
 
     #[test]
     fn load_file_missing_is_absent() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,22 +182,7 @@ async fn main() -> ExitCode {
             )
             .await
         }
-        Command::Clean => {
-            let removed = match audited_actions::cache_dir() {
-                Some(dir) if dir.is_dir() => std::fs::remove_dir_all(&dir).is_ok(),
-                _ => false,
-            };
-
-            if cli.json {
-                let msg = serde_json::json!({ "cleaned": removed });
-                println!("{msg}");
-            } else if removed {
-                println!("Cache cleaned.");
-            } else {
-                println!("Nothing to clean.");
-            }
-            return ExitCode::SUCCESS;
-        }
+        Command::Clean => clean_cache(cli.json),
         Command::Completions { shell } => {
             clap_complete::generate(
                 *shell,
@@ -231,4 +216,23 @@ async fn main() -> ExitCode {
             ExitCode::from(2)
         }
     }
+}
+
+fn clean_cache(json: bool) -> anyhow::Result<ExitCode> {
+    let removed = match audited_actions::cache_dir() {
+        Some(dir) => match std::fs::remove_dir_all(&dir) {
+            Ok(()) => true,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+            Err(error) => return Err(anyhow::anyhow!("Could not remove audit cache: {error}")),
+        },
+        None => false,
+    };
+    if json {
+        println!("{}", serde_json::json!({ "cleaned": removed }));
+    } else if removed {
+        println!("Cache cleaned.");
+    } else {
+        println!("Nothing to clean.");
+    }
+    Ok(ExitCode::SUCCESS)
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -37,6 +37,7 @@ async fn run_with_client(
     // skips are excluded: those are warnings attached to a successful pin.
     let mut unpinnable = 0usize;
     let mut coverage_incomplete = false;
+    let mut resolution_failed = false;
     let mut pending_edits: Vec<(workflow::WorkflowFile, Vec<workflow::ActionEdit>)> = Vec::new();
 
     for file in &files {
@@ -160,6 +161,7 @@ async fn run_with_client(
                             });
                         }
                         Err(e) => {
+                            resolution_failed = true;
                             unpinnable += 1;
                             report.skipped.push(PinSkip {
                                 file: workflow::display_path(file.path(), repo_root),
@@ -178,7 +180,7 @@ async fn run_with_client(
         }
     }
 
-    if apply && !coverage_incomplete {
+    if apply && !coverage_incomplete && !resolution_failed {
         for (file, edits) in &pending_edits {
             workflow::rewrite_actions(file, &workflow::render_action_edits(edits)?)?;
         }
@@ -191,7 +193,7 @@ async fn run_with_client(
         report.print_human();
     }
 
-    if coverage_incomplete {
+    if coverage_incomplete || (apply && resolution_failed) {
         Ok(ExitCode::from(2))
     } else if !apply && (!report.pinned.is_empty() || unpinnable > 0) {
         Ok(ExitCode::from(1))
@@ -406,5 +408,74 @@ mod tests {
 
         assert_code(code, 2);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), original);
+    }
+    #[tokio::test]
+    async fn lookup_failure_blocks_every_pending_write() {
+        for failing_status in [401, 404, 500] {
+            for failure_first in [false, true] {
+                let server = MockServer::start().await;
+                Mock::given(method("GET"))
+                    .and(path("/repos/o/available/git/ref/tags/v2"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                        "object": { "sha": SHA, "type": "commit" }
+                    })))
+                    .mount(&server)
+                    .await;
+                Mock::given(method("GET"))
+                    .and(path("/repos/o/available/git/matching-refs/tags/v2"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+                    .mount(&server)
+                    .await;
+                Mock::given(method("GET"))
+                    .and(path("/repos/o/unavailable/git/ref/tags/v2"))
+                    .respond_with(ResponseTemplate::new(failing_status))
+                    .mount(&server)
+                    .await;
+                let good = "jobs:\n  test:\n    steps:\n      - uses: o/available@v2\n";
+                let bad = "jobs:\n  test:\n    steps:\n      - uses: o/unavailable@v2\n";
+                let (first, second) = if failure_first {
+                    (bad, good)
+                } else {
+                    (good, bad)
+                };
+                let (dir, file) = repo_with_workflow(first);
+                let other = file.with_file_name("other.yml");
+                std::fs::write(&other, second).unwrap();
+                let code = run_with_client(dir.path(), true, true, &client_for(&server))
+                    .await
+                    .unwrap();
+                assert_code(code, 2);
+                assert_eq!(std::fs::read_to_string(file).unwrap(), first);
+                assert_eq!(std::fs::read_to_string(other).unwrap(), second);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn manual_refs_do_not_block_successful_tag_write() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/git/ref/tags/v2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "object": { "sha": SHA, "type": "commit" }
+            })))
+            .mount(&server)
+            .await;
+        // Comment refinement is best effort after the immutable SHA is resolved.
+        Mock::given(method("GET"))
+            .and(path("/repos/o/r/git/matching-refs/tags/v2"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let original = "jobs:\n  test:\n    steps:\n      - uses: o/r@v2\n      - uses: o/manual@main\n      - uses: docker://example/image:stable\n";
+        let (dir, file) = repo_with_workflow(original);
+        let code = run_with_client(dir.path(), true, true, &client_for(&server))
+            .await
+            .unwrap();
+        assert_code(code, 0);
+        assert_eq!(
+            std::fs::read_to_string(file).unwrap(),
+            original.replace("o/r@v2", &format!("o/r@{SHA} # v2"))
+        );
     }
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -539,9 +539,8 @@ fn warn_enrichment_incomplete(rule: &str, e: &anyhow::Error) {
 /// Fire `source.archived` findings for any pinned action whose repo is
 /// archived on GitHub. Requires a token; the caller has already resolved one.
 ///
-/// API calls are cached per `(owner, repo)` since archived status is a
-/// repo-level property. A failed lookup (404, network) is silently treated
-/// as "not archived" — one bad repo must not nuke the whole scan.
+/// API calls are cached per `(owner, repo)`. Failed lookups mark coverage
+/// incomplete; already collected findings remain in the report.
 async fn enrich_with_source_archived(
     report: &mut ScoreReport,
     repo_root: &Path,
@@ -580,7 +579,7 @@ async fn enrich_with_source_archived(
             Err(e) if is_hard_github_error(&e) => {
                 warn_enrichment_incomplete("source.archived", &e);
                 report.mark_coverage_incomplete(format!("source.archived evaluation stopped: {e}"));
-                return Ok(());
+                break;
             }
             Err(e) => {
                 warn_enrichment_incomplete("source.archived", &e);
@@ -722,7 +721,7 @@ async fn enrich_with_source_advisory(
     let mut advisories: BTreeMap<(String, String), Vec<SecurityAdvisory>> = BTreeMap::new();
     let mut queried: std::collections::BTreeSet<(String, String)> =
         std::collections::BTreeSet::new();
-    for (action_ref, (owner, repo, tag)) in &action_resolved {
+    'advisory_queries: for (action_ref, (owner, repo, tag)) in &action_resolved {
         let package = action_ref
             .rsplit_once('@')
             .map(|(package, _)| package)
@@ -739,7 +738,7 @@ async fn enrich_with_source_advisory(
                     report.mark_coverage_incomplete(format!(
                         "source.advisory evaluation stopped: {e}"
                     ));
-                    return Ok(());
+                    break 'advisory_queries;
                 }
                 Err(e) => {
                     warn_enrichment_incomplete("source.advisory", &e);
@@ -754,6 +753,32 @@ async fn enrich_with_source_advisory(
                 if !existing.iter().any(|item| item.ghsa_id == advisory.ghsa_id) {
                     existing.push(advisory);
                 }
+            }
+        }
+    }
+
+    for (action_ref, (owner, repo, tag)) in &action_resolved {
+        let package = action_ref
+            .rsplit_once('@')
+            .map_or(action_ref.as_str(), |(package, _)| package);
+        let packages = action_advisory_packages(package, owner, repo);
+        for advisory in advisories
+            .get(&(owner.clone(), repo.clone()))
+            .into_iter()
+            .flatten()
+        {
+            if advisory.vulnerabilities.iter().any(|vulnerability| {
+                vuln_is_for_action(vulnerability, &packages)
+                    && vulnerability
+                        .vulnerable_version_range
+                        .as_deref()
+                        .and_then(|range| version_in_range(tag, range))
+                        .is_none()
+            }) {
+                report.mark_coverage_incomplete(format!(
+                    "source.advisory could not evaluate a version range in {} for {action_ref}",
+                    advisory.ghsa_id
+                ));
             }
         }
     }
@@ -852,36 +877,14 @@ async fn enrich_with_remote_runtime(
         }
 
         let mut collector = AuditCollector::new(false);
-        match audit_source::scan_action_source(client, action, &mut collector, config).await {
-            Ok(ActionScanStatus::Complete) => {}
-            Ok(ActionScanStatus::Incomplete) => {
-                report.mark_coverage_incomplete(format!(
-                    "remote source scan incomplete for {action_ref}"
-                ));
-            }
-            Err(e) if is_hard_github_error(&e) => {
-                warn_enrichment_incomplete("runtime (remote action source)", &e);
-                report.mark_coverage_incomplete(format!(
-                    "remote source scan stopped at {action_ref}: {e}"
-                ));
-                return Ok(());
-            }
-            Err(e) => {
-                eprintln!(
-                    "warning: could not scan {} for runtime scoring: {}",
-                    crate::output::sanitize_for_terminal(&action.full_name()),
-                    crate::output::sanitize_for_terminal(&e.to_string())
-                );
-                report.mark_coverage_incomplete(format!(
-                    "remote source scan failed for {action_ref}: {e}"
-                ));
-                continue;
-            }
-        }
+        let scan_result =
+            audit_source::scan_action_source(client, action, &mut collector, config).await;
 
         let mut occs = occurrences.get(action_ref).cloned().unwrap_or_default();
         occs.sort_by(|a, b| a.workflow.cmp(&b.workflow).then(a.line.cmp(&b.line)));
 
+        impact.trusted_host_fetches += collector.trusted_host_allowed;
+        impact.extra_data_format_fetches += collector.extra_data_format_allowed;
         for finding in collector.findings {
             if config.is_pattern_ignored(&finding.description) {
                 impact.findings_suppressed += 1;
@@ -902,6 +905,32 @@ async fn enrich_with_remote_runtime(
                 remediation: rule.remediation(),
                 details: Some(format!("{location} — {}", finding.description)),
             });
+        }
+        match scan_result {
+            Ok(ActionScanStatus::Complete) => {}
+            Ok(ActionScanStatus::Incomplete) => {
+                report.mark_coverage_incomplete(format!(
+                    "remote source scan incomplete for {action_ref}"
+                ));
+            }
+            Err(e) if is_hard_github_error(&e) => {
+                warn_enrichment_incomplete("runtime (remote action source)", &e);
+                report.mark_coverage_incomplete(format!(
+                    "remote source scan stopped at {action_ref}: {e}"
+                ));
+                break;
+            }
+            Err(e) => {
+                eprintln!(
+                    "warning: could not scan {} for runtime scoring: {}",
+                    crate::output::sanitize_for_terminal(&action.full_name()),
+                    crate::output::sanitize_for_terminal(&e.to_string())
+                );
+                report.mark_coverage_incomplete(format!(
+                    "remote source scan failed for {action_ref}: {e}"
+                ));
+                continue;
+            }
         }
     }
 
@@ -1432,7 +1461,6 @@ pub fn render_html(report: &ScoreReport) -> String {
     out.push_str(HTML_CSS);
     out.push_str("</style>\n</head>\n<body>\n<div class=\"container\">\n");
 
-    // Header
     out.push_str("<div class=\"header\">\n  <div class=\"title\">pinprick score</div>\n");
     out.push_str(&format!(
         "  <div class=\"version\">rubric v{} · pinprick {}</div>\n</div>\n",
@@ -1440,7 +1468,6 @@ pub fn render_html(report: &ScoreReport) -> String {
         escape_html(report.pinprick_version)
     ));
 
-    // Grade banner
     out.push_str(&format!(
         "<div class=\"grade-banner\">\n  <div class=\"grade grade-{0}\">{0}</div>\n  <div>\n    <div class=\"score-number\">{1} / 100</div>\n    <div class=\"totals\">{2} workflows scanned · {3} unique actions · {4} findings</div>\n  </div>\n</div>\n",
         escape_html(report.grade),
@@ -1458,7 +1485,6 @@ pub fn render_html(report: &ScoreReport) -> String {
         out.push_str("</ul></div>\n");
     }
 
-    // Findings
     if report.findings.is_empty() {
         out.push_str("<div class=\"no-findings\">No findings. ");
         out.push_str(&escape_html(&format!(
@@ -1486,6 +1512,12 @@ pub fn render_html(report: &ScoreReport) -> String {
                 "  <div class=\"remediation\">{}</div>\n",
                 escape_html(f.remediation)
             ));
+            if let Some(details) = &f.details {
+                out.push_str(&format!(
+                    "  <div class=\"details\">{}</div>\n",
+                    escape_html(details)
+                ));
+            }
             if !f.occurrences.is_empty() {
                 out.push_str("  <ul class=\"occurrences\">\n");
                 for occ in &f.occurrences {
@@ -1505,7 +1537,6 @@ pub fn render_html(report: &ScoreReport) -> String {
         }
     }
 
-    // Footer
     out.push_str("<div class=\"footer\">\n  Generated by <a href=\"https://pinprick.rs\">pinprick</a>. Scoring rubric: <a href=\"https://github.com/starhaven-io/pinprick/blob/main/docs/scoring.md\">docs/scoring.md</a>.\n</div>\n");
 
     out.push_str("</div>\n</body>\n</html>\n");
@@ -2638,18 +2669,19 @@ jobs:
                 category: Category::Pin,
                 severity: Severity::Low,
                 points: 2,
-                action_ref: Some("<evil>/bar@v1".to_string()),
+                action_ref: Some("<example>/bar@v1".to_string()),
                 occurrences: vec![Occurrence {
                     workflow: "a&b.yml".to_string(),
                     line: 1,
                 }],
                 remediation: "Pin to a full 40-char SHA; keep the tag as a comment",
-                details: None,
+                details: Some("Review <package> & its advisory".to_string()),
             }],
         };
         let html = render_html(&report);
-        assert!(!html.contains("<evil>"));
-        assert!(html.contains("&lt;evil&gt;"));
+        assert!(!html.contains("<example>"));
+        assert!(html.contains("&lt;example&gt;"));
+        assert!(html.contains("Review &lt;package&gt; &amp; its advisory"));
         assert!(html.contains("a&amp;b.yml"));
     }
 
@@ -2790,45 +2822,243 @@ jobs:
         }
 
         #[tokio::test]
-        async fn source_advisory_fires_when_pin_is_in_vulnerable_range() {
+        async fn source_archived_retains_findings_before_auth_failure() {
             let dir = tempfile::TempDir::new().unwrap();
             let mut report = base_report(dir.path());
-
+            let workflow = dir.path().join(".github/workflows/ci.yml");
+            let mut content = std::fs::read_to_string(&workflow).unwrap();
+            content.push_str(&format!("      - uses: z/unavailable@{}\n", "b".repeat(40)));
+            std::fs::write(workflow, content).unwrap();
             let server = MockServer::start().await;
-            // The SHA pin resolves to v1.0.0 via the tags endpoint...
             Mock::given(method("GET"))
-                .and(path("/repos/o/r/tags"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                    { "name": "v1.0.0", "commit": { "sha": "a".repeat(40) } }
-                ])))
+                .and(path("/repos/o/r"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({"archived": true})))
                 .mount(&server)
                 .await;
-            // ...which falls inside this advisory's vulnerable range.
             Mock::given(method("GET"))
-                .and(path("/advisories"))
-                .respond_with(ResponseTemplate::new(200).set_body_json(json!([
-                    {
-                        "ghsa_id": "GHSA-test",
-                        "html_url": "https://github.com/advisories/GHSA-test",
-                        "severity": "high",
-                        "summary": "vulnerable",
-                        "vulnerabilities": [
-                            {
-                                "package": { "name": "o/r" },
-                                "vulnerable_version_range": "< 1.1.0",
-                                "patched_versions": "1.1.0"
-                            }
-                        ]
-                    }
-                ])))
+                .and(path("/repos/z/unavailable"))
+                .respond_with(ResponseTemplate::new(401))
                 .mount(&server)
                 .await;
             let client = GitHubClient::with_base("t".into(), server.uri());
+            enrich_with_source_archived(&mut report, dir.path(), &client)
+                .await
+                .unwrap();
+            assert!(!report.coverage_complete);
+            assert_eq!(report.findings.len(), 1);
+            assert_eq!(report.findings[0].id, "source.archived");
+            assert_eq!(report.score, 90);
+        }
 
+        #[tokio::test]
+        async fn remote_runtime_retains_findings_and_policy_impact_before_auth_failure() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let _ = base_report(dir.path());
+            let workflow = dir.path().join(".github/workflows/ci.yml");
+            let mut content = std::fs::read_to_string(&workflow).unwrap();
+            content.push_str(&format!("      - uses: z/unavailable@{}\n", "b".repeat(40)));
+            std::fs::write(workflow, content).unwrap();
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path(format!("/repos/o/r/git/trees/{}", "a".repeat(40))))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "tree": [{"path": "action.yml", "type": "blob"}]
+                })))
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/repos/o/r/contents/action.yml"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(
+                    "runs:\n  using: composite\n  steps:\n    - shell: bash\n      run: |\n        npm install example-package\n        curl https://artifacts.example.com/tool -o tool\n        curl https://example.com/schema.proto -o schema.proto\n"
+                ))
+                .mount(&server).await;
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/repos/z/unavailable/git/trees/{}",
+                    "b".repeat(40)
+                )))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+            let config = Config {
+                trusted_hosts: vec!["artifacts.example.com".into()],
+                extra_data_formats: vec!["proto".into()],
+                ..Config::default()
+            };
+            let (mut report, mut impact) = score_repo(dir.path(), &config).unwrap();
+            let client = GitHubClient::with_base("t".into(), server.uri());
+            enrich_with_remote_runtime(&mut report, dir.path(), &client, &config, &mut impact)
+                .await
+                .unwrap();
+            assert!(!report.coverage_complete);
+            assert_eq!(report.findings.len(), 1);
+            assert_eq!(report.findings[0].id, "runtime.fetch.low");
+            assert_eq!(report.score, 97);
+            assert_eq!(impact.trusted_host_fetches, 1);
+            assert_eq!(impact.extra_data_format_fetches, 1);
+        }
+
+        #[tokio::test]
+        async fn current_graph_findings_survive_nested_lookup_errors() {
+            for status in [401, 404, 500] {
+                for depth in [1, 2] {
+                    let dir = tempfile::TempDir::new().unwrap();
+                    let _ = base_report(dir.path());
+                    let workflow = dir.path().join(".github/workflows/ci.yml");
+                    let mut contents = std::fs::read_to_string(&workflow).unwrap();
+                    contents.push_str(&format!("      - uses: z/later@{}\n", "c".repeat(40)));
+                    std::fs::write(&workflow, contents).unwrap();
+                    let server = MockServer::start().await;
+                    for level in 0..depth {
+                        let repo = if level == 0 { "r" } else { "middle" };
+                        let sha = if level == 0 { "a" } else { "b" }.repeat(40);
+                        let child = if level + 1 == depth {
+                            "unavailable"
+                        } else {
+                            "middle"
+                        };
+                        Mock::given(method("GET"))
+                            .and(path(format!("/repos/o/{repo}/git/trees/{sha}")))
+                            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                                "tree": [{"path": "action.yml", "type": "blob"}]
+                            })))
+                            .mount(&server)
+                            .await;
+                        Mock::given(method("GET"))
+                            .and(path(format!("/repos/o/{repo}/contents/action.yml")))
+                            .respond_with(ResponseTemplate::new(200).set_body_string(format!(
+                                "runs:\n  using: composite\n  steps:\n    - shell: bash\n      run: |\n        npm install example-package\n        curl https://artifacts.example.com/tool -o tool\n        curl https://example.com/schema.proto -o schema.proto\n    - uses: o/{child}@{}\n", "b".repeat(40)
+                            )))
+                            .mount(&server).await;
+                    }
+                    Mock::given(method("GET"))
+                        .and(path(format!(
+                            "/repos/o/unavailable/git/trees/{}",
+                            "b".repeat(40)
+                        )))
+                        .respond_with(ResponseTemplate::new(status))
+                        .mount(&server)
+                        .await;
+                    Mock::given(method("GET"))
+                        .and(path(format!("/repos/z/later/git/trees/{}", "c".repeat(40))))
+                        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"tree": []})))
+                        .expect(if status == 401 { 0 } else { 1 })
+                        .mount(&server)
+                        .await;
+                    let config = Config {
+                        trusted_hosts: vec!["artifacts.example.com".into()],
+                        extra_data_formats: vec!["proto".into()],
+                        ..Config::default()
+                    };
+                    let (mut report, mut impact) = score_repo(dir.path(), &config).unwrap();
+                    let client = GitHubClient::with_base("t".into(), server.uri());
+                    enrich_with_remote_runtime(
+                        &mut report,
+                        dir.path(),
+                        &client,
+                        &config,
+                        &mut impact,
+                    )
+                    .await
+                    .unwrap();
+                    assert!(!report.coverage_complete);
+                    assert!(!report.coverage_notes.is_empty());
+                    assert_eq!(report.findings.len(), depth);
+                    assert_eq!(report.score, 100 - 3 * depth as u32);
+                    assert!(has_deductions(&report));
+                    assert_eq!(impact.trusted_host_fetches, depth);
+                    assert_eq!(impact.extra_data_format_fetches, depth);
+                    for finding in &report.findings {
+                        assert_eq!(finding.id, "runtime.fetch.low");
+                        assert_eq!(finding.action_ref, Some(format!("o/r@{}", "a".repeat(40))));
+                        assert_eq!(finding.occurrences[0].workflow, ".github/workflows/ci.yml");
+                        assert!(finding.details.as_deref().unwrap().contains("action.yml"));
+                    }
+                    server.verify().await;
+                }
+            }
+        }
+
+        #[tokio::test]
+        async fn source_advisory_fires_when_pin_is_in_vulnerable_range() {
+            for range in [Some("< 1.1.0"), Some("unsupported range"), None] {
+                let dir = tempfile::TempDir::new().unwrap();
+                let mut report = base_report(dir.path());
+
+                let server = MockServer::start().await;
+                // The SHA pin resolves to v1.0.0 via the tags endpoint...
+                Mock::given(method("GET"))
+                    .and(path("/repos/o/r/tags"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                        { "name": "v1.0.0", "commit": { "sha": "a".repeat(40) } }
+                    ])))
+                    .mount(&server)
+                    .await;
+                // ...which falls inside this advisory's vulnerable range.
+                Mock::given(method("GET"))
+                    .and(path("/advisories"))
+                    .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+                        {
+                            "ghsa_id": "GHSA-test",
+                            "html_url": "https://github.com/advisories/GHSA-test",
+                            "severity": "high",
+                            "summary": "vulnerable",
+                            "vulnerabilities": [
+                                {
+                                    "package": { "name": "o/r" },
+                                    "vulnerable_version_range": range,
+                                    "patched_versions": "1.1.0"
+                                }
+                            ]
+                        }
+                    ])))
+                    .mount(&server)
+                    .await;
+                let client = GitHubClient::with_base("t".into(), server.uri());
+
+                enrich_with_source_advisory(&mut report, dir.path(), &client)
+                    .await
+                    .unwrap();
+                let supported = range == Some("< 1.1.0");
+                assert_eq!(report.coverage_complete, supported);
+                assert_eq!(
+                    report.findings.iter().any(|f| f.id == "source.advisory"),
+                    supported
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn source_advisory_retains_findings_before_auth_failure() {
+            let dir = tempfile::TempDir::new().unwrap();
+            let mut report = base_report(dir.path());
+            std::fs::write(dir.path().join(".github/workflows/ci.yml"),
+                "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: o/r@v1.0.0\n      - uses: z/unavailable@v1.0.0\n").unwrap();
+            let server = MockServer::start().await;
+            Mock::given(method("GET")).and(path("/advisories"))
+                .and(wiremock::matchers::query_param("affects", "o/r@1.0.0"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                    "ghsa_id": "GHSA-example", "html_url": "https://example.com/advisory",
+                    "severity": "high", "summary": "example advisory",
+                    "vulnerabilities": [{"package": {"name": "o/r"}, "vulnerable_version_range": "< 1.1.0", "patched_versions": "1.1.0"}]
+                }])))
+                .mount(&server).await;
+            Mock::given(method("GET"))
+                .and(path("/advisories"))
+                .and(wiremock::matchers::query_param(
+                    "affects",
+                    "z/unavailable@1.0.0",
+                ))
+                .respond_with(ResponseTemplate::new(401))
+                .mount(&server)
+                .await;
+            let client = GitHubClient::with_base("t".into(), server.uri());
             enrich_with_source_advisory(&mut report, dir.path(), &client)
                 .await
                 .unwrap();
-            assert!(report.findings.iter().any(|f| f.id == "source.advisory"));
+            assert!(!report.coverage_complete);
+            assert_eq!(report.findings.len(), 1);
+            assert_eq!(report.findings[0].id, "source.advisory");
         }
 
         #[tokio::test]

--- a/src/update.rs
+++ b/src/update.rs
@@ -387,11 +387,11 @@ fn prerelease_newer(current: &str, candidate: &str) -> bool {
 /// The semver `+build` tail is stripped before the numeric split.
 fn parse_version(s: &str) -> (Vec<u64>, Option<String>) {
     let s = s.trim_start_matches('v');
+    let s = s.split_once('+').map_or(s, |(version, _)| version);
     let (head, pre) = match s.split_once('-') {
         Some((before, suffix)) => (before, Some(suffix.to_string())),
         None => (s, None),
     };
-    let head = head.split_once('+').map(|(b, _)| b).unwrap_or(head);
     let parts = head
         .split('.')
         .filter_map(|p| p.parse::<u64>().ok())
@@ -490,6 +490,9 @@ mod tests {
     fn build_metadata_stripped() {
         assert!(!is_newer("v1.2.3+build.5", "v1.2.3+build.9"));
         assert!(is_newer("v1.2.3+build.9", "v1.2.4+build.1"));
+        assert!(is_newer("v1.2.3-rc.1+build.9", "v1.2.3-rc.2+build.1"));
+        assert!(!is_newer("v1.2.3-rc.2+build.1", "v1.2.3-rc.1+build.9"));
+        assert!(!is_newer("v1.2.3-rc.1+build.1", "v1.2.3-rc.1+build.9"));
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -810,7 +810,7 @@ pub fn open_child_file_path(repo_root: &Path, rel: &Path) -> Result<Option<File>
         let file = match openat_file(
             &current,
             name,
-            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
         ) {
             Ok(file) => file,
             Err(e) if e == Errno::LOOP || path_is_symlink(&display_path) => {
@@ -861,9 +861,10 @@ fn open_workflow_file(file: &WorkflowFile) -> Result<File> {
     match openat_file(
         &*file.dir,
         file.name.as_os_str(),
-        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW | OFlags::NONBLOCK,
     ) {
-        Ok(handle) => Ok(handle),
+        Ok(handle) if handle.metadata()?.is_file() => Ok(handle),
+        Ok(_) => anyhow::bail!("workflow is not a regular file: {}", file.path.display()),
         Err(e) if e == Errno::LOOP => {
             Err(UnsafeWorkflowPath::symlinked_workflow_file(file.path()).into())
         }
@@ -1737,6 +1738,35 @@ jobs:
 
         let err = open_workflows_dirs(dir.path(), DEFAULT_FORGE_ROOTS).unwrap_err();
         assert!(err.to_string().contains("symlinked directory"));
+    }
+
+    #[test]
+    fn workflow_read_rechecks_regular_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join(".github/workflows/ci.yml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "name: example\n").unwrap();
+        let files = find_workflows(dir.path()).unwrap();
+        assert!(
+            open_workflow_file(&files[0])
+                .unwrap()
+                .metadata()
+                .unwrap()
+                .is_file()
+        );
+        std::fs::remove_file(&path).unwrap();
+        std::fs::create_dir(&path).unwrap();
+        assert!(
+            open_workflow_file(&files[0])
+                .unwrap_err()
+                .to_string()
+                .contains("not a regular file")
+        );
+        assert!(
+            open_child_file_path(dir.path(), Path::new(".github/workflows/ci.yml"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -39,24 +39,21 @@ jobs:
 ";
     let dir = common::repo_with_workflow("ci.yml", workflow);
 
-    common::pinprick_cmd()
-        .env("GITHUB_TOKEN", "dummy")
+    let output = common::pinprick_cmd()
+        .arg("--json")
         .arg("audit")
         .arg(dir.path())
-        .assert()
-        .code(2)
-        .stderr(predicate::str::contains("audited (bundled)").not())
-        .stderr(predicate::str::contains("Fetching actions/cache/restore"));
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["audited_bundled"], 0);
+    assert_eq!(report["external_actions_skipped"], 2);
+    assert_eq!(report["coverage_complete"], false);
 }
 
 #[test]
 fn no_audited_catalog_bypasses_bundled_verdict() {
-    // --no-audited-catalog must force a fresh scan even for a SHA the bundled
-    // catalog vouches for — that is what lets CI re-verify catalog entries
-    // against the current detection rules. The dummy token makes the fetch
-    // fail. The assertion is that a fetch was attempted instead of the bundled
-    // short-circuit and that the failed fresh scan cannot produce a clean
-    // verdict.
     let workflow = "\
 name: cache
 on: push
@@ -64,20 +61,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
 ";
     let dir = common::repo_with_workflow("ci.yml", workflow);
-
-    common::pinprick_cmd()
-        .env("GITHUB_TOKEN", "dummy")
-        .arg("audit")
-        .arg("--no-audited-catalog")
-        .arg(dir.path())
-        .assert()
-        .code(2)
-        .stderr(predicate::str::contains("audited (bundled)").not())
-        .stderr(predicate::str::contains("Fetching actions/cache/restore"))
-        .stdout(predicate::str::contains("Coverage incomplete"));
+    for bypass in [false, true] {
+        let mut command = common::pinprick_cmd();
+        command.arg("--json").arg("audit").arg(dir.path());
+        if bypass {
+            command.arg("--no-audited-catalog");
+        }
+        let output = command.output().unwrap();
+        let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(output.status.code(), Some(if bypass { 2 } else { 0 }));
+        assert_eq!(report["audited_bundled"], usize::from(!bypass));
+        assert_eq!(report["external_actions_skipped"], usize::from(bypass));
+        assert_eq!(report["coverage_complete"], !bypass);
+    }
 }
 
 #[test]

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -86,12 +86,41 @@ fn json_output() {
 }
 
 #[test]
-fn always_exits_zero() {
-    common::pinprick_cmd().arg("clean").assert().success();
+fn removal_error_exits_two_without_claiming_success() {
+    let xdg = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(xdg.path().join("pinprick")).unwrap();
+    let cache = xdg.path().join("pinprick/audited");
+    std::fs::write(&cache, "unexpected file").unwrap();
+    for json in [false, true] {
+        let mut command = common::pinprick_cmd();
+        command.env("XDG_CACHE_HOME", xdg.path());
+        if json {
+            command.arg("--json");
+        }
+        command
+            .arg("clean")
+            .assert()
+            .code(2)
+            .stdout(predicate::str::is_empty())
+            .stderr(predicate::str::contains("Could not remove audit cache"));
+    }
+    assert_eq!(std::fs::read_to_string(cache).unwrap(), "unexpected file");
 }
 
 #[test]
 fn idempotent() {
-    common::pinprick_cmd().arg("clean").assert().success();
-    common::pinprick_cmd().arg("clean").assert().success();
+    let xdg = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(xdg.path().join("pinprick/audited")).unwrap();
+    common::pinprick_cmd()
+        .env("XDG_CACHE_HOME", xdg.path())
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Cache cleaned."));
+    common::pinprick_cmd()
+        .env("XDG_CACHE_HOME", xdg.path())
+        .arg("clean")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Nothing to clean."));
 }


### PR DESCRIPTION
Clean audit verdicts could be reused after scans with custom trust exemptions, partial source lookups could lose findings, and required pin lookups could fail while other workflow edits were still written. Bind local cache verdicts to the scanner and default policy, require literal URL boundaries before applying component exemptions, retain findings and coverage details across enrichment failures, and refuse all pending pin writes when required resolution fails.

Canonical catalog maintenance now isolates configuration and requires a fresh, complete scan. The patch also rejects non-regular local inputs, reports cache-cleanup failures, fixes prerelease ordering and deterministic catalog embedding, and aligns command, scoring, configuration and detection documentation with the implemented contracts. Release tooling preserves breaking-change notes, verifies the notarized binary requirement, cleans temporary signing material, and prepares DCO sign-offs for bot-generated cask commits while preserving existing hooks.

Site deployment uses the lockfile-selected Wrangler CLI with the estate npm policy and strict installation controls. Dependency setup precedes restoration of the signed artifact, and the publish step directly invokes Wrangler without npm lifecycle hooks or rebuilding the site. This removes the additional Cloudflare Action and its separate tool-version pin while retaining build/sign/deploy isolation and step-scoped credentials. Workflow regressions also run for site-only changes.

The clean committed revision passed the enabled pre-push `just check` gate: 764 Rust unit tests, 109 integration tests, 11 Python workflow-tool tests, clippy, formatting, typos, dependency policy, workflow analysis, site build and deployment dry run. Regressions use bounded static analysis, local mock APIs and disposable workflow or Git fixtures. No fetched action code was executed, and live catalog refresh, hosted platform/release checks, signing services and deployment remain unverified. The fleet-managed npm checker is excluded and follows the separate fleet release and sync path.

AI disclosure: GPT-6 with source review, bounded static and local mock regressions, and the complete pre-push repository gate.
