### PR TITLE
ci: gate the conclusion aggregate on the pinprick audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       run_codecov: ${{ steps.matrix.outputs.run_codecov }}
+      run_pinprick: ${{ steps.matrix.outputs.run_pinprick }}
       run_zizmor: ${{ steps.matrix.outputs.run_zizmor }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,6 +50,7 @@ jobs:
           # Codecov has a baseline for PR comparisons.
           if [[ "${EVENT_NAME}" == "push" ]]; then
             echo 'matrix=[{"name":"Lint","check":"lint","runner":"ubuntu-24.04","fetch_depth":1},{"name":"Coverage","check":"coverage","runner":"ubuntu-24.04","fetch_depth":1}]' >> "${GITHUB_OUTPUT}"
+            echo "run_pinprick=false" >> "${GITHUB_OUTPUT}"
             echo "run_zizmor=false" >> "${GITHUB_OUTPUT}"
             echo "run_codecov=true" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -64,6 +66,7 @@ jobs:
             fi
           }
           RUN_ZIZMOR=false
+          RUN_PINPRICK=false
 
           # `edited` (title/body/base) also runs the full path-derived matrix. The
           # aggregate "conclusion" job is the only required status check, so it must
@@ -109,6 +112,9 @@ jobs:
           if echo "${CHANGED}" | grep -qE '^\.github/workflows/'; then
             RUN_ZIZMOR=true
           fi
+          if echo "${CHANGED}" | grep -qE '^src/|^Cargo\.(toml|lock)$|^rust-toolchain\.toml$|^\.github/workflows/'; then
+            RUN_PINPRICK=true
+          fi
 
           # Fail safe for unclassified project inputs. Documentation-only
           # changes may skip the expensive matrix; every other unknown path
@@ -123,6 +129,7 @@ jobs:
           fi
 
           echo "matrix=${MATRIX}" >> "${GITHUB_OUTPUT}"
+          echo "run_pinprick=${RUN_PINPRICK}" >> "${GITHUB_OUTPUT}"
           echo "run_zizmor=${RUN_ZIZMOR}" >> "${GITHUB_OUTPUT}"
           echo "run_codecov=$(jq -r 'any(.[]; .check == "coverage")' <<<"${MATRIX}")" >> "${GITHUB_OUTPUT}"
 
@@ -468,9 +475,24 @@ jobs:
       security-events: write # required for zizmor SARIF upload
     uses: starhaven-io/.github/.github/workflows/reusable-zizmor.yml@e748ec16bd1207114a766d1d761a6743a6e3bf3a # v2026.09.09.4
 
+  pinprick:
+    name: pinprick
+    needs: generate-matrix
+    if: needs.generate-matrix.outputs.run_pinprick == 'true'
+    permissions:
+      contents: read
+      security-events: write # required for SARIF upload on same-repository changes
+    # Temporary trade-off: gate with the released engine until the fleet-pinned
+    # scanner can follow a local reusable-workflow call. Restore PR-time
+    # build-from-source dogfooding when that support is delivered.
+    uses: starhaven-io/.github/.github/workflows/reusable-pinprick-audit.yml@e748ec16bd1207114a766d1d761a6743a6e3bf3a # v2026.09.09.4
+    with:
+      advanced-security: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      fail-on-findings: true
+
   conclusion:
     name: conclusion
-    needs: [generate-matrix, commits, check, zizmor, codecov]
+    needs: [generate-matrix, commits, check, zizmor, pinprick, codecov]
     runs-on: ubuntu-slim
     timeout-minutes: 15
     if: always()
@@ -483,29 +505,41 @@ jobs:
           COMMITS_RESULT: ${{ needs.commits.result }}
           CHECK_RESULT: ${{ needs.check.result }}
           ZIZMOR_RESULT: ${{ needs.zizmor.result }}
+          PINPRICK_RESULT: ${{ needs.pinprick.result }}
           MATRIX: ${{ needs.generate-matrix.outputs.matrix }}
           RUN_ZIZMOR: ${{ needs.generate-matrix.outputs.run_zizmor }}
+          RUN_PINPRICK: ${{ needs.generate-matrix.outputs.run_pinprick }}
           EVENT_NAME: ${{ github.event_name }}
           MATRIX_RESULT: ${{ needs.generate-matrix.result }}
         run: |
+          require_result() {
+            local name="$1" result="$2" required="$3"
+            case "${required}" in
+              true) test "${result}" = success ;;
+              false) test "${result}" = skipped ;;
+              *) echo "::error::Invalid routing decision for ${name}."; return 1 ;;
+            esac || { echo "::error::${name} ended with ${result:-no result}."; return 1; }
+          }
+
           test "${MATRIX_RESULT}" = "success"
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            test "${COMMITS_RESULT}" = "success"
-          else
-            test "${COMMITS_RESULT}" = "skipped"
-          fi
+          case "${EVENT_NAME}" in
+            pull_request) require_result commits "${COMMITS_RESULT}" true ;;
+            push) require_result commits "${COMMITS_RESULT}" false ;;
+            *) echo "::error::Unexpected CI event."; exit 1 ;;
+          esac
           if [[ "${MATRIX}" == "[]" ]]; then
-            test "${CHECK_RESULT}" = "skipped"
+            require_result check "${CHECK_RESULT}" false
+          elif [[ -n "${MATRIX}" ]]; then
+            require_result check "${CHECK_RESULT}" true
           else
-            test "${CHECK_RESULT}" = "success"
+            echo "::error::The check matrix could not be determined."
+            exit 1
           fi
