### PR TITLE
ci: isolate coverage uploads and align workflow controls

### DIFF
--- a/.github/workflows/audit-actions.yml
+++ b/.github/workflows/audit-actions.yml
@@ -26,6 +26,7 @@ defaults:
 concurrency:
   group: audit-actions
   cancel-in-progress: false
+  queue: max
 
 permissions: {}
 
@@ -212,6 +213,7 @@ jobs:
         with:
           name: audited-actions
           path: audited-actions/
+          retention-days: 1
 
   update:
     name: Update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      run_codecov: ${{ steps.matrix.outputs.run_codecov }}
       run_zizmor: ${{ steps.matrix.outputs.run_zizmor }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,8 +48,9 @@ jobs:
           # Push to main: run lint to warm the cache, and Coverage so
           # Codecov has a baseline for PR comparisons.
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            echo 'matrix=[{"name":"Lint","check":"lint","runner":"ubuntu-24.04"},{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}]' >> "${GITHUB_OUTPUT}"
+            echo 'matrix=[{"name":"Lint","check":"lint","runner":"ubuntu-24.04"},{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04"}]' >> "${GITHUB_OUTPUT}"
             echo "run_zizmor=false" >> "${GITHUB_OUTPUT}"
+            echo "run_codecov=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -76,7 +78,7 @@ jobs:
             add_check '{"name":"Test (Linux)","check":"test","runner":"ubuntu-24.04"}'
             add_check '{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-24.04-arm"}'
             add_check '{"name":"Test (macOS)","check":"test","runner":"macos-26"}'
-            add_check '{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}'
+            add_check '{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04"}'
             add_check '{"name":"MSRV","check":"msrv","runner":"ubuntu-24.04"}'
           fi
 
@@ -116,12 +118,13 @@ jobs:
             add_check '{"name":"Test (Linux)","check":"test","runner":"ubuntu-24.04"}'
             add_check '{"name":"Test (Linux ARM)","check":"test","runner":"ubuntu-24.04-arm"}'
             add_check '{"name":"Test (macOS)","check":"test","runner":"macos-26"}'
-            add_check '{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","environment":"codecov"}'
+            add_check '{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04"}'
             add_check '{"name":"MSRV","check":"msrv","runner":"ubuntu-24.04"}'
           fi
 
           echo "matrix=${MATRIX}" >> "${GITHUB_OUTPUT}"
           echo "run_zizmor=${RUN_ZIZMOR}" >> "${GITHUB_OUTPUT}"
+          echo "run_codecov=$(jq -r 'any(.[]; .check == "coverage")' <<<"${MATRIX}")" >> "${GITHUB_OUTPUT}"
 
   commits:
     name: Conventional Commits
@@ -137,9 +140,6 @@ jobs:
     if: ${{ needs.generate-matrix.outputs.matrix != '[]' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
-    environment:
-      name: ${{ matrix.environment }}
-      deployment: false
     permissions:
       contents: read
     strategy:
@@ -274,31 +274,31 @@ jobs:
         run: cargo install cargo-llvm-cov --locked --version 0.9.0
 
       - name: Run tests with coverage
+        id: coverage-tests
         if: matrix.check == 'coverage'
         run: cargo llvm-cov nextest --profile ci --lcov --output-path lcov.info
 
-      - name: Install verified Codecov CLI
-        if: ${{ !cancelled() && matrix.check == 'coverage' }}
-        run: |
-          curl --fail --location --show-error --silent \
-            --output "${RUNNER_TEMP}/codecov" \
-            "https://cli.codecov.io/v11.3.1/linux/codecov"
-          echo "ca1d64196d2d34771084afe76ea657d581bf628e31d993ff8e52ea09cc88a56d  ${RUNNER_TEMP}/codecov" | sha256sum --check --strict
-          chmod 0755 "${RUNNER_TEMP}/codecov"
-
-      - name: Upload coverage to Codecov
+      - name: Normalize report paths
         if: ${{ !cancelled() && matrix.check == 'coverage' }}
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          TEST_RESULT: ${{ steps.coverage-tests.outcome }}
         run: |
-          "${RUNNER_TEMP}/codecov" upload-process --disable-search --file lcov.info
+          reports=(--junit target/nextest/ci/junit.xml)
+          if [[ -f lcov.info || "${TEST_RESULT}" != failure ]]; then
+            reports+=(--coverage lcov.info)
+          fi
+          python3 -I scripts/upload-codecov.py --prepare "${reports[@]}"
 
-      - name: Upload test results to Codecov
+      - name: Save coverage reports
         if: ${{ !cancelled() && matrix.check == 'coverage' }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          "${RUNNER_TEMP}/codecov" upload-process --disable-search --file target/nextest/ci/junit.xml --report-type test_results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-reports
+          path: |
+            lcov.info
+            target/nextest/ci/junit.xml
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Save coverage tools cache
         if: matrix.check == 'coverage' && github.event_name == 'push' && steps.cov-tools-cache.outputs.cache-hit != 'true'
@@ -384,6 +384,42 @@ jobs:
           fi
           exit "${FAILED}"
 
+  codecov:
+    name: Codecov
+    needs: [generate-matrix, check]
+    # Forks still run coverage tests; Codecov OIDC accepts same-repository runs.
+    if: ${{ !cancelled() && needs.generate-matrix.outputs.run_codecov == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # Authenticate report uploads to Codecov with GitHub OIDC.
+    steps:
+      - name: Check out the trusted uploader
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          sparse-checkout: /scripts/upload-codecov.py
+          sparse-checkout-cone-mode: false
+          path: codecov-uploader
+
+      - name: Download coverage-reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-reports
+          path: reports
+
+      - name: Upload reports with verified Codecov CLI
+        env:
+          TEST_RESULT: ${{ needs.check.result }}
+        run: |
+          reports=(--junit reports/target/nextest/ci/junit.xml)
+          if [[ -f reports/lcov.info || "${TEST_RESULT}" != failure ]]; then
+            reports+=(--coverage reports/lcov.info)
+          fi
+          python3 -I codecov-uploader/scripts/upload-codecov.py "${reports[@]}"
+
   zizmor:
     name: zizmor
     needs: generate-matrix
@@ -395,13 +431,16 @@ jobs:
 
   conclusion:
     name: conclusion
-    needs: [generate-matrix, commits, check, zizmor]
+    needs: [generate-matrix, commits, check, zizmor, codecov]
     runs-on: ubuntu-slim
     timeout-minutes: 15
     if: always()
     steps:
       - name: Result
         env:
+          CODECOV_ELIGIBLE: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
+          RUN_CODECOV: ${{ needs.generate-matrix.outputs.run_codecov }}
+          CODECOV_RESULT: ${{ needs.codecov.result }}
           COMMITS_RESULT: ${{ needs.commits.result }}
           CHECK_RESULT: ${{ needs.check.result }}
           ZIZMOR_RESULT: ${{ needs.zizmor.result }}
@@ -425,4 +464,9 @@ jobs:
             test "${ZIZMOR_RESULT}" = "success"
           else
             test "${ZIZMOR_RESULT}" = "skipped"
+          fi
+          if [[ "${RUN_CODECOV}" == "true" && "${CODECOV_ELIGIBLE}" == "true" ]]; then
+            test "${CODECOV_RESULT}" = "success"
+          else
+            test "${CODECOV_RESULT}" = "skipped"
           fi

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -9,6 +9,7 @@ on:
       - "catalog-minisign.pub"
       - "Cargo.toml"
       - ".github/workflows/deploy-site.yml"
+      - "scripts/check-npm-install-policy.mjs"
   schedule:
     - cron: "17 6 * * 1"
   workflow_dispatch:
@@ -20,7 +21,7 @@ defaults:
 permissions: {}
 
 concurrency:
-  group: deploy-site
+  group: ${{ github.ref == 'refs/heads/main' && 'deploy-site' || format('rejected-deploy-{0}', github.run_id) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ defaults:
 concurrency:
   group: release
   cancel-in-progress: false
+  queue: max
 
 permissions: {}
 
@@ -260,6 +261,8 @@ jobs:
         with:
           name: ${{ env.ARTIFACT }}
           path: "${{ env.ARTIFACT }}.tar.gz"
+          if-no-files-found: error
+          retention-days: 7
 
   attest:
     name: Attest (${{ matrix.target }})

--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ Findings followed within 3 lines by checksum or signature verification (`sha256s
 
 | Code | Meaning                                                                                   |
 | ---- | ----------------------------------------------------------------------------------------- |
-| 0    | Clean — no findings, no pending updates                                                   |
-| 1    | Findings present (audit), score deductions present, or updates available (update dry-run) |
+| 0    | Clean result or successful write                                                   |
+| 1    | Audit findings, score deductions, pending or unpinnable references (pin dry-run), or available updates (update dry-run) |
 | 2    | Error, or incomplete audit/pin/update coverage; verified updates may still apply with `update --write` |
 
 ## Building

--- a/justfile
+++ b/justfile
@@ -183,7 +183,7 @@ check:
         skip cargo-deny cargo-deny cargo-deny
     fi
     if command -v zizmor &>/dev/null; then
-        run zizmor --persona auditor .github/workflows/
+        run zizmor --strict-collection --persona auditor .github/workflows/
     else
         skip audit zizmor zizmor
     fi

--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -23,6 +23,25 @@ def workflow_step(workflow: str, name: str) -> str:
 
 
 class ReleaseToolsTests(unittest.TestCase):
+    def test_distinct_release_and_catalog_requests_are_retained(self):
+        for name, group in [('release.yml', 'release'), ('audit-actions.yml', 'audit-actions')]:
+            workflow = (ROOT / '.github/workflows' / name).read_text()
+            concurrency = workflow.split('concurrency:\n', 1)[1].split('\n\n', 1)[0]
+            self.assertEqual(dict(line.strip().split(': ', 1) for line in concurrency.splitlines()), {
+                'group': group, 'cancel-in-progress': 'false', 'queue': 'max',
+            })
+
+    def test_rejected_site_dispatch_cannot_cancel_main_deployment(self):
+        workflow = (ROOT / '.github/workflows/deploy-site.yml').read_text()
+        self.assertIn(
+            "group: ${{ github.ref == 'refs/heads/main' && 'deploy-site' "
+            "|| format('rejected-deploy-{0}', github.run_id) }}",
+            workflow,
+        )
+        push = workflow.split('  schedule:', 1)[0]
+        for path in ['.github/workflows/deploy-site.yml', 'scripts/check-npm-install-policy.mjs']:
+            self.assertIn(f'      - "{path}"', push)
+
     def test_site_deploy_preserves_signed_output_and_uses_locked_tool(self):
         deploy = (ROOT / '.github/workflows/deploy-site.yml').read_text().split('\n  deploy:\n', 1)[1]
         setup, publish = deploy.split('      - name: Deploy signed site to Cloudflare Workers\n', 1)


### PR DESCRIPTION
Coverage tests now produce normalized report artifacts without Codecov credentials; a separate OIDC job uploads them using the fleet's verified CLI helper from trusted base source. The conclusion job enforces upload eligibility, release and catalog requests remain queued, and rejected deployment refs cannot cancel the main deployment. Artifact retention, strict local workflow collection, and documented exit codes are aligned with the existing contracts.

Merge prerequisite: merge [fleet hub #175](https://github.com/starhaven-io/.github/pull/175), publish the fleet release, and merge the bot's generated uploader sync into this repository's main branch first, then refresh this branch and rerun CI. The helper remains fleet-owned and is absent from this source-only PR; coverage is expected to fail until that prerequisite lands.

The source-only commit passed the enabled pre-push `just check` gate, including Rust and local workflow regression tests, clippy, formatting, dependency policy, strict workflow audit, site build and Wrangler dry-run. Hosted coverage upload and deployment remain unverified by these local checks.

AI disclosure: GPT-6 Astra with source review, local regression tests and the enabled pre-push repository gate.
