### PR TITLE
fix(audit): stop the audit treating a local workflow call as an action

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -257,6 +257,17 @@ pub async fn run(
 
         let mut actions = workflow::scan_content(&content);
         for action in workflow::scan_local_actions(&content) {
+            // A reference that resolves to a real workflow file is a
+            // reusable-workflow call, not an action directory, and every
+            // workflow under a forge root is already enumerated and scanned in
+            // its own right. Anything that does not resolve stays an action.
+            if workflow::resolves_to_workflow_file(
+                repo_root,
+                &action.path,
+                workflow::DEFAULT_FORGE_ROOTS,
+            ) {
+                continue;
+            }
             let key = format!("local:{}", action.path);
             if !scanned_actions.insert(key.clone()) {
                 continue;

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use rustix::fs::{self as rfs, AtFlags, Dir, Mode, OFlags};
 use rustix::io::Errno;
+use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::os::unix::ffi::OsStrExt;
@@ -318,6 +319,39 @@ pub fn parse_local_uses_line(line: &str, line_number: usize) -> Option<LocalActi
             line_number,
         })
     })
+}
+
+/// Whether a local `uses:` value resolves to a real reusable-workflow file.
+///
+/// GitHub distinguishes a workflow call from an action structurally, not by
+/// filename, and YAML node properties such as anchors put that structure out of
+/// reach of a line scanner. So this asks the filesystem instead: the reference
+/// is a workflow call only when it names an existing regular file directly
+/// under a forge `workflows/` directory. A directory (including one named
+/// `check.yml`), a missing path, a symlink, or any error answers `false`, so an
+/// unresolved reference stays an action and is scanned or reported unscannable.
+/// Skipping is never the fallback.
+pub fn resolves_to_workflow_file(repo_root: &Path, path: &str, forge_roots: &[&str]) -> bool {
+    let Some(rel) = path.strip_prefix("./").or_else(|| path.strip_prefix("$/")) else {
+        return false;
+    };
+    let rel_path = Path::new(rel);
+    let components: Vec<_> = rel_path.components().collect();
+    let [
+        Component::Normal(forge),
+        Component::Normal(workflows),
+        Component::Normal(_),
+    ] = components.as_slice()
+    else {
+        return false;
+    };
+    if !forge_roots.iter().any(|root| *forge == OsStr::new(root)) {
+        return false;
+    }
+    if *workflows != OsStr::new("workflows") {
+        return false;
+    }
+    matches!(open_child_file_path(repo_root, rel_path), Ok(Some(_)))
 }
 
 fn is_safe_local_action_path(path: &str) -> bool {
@@ -1309,6 +1343,83 @@ jobs:
         assert_eq!(actions[1].path, "$/");
         assert_eq!(actions[2].path, "$/.github/actions/my-action");
         assert!(scan_unsupported_uses(yaml).is_empty());
+    }
+
+    #[test]
+    fn resolver_accepts_only_real_workflow_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".github/workflows")).unwrap();
+        std::fs::write(
+            root.join(".github/workflows/child.yml"),
+            "on: workflow_call\n",
+        )
+        .unwrap();
+        // An action directory named like a workflow file is not a workflow.
+        std::fs::create_dir_all(root.join(".github/actions/check.yml")).unwrap();
+        // Nor is a directory sitting inside the workflows directory.
+        std::fs::create_dir_all(root.join(".github/workflows/decoy.yml")).unwrap();
+
+        let roots = DEFAULT_FORGE_ROOTS;
+        assert!(resolves_to_workflow_file(
+            root,
+            "$/.github/workflows/child.yml",
+            roots
+        ));
+        assert!(resolves_to_workflow_file(
+            root,
+            "./.github/workflows/child.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "./.github/actions/check.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "./.github/workflows/decoy.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "./.github/workflows/missing.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "./.github/workflows/nested/child.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "./elsewhere/child.yml",
+            roots
+        ));
+        assert!(!resolves_to_workflow_file(
+            root,
+            "external/action@v1",
+            roots
+        ));
+    }
+
+    #[test]
+    fn resolver_refuses_a_symlinked_workflow() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join(".github/workflows")).unwrap();
+        std::fs::write(root.join("real.yml"), "on: workflow_call\n").unwrap();
+        std::os::unix::fs::symlink(
+            root.join("real.yml"),
+            root.join(".github/workflows/link.yml"),
+        )
+        .unwrap();
+        // A symlink errors out, and an error must never mean "skip".
+        assert!(!resolves_to_workflow_file(
+            root,
+            "$/.github/workflows/link.yml",
+            DEFAULT_FORGE_ROOTS
+        ));
     }
 
     #[test]

