### PR TITLE
ci: stop writing Python bytecode during script tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Test workflow tooling
         if: matrix.check == 'lint' || matrix.check == 'site'
-        run: PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
+        run: python3 -B -m unittest discover -s scripts -p 'test_*.py'
 
       - name: Restore cargo build cache
         id: cargo-build-cache

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test:
 
 # Check release tooling using local stubs
 script-tests:
-    PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
+    python3 -B -m unittest discover -s scripts -p 'test_*.py'
 
 # Lint
 
@@ -193,7 +193,7 @@ check:
         skip audit zizmor zizmor
     fi
     run cargo test --locked
-    run env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts -p 'test_*.py'
+    run python3 -B -m unittest discover -s scripts -p 'test_*.py'
     echo "--- site-format-check ---"
     (cd site && npm run format:check) || failed=1
     echo "--- site-build ---"


### PR DESCRIPTION
The release-tooling suite was invoked with a `PYTHONDONTWRITEBYTECODE=1` prefix in the justfile and in the CI step. `python3 -B` carries the flag on the interpreter invocation instead of the caller's environment, so the spelling is identical in both places and does not depend on `env` passing the assignment through.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit.