### PR TITLE
chore: release 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps `version` in `Cargo.toml` and the `pinprick` entry in `Cargo.lock` to 0.24.1 so the Release workflow can tag and publish it. No source changes; `Cargo.lock` moves with the manifest.

Patch: #572 restores scanning of a repository-root local action. 0.24.0 rejected `uses: ./` and `uses: $/` as unsafe paths, and #548's fail-closed coverage rules turn that into incomplete coverage and exit 2, so any workflow referencing its own repository root fails the audit rather than being checked. `fail-on-findings: false` does not soften it, because exit 2 is an error rather than a finding. pinprick-action's self-test does exactly this, which is why the 0.24.0 wrapper bump failed `Console mode` on all nine platforms.

Also included: #571, which merges the Homebrew cask bump against validated checks instead of arming auto-merge, so this release is the first to exercise that path.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit and the built binary confirmed to report `pinprick 0.24.1`.