### PR TITLE
fix(scripts): canonicalize the cask DCO test fixture root

### DIFF
--- a/scripts/test_release_tools.py
+++ b/scripts/test_release_tools.py
@@ -236,7 +236,7 @@ class CaskDCOTests(unittest.TestCase):
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp.cleanup)
-        self.root = Path(self.temp.name)
+        self.root = Path(self.temp.name).resolve()
         self.tap = self.root / "tap checkout"
         self.runner = self.root / "runner temp"
         self.bin = self.root / "bin"


### PR DESCRIPTION
`CaskDCOTests` built its fixture from `tempfile.TemporaryDirectory()` without resolving it, so `test_cleanup_preserves_a_substituted_link` compared a lexical temp path against the physical one the tooling records. `release.yml` derives `TAP_ROOT` with `pwd -P` and resolves `HOOKS_DIR` before its containment check, so the production path is canonical by design and the fixture was the side that needed to match.

The assertion fails wherever the temporary directory is reached through a symlink, which on macOS includes the default `/var/folders` root and `/tmp`. Script tests run only in the Linux `lint` and `site` matrix entries, where `/tmp` is a real directory, so CI could not observe it. All 46 script tests now pass under `/var/folders`, `/tmp` and `/private/tmp`.

AI disclosure: Claude Opus 5 with the full `just check` gate and the script suite rerun under three temporary-directory spellings.