### PR TITLE
chore: release 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps `version` in `Cargo.toml` and the `pinprick` entry in `Cargo.lock` to 0.24.0 so the Release workflow can tag and publish it. No source changes; `Cargo.lock` moves with the manifest.

Minor rather than patch: two changes since 0.23.1 alter audit outcomes. #548 makes every command fail closed on incomplete coverage, so `audit` exits 2 on incomplete coverage and `update` exits 2 when an action could not be checked, restricts checksum suppression to verification material that was not fetched at runtime, and narrows a root catalog verdict so it no longer covers subpath actions. #565 stamps bundled, signed-remote and local-cache verdicts with a detection-rules version and holds them inert unless it matches the running scanner, so a verdict earned under older rules stops vouching for source the current rules would flag.

The catalog shrinks accordingly. #548 removes three entries whose runtime downloads the old scanner never inspected, and #565 removes 50 more across 14 action families, leaving 359 entries stamped `rules_version: 1`. Also included are #557, which preserves audit trust and findings across incomplete scans, #544, which aligns the site's declared HSTS max-age with the edge baseline, #566, which canonicalizes a release-tooling test fixture, and 33 dependency updates that reach the binary through the lockfile.

Already-released clients ignore `rules_version`, so the binding in #565 takes full effect only for clients running 0.24.0 or later.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit and the built binary confirmed to report `pinprick 0.24.0`.