### PR TITLE
chore: release 0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"


### PR DESCRIPTION
Bumps `version` in `Cargo.toml` and the `pinprick` entry in `Cargo.lock` to 0.24.2 so the Release workflow can tag and publish it. No source changes; `Cargo.lock` moves with the manifest.

Patch: #579 stops the audit treating a local reusable-workflow call as an action. 0.24.0 and 0.24.1 opened the referenced workflow file as an action directory, which failed, and under #548's fail-closed coverage rules that became incomplete coverage and exit 2. Any repository calling its own reusable workflows could not pass its own audit; the fleet hub hits it on three calls in `conclusion.yml`.

A reference is now treated as a workflow call only when it resolves to an existing regular file directly under a forge `workflows/` directory, opened `O_NOFOLLOW`. Directories, missing paths, symlinks, nested paths and errors all leave it an action, so skipping requires a positive filesystem identity rather than being the fallback. `score` collects local actions separately and is unaffected by this release.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit and the built binary confirmed to report `pinprick 0.24.2`.