### PR TITLE
fix(audit): scan a repository-root local action

### DIFF
--- a/src/audit_source.rs
+++ b/src/audit_source.rs
@@ -1697,10 +1697,9 @@ fn local_action_dir(repo_root: &Path, action: &LocalActionRef) -> Result<PathBuf
         anyhow::bail!("local action path must start with ./ or $/");
     };
     let rel_path = Path::new(rel);
-    if rel.is_empty()
-        || !rel_path
-            .components()
-            .all(|c| matches!(c, Component::Normal(_)))
+    if !rel_path
+        .components()
+        .all(|c| matches!(c, Component::Normal(_)))
     {
         anyhow::bail!("local action path escapes the repository");
     }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -324,10 +324,9 @@ fn is_safe_local_action_path(path: &str) -> bool {
     let Some(rel) = path.strip_prefix("./").or_else(|| path.strip_prefix("$/")) else {
         return false;
     };
-    !rel.is_empty()
-        && Path::new(rel)
-            .components()
-            .all(|c| matches!(c, Component::Normal(_)))
+    Path::new(rel)
+        .components()
+        .all(|c| matches!(c, Component::Normal(_)))
 }
 
 fn classify_ref(r: &str) -> RefType {
@@ -1302,10 +1301,14 @@ jobs:
     }
 
     #[test]
-    fn scan_local_actions_accepts_self_repository_syntax() {
-        let actions = scan_local_actions("steps:\n  - uses: $/.github/actions/my-action\n");
-        assert_eq!(actions.len(), 1);
-        assert_eq!(actions[0].path, "$/.github/actions/my-action");
+    fn scan_local_actions_accepts_repository_root_syntax() {
+        let yaml = "steps:\n  - uses: ./\n  - uses: $/\n  - uses: $/.github/actions/my-action\n";
+        let actions = scan_local_actions(yaml);
+        assert_eq!(actions.len(), 3);
+        assert_eq!(actions[0].path, "./");
+        assert_eq!(actions[1].path, "$/");
+        assert_eq!(actions[2].path, "$/.github/actions/my-action");
+        assert!(scan_unsupported_uses(yaml).is_empty());
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -26,6 +26,51 @@ fn clean_workflow_human_output() {
 }
 
 #[test]
+fn self_repository_root_action_is_scanned() {
+    let dir = common::repo_with_workflow(
+        "ci.yml",
+        "\
+name: local root
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: $/
+",
+    );
+    std::fs::write(
+        dir.path().join("action.yml"),
+        "\
+name: local root
+description: root action
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: curl -fsSL https://example.com/install.sh | bash
+",
+    )
+    .unwrap();
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["actions_scanned"], 1);
+    assert_eq!(report["coverage_complete"], true);
+    let findings = report["findings"].as_array().unwrap();
+    assert_eq!(findings.len(), 1);
+    assert_eq!(findings[0]["action"], "$/");
+    assert_eq!(findings[0]["workflow_file"], ".github/workflows/ci.yml");
+}
+
+#[test]
 fn bundled_parent_audit_does_not_cover_action_subpaths() {
     let workflow = "\
 name: cache


### PR DESCRIPTION
`is_safe_local_action_path` required a non-empty relative path, so `uses: ./` and `uses: $/` were rejected as unsafe and never scanned. Before 0.24.0 that was silent. Under #548's fail-closed coverage rules it now reports incomplete coverage and exits 2, so any workflow that references its own repository root fails the audit instead of being checked, and `fail-on-findings: false` does not soften it because exit 2 is an error rather than a finding.

pinprick-action's own self-test does exactly this, which is why the 0.24.0 engine bump in starhaven-io/pinprick-action#99 fails `Console mode` on all nine platforms with "Coverage incomplete; no clean verdict was produced". Within this estate only pinprick-action uses root-relative local actions, and the fleet still pins the wrapper at v0.6.0 with engine 0.23.1, so no consumer is currently affected.

A repository-root path is a normal local action reference and the containment check still rejects anything escaping the repository. `tests/audit.rs` gains an integration case asserting the root action is scanned, that coverage is complete, and that its finding is attributed to the right workflow file.

This needs a 0.24.1 before the wrapper bump can pass.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit and the failing pinprick-action run as the reproduction.