-          if [[ "${RUN_ZIZMOR}" == "true" ]]; then
-            test "${ZIZMOR_RESULT}" = "success"
-          else
-            test "${ZIZMOR_RESULT}" = "skipped"
-          fi
-          if [[ "${RUN_CODECOV}" == "true" && "${CODECOV_ELIGIBLE}" == "true" ]]; then
-            test "${CODECOV_RESULT}" = "success"
-          else
-            test "${CODECOV_RESULT}" = "skipped"
-          fi
+          require_result zizmor "${ZIZMOR_RESULT}" "${RUN_ZIZMOR}"
+          require_result pinprick "${PINPRICK_RESULT}" "${RUN_PINPRICK}"
+          case "${RUN_CODECOV}:${CODECOV_ELIGIBLE}" in
+            true:true) CODECOV_REQUIRED=true ;;
+            true:false | false:true | false:false) CODECOV_REQUIRED=false ;;
+            *) echo "::error::Invalid Codecov routing decision."; exit 1 ;;
+          esac
+          require_result codecov "${CODECOV_RESULT}" "${CODECOV_REQUIRED}"

--- a/scripts/test_ci_conclusion.py
+++ b/scripts/test_ci_conclusion.py
@@ -1,0 +1,90 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+AUDIT_WORKFLOW = ROOT / ".github" / "workflows" / "pinprick-audit.yml"
+
+
+def workflow_run_block(step_name: str) -> str:
+    source = CI_WORKFLOW.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\n(?:^        .*\n)*?^        run: \|\n(?P<run>(?:^          .*\n|^\n)+)",
+        source,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"missing workflow step: {step_name}")
+    return textwrap.dedent(match.group("run"))
+
+
+class CIConclusionTests(unittest.TestCase):
+    def setUp(self):
+        self.script = workflow_run_block("Result")
+        self.environment = {
+            "GITHUB_EVENT_NAME": "pull_request",
+            "MATRIX_RESULT": "success",
+            "COMMITS_RESULT": "success",
+            "CHECK_RESULT": "success",
+            "ZIZMOR_RESULT": "success",
+            "PINPRICK_RESULT": "success",
+            "CODECOV_RESULT": "success",
+            "MATRIX": '[{"check":"coverage"}]',
+            "RUN_ZIZMOR": "true",
+            "RUN_PINPRICK": "true",
+            "RUN_CODECOV": "true",
+            "CODECOV_ELIGIBLE": "true",
+            "EVENT_NAME": "pull_request",
+        }
+
+    def conclude(self, **overrides):
+        return subprocess.run(
+            ["/bin/bash", "-euo", "pipefail", "-c", self.script],
+            env={**os.environ, **self.environment, **overrides},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_selected_pinprick_audit_must_succeed(self):
+        self.assertEqual(self.conclude().returncode, 0)
+        for result in ("failure", "cancelled", "skipped", ""):
+            with self.subTest(result=result):
+                self.assertNotEqual(self.conclude(PINPRICK_RESULT=result).returncode, 0)
+
+    def test_only_unselected_pinprick_audit_may_skip(self):
+        self.assertEqual(self.conclude(RUN_PINPRICK="false", PINPRICK_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_PINPRICK="false", PINPRICK_RESULT="failure").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_PINPRICK="", PINPRICK_RESULT="skipped").returncode, 0)
+
+    def test_every_routing_decision_fails_closed(self):
+        self.assertNotEqual(self.conclude(EVENT_NAME="unknown", COMMITS_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(MATRIX="", CHECK_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_ZIZMOR="", ZIZMOR_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(RUN_CODECOV="", CODECOV_RESULT="skipped").returncode, 0)
+        self.assertNotEqual(self.conclude(CODECOV_ELIGIBLE="", CODECOV_RESULT="skipped").returncode, 0)
+
+    def test_pr_gate_uses_the_fleet_audit_and_keeps_source_dogfooding(self):
+        audit = AUDIT_WORKFLOW.read_text(encoding="utf-8")
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        # The build-from-source audit is not callable, so the merge-critical
+        # gate gets the fleet audit. It keeps its own pull request trigger so
+        # a change to the engine is still audited by the engine under review.
+        self.assertNotIn("  workflow_call:\n", audit)
+        self.assertIn("  pull_request:\n", audit)
+        self.assertIn("  push:\n", audit)
+        self.assertIn(
+            "uses: starhaven-io/.github/.github/workflows/reusable-pinprick-audit.yml@",
+            ci,
+        )
+        self.assertIn("      fail-on-findings: true", ci)
+        self.assertNotIn("uses: $/.github/workflows/", ci)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The aggregate did not depend on an audit job. CI now calls the fleet audit and the aggregate depends on it, with routing that fails closed on an unresolved decision.

The build-from-source audit **keeps** its pull request trigger, so a change to the engine is still audited by the engine under review. An earlier revision of this change made it push-only, because 0.24.1 could not scan a local reusable-workflow call and the local form therefore could not pass. #579 fixed that in 0.24.2, so the constraint expired and the dogfooding is retained. `test_pr_gate_uses_the_fleet_audit_and_keeps_source_dogfooding` pins that.

The merge-critical gate uses the fleet audit rather than the build-from-source one because the latter is not `workflow_call`-able. Both run on pull requests.

Part of the fleet conclusion contract: starhaven-io/.github#188 declared it, starhaven-io/.github#189 made it deliverable. The added audit call is pinned at the delivered fleet release v2026.09.09.4; a new call is admitted at the canonical pin, which is what Brewy #355 initially failed on.

AI disclosure: Claude Opus 5 with the full `just check` gate run locally on this commit.