--- a/tests/audit.rs
+++ b/tests/audit.rs
@@ -71,6 +71,139 @@ runs:
 }
 
 #[test]
+fn local_reusable_workflow_call_does_not_break_coverage() {
+    let dir = common::repo_with_workflow(
+        "ci.yml",
+        "\
+name: caller
+on: pull_request
+jobs:
+  commits:
+    uses: $/.github/workflows/reusable-commits.yml
+",
+    );
+    std::fs::write(
+        dir.path().join(".github/workflows/reusable-commits.yml"),
+        "\
+name: reusable commits
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+",
+    )
+    .unwrap();
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["coverage_complete"], true);
+    assert!(report["findings"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn yaml_suffixed_local_action_directory_is_still_scanned() {
+    let dir = common::repo_with_workflow(
+        "ci.yml",
+        "\
+name: caller
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/check.yml
+",
+    );
+    let action_dir = dir.path().join(".github/actions/check.yml");
+    std::fs::create_dir_all(&action_dir).unwrap();
+    std::fs::write(
+        action_dir.join("action.yml"),
+        "\
+name: check
+description: an action directory named like a workflow file
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: curl -fsSL https://example.com/install.sh | bash
+",
+    )
+    .unwrap();
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["actions_scanned"], 1);
+    assert_eq!(report["coverage_complete"], true);
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
+fn anchored_steps_do_not_hide_a_local_action() {
+    // YAML node properties put step context out of reach of a line scanner, so
+    // classification must not depend on recognizing `steps:` at all.
+    let dir = common::repo_with_workflow(
+        "ci.yml",
+        "\
+name: caller
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: &audit_steps
+      - uses: ./.github/actions/check.yml
+  rerun:
+    runs-on: ubuntu-latest
+    steps: *audit_steps
+",
+    );
+    let action_dir = dir.path().join(".github/actions/check.yml");
+    std::fs::create_dir_all(&action_dir).unwrap();
+    std::fs::write(
+        action_dir.join("action.yml"),
+        "\
+name: check
+description: an action directory named like a workflow file
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: curl -fsSL https://example.com/install.sh | bash
+",
+    )
+    .unwrap();
+
+    let output = common::pinprick_cmd()
+        .arg("--json")
+        .arg("audit")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["actions_scanned"], 1);
+    assert_eq!(report["coverage_complete"], true);
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    assert_eq!(output.status.code(), Some(1));
+}
+
+#[test]
 fn bundled_parent_audit_does_not_cover_action_subpaths() {
     let workflow = "\
 name: cache


### PR DESCRIPTION
A job-level `uses:` naming a local workflow is a reusable-workflow call, but auditing a checkout treated it as an action and tried to open the file as an action directory. That failed, and under #548's fail-closed coverage rules it became incomplete coverage and exit 2, so a repository calling its own reusable workflows could not pass its own audit. The hub hits this on three calls in `conclusion.yml`, which currently blocks its merge-critical audit.

The reference is resolved against the filesystem rather than classified from the YAML text, because two cheaper signals are both wrong. A filename suffix cannot decide it: an action directory may legitimately be named `check.yml`, and a suffix test skips it while reporting a clean scan. A line scanner reading `steps:` context cannot decide it either: YAML node properties such as anchors (`steps: &audit_steps`) put that structure out of reach, with the same false-clean result.

So a reference is a workflow call only when it names an existing regular file directly under a forge `workflows/` directory, opened `O_NOFOLLOW`. A directory, a missing path, a symlink, a nested path, or any error leaves it an action, so an unresolved reference is still scanned or reported unscannable. Skipping requires a positive filesystem identity; it is never the fallback.

The skip is applied in `audit` rather than in the shared scanner. Remote reusable-workflow analysis still collects local children so it can bind them to the remote repository, and `reusable_workflow_local_children_are_repository_bound` covers that. Every workflow under a forge root is already enumerated and scanned on its own, so nothing stops being covered.

Coverage added: the anchored-steps fixture, a `check.yml` action directory under plain steps, and resolver units for a decoy directory inside `workflows/`, a missing file, a nested path, a non-forge path, and a symlinked workflow.

`score` collects local actions separately, at three call sites, and still reports these calls as incomplete coverage. That is unchanged here and needs its own fix.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit, and base-versus-head comparison on both counterexamples.