### PR TITLE
feat(audit): report exact reviewed workflow risk acceptances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinprick"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1129,6 +1129,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pinprick"
-version = "0.24.2"
+version = "0.25.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "GitHub Actions supply chain security tool"
@@ -45,6 +45,7 @@ thiserror = "2"
 colored = "3"
 toml = "1"
 semver = "1"
+sha2 = "0.10"
 minisign-verify = "0.2.5"
 rustix = { version = "1", features = ["fs"] }
 

--- a/site/src/content/docs/configuration/config-file.md
+++ b/site/src/content/docs/configuration/config-file.md
@@ -82,6 +82,25 @@ trusted-hosts = [
 
 To suppress a specific pattern that `trusted-hosts` doesn't cover, use [`ignore.patterns`](#ignorepatterns) instead.
 
+### `accept-workflow-findings`
+
+Accept a reviewed finding in a local workflow without skipping source coverage or hiding other findings. Each entry matches the exact repository-relative workflow path, SHA-256 of the complete workflow bytes, category, severity, description, and logical command from `pinprick audit --json`. A nonempty reason is required. Wildcards and substring matching are not supported.
+
+```toml
+[[accept-workflow-findings]]
+workflow = ".github/workflows/scan.yml"
+workflow-sha256 = "<SHA-256 of the reviewed workflow>"
+category = "shell_fetch"
+severity = "low"
+description = "<exact finding description>"
+command = '<exact pattern_matched from the audit JSON>'
+reason = "<owner, justification, compensating controls, and review conditions>"
+```
+
+Only repository-local configuration can accept workflow findings. Entries do not apply to remote or local action findings, do not skip any source reads, and do not make incomplete coverage successful. Any workflow byte change invalidates its acceptances; review the changed workflow before updating its hash. An invalid or stale entry accepts nothing. Use `shasum -a 256 .github/workflows/scan.yml` to compute the hash after review.
+
+Accepted findings remain visible in ordinary human output and the JSON `accepted` array. SARIF retains the original result with an external, accepted suppression and its justification. The audit exits zero only when coverage is complete and no unaccepted findings remain. `--no-repo-config` restores the findings. Acceptance changes audit policy only: it does not improve posture scores or create reusable clean action catalog verdicts.
+
 ### `ignore.actions`
 
 Skip scanning specific actions entirely. Useful for actions you've reviewed manually or that produce known false positives. Matching is case-insensitive and respects path boundaries: `"actions/checkout"` matches that repository at any SHA, while `"actions"` or `"actions/"` matches the owner. Partial repository names do not match.

--- a/site/src/content/docs/reference/detections.md
+++ b/site/src/content/docs/reference/detections.md
@@ -137,6 +137,8 @@ Not flagged:
 
 Triggers when `curl` or `wget` writes a `$`-sourced URL to a target that does not look like a data file. pinprick cannot inspect the URL path, so this is intentionally lower severity than a known unversioned URL.
 
+An unresolved output target is treated as potentially executable. For example, `--output "$2"` and `--output "${RUNNER_TEMP}/body.json"` trigger even when the intended response is JSON; the scanner cannot establish the destination. A literal `--output body.json` can use the data-format exemption. A literal executable target with a variable URL also triggers. Curl's `--disable` option does not resolve an expanded destination.
+
 ```bash
 curl -fsSL "$RELEASE_URL" -o tool
 wget "$TOOL_URL" -O bin/tool
@@ -770,7 +772,9 @@ The exemption applies only to the _unversioned-URL_ rules — the same scope as 
 
 When a finding is intentional and you want `pinprick audit` to stop flagging it, reach for the tightest mechanism that covers the case. Each mechanism lives in [`.pinprick.toml`](/configuration/config-file), is visible in code review, and applies across the whole repo.
 
-There are two distinct outcomes to be aware of:
+There are three distinct outcomes to be aware of:
+
+- **Accepted finding** — a repository-local [`accept-workflow-findings`](/configuration/config-file#accept-workflow-findings) entry binds an exact finding to the complete reviewed workflow's SHA-256 and a reason. It remains visible in every output format, including ordinary human output. Source coverage is unchanged, and workflow changes invalidate the acceptance.
 
 - **Allowed match** — the rule still matched, but the finding is recorded as allowed instead of emitted. Visible under `--verbose` with a reason, so a reviewer auditing the audit can still see what fired. Used by [`trusted-hosts`](#trusted-hosts), [`extra-data-formats`](#extra-data-formats), the [versioned-URL heuristic](#versioned-url-heuristic), the [data-format exemption](#data-format-exemption), the [piped-to-`jq` exemption](#piped-to-jq-exemption), and the [audited-actions list](/commands/audit#audited-actions-list).
 - **Removed finding** — the finding is dropped from the report entirely and is not visible under `--verbose`. Used by [`ignore.patterns`](#ignorepatterns), [`ignore.actions`](#ignoreactions), and [`severity`](#severity-threshold).

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde_norway::Value;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
@@ -33,7 +34,9 @@ use crate::audited_actions::{AuditSource, AuditedActions};
 use crate::auth;
 use crate::config::Config;
 use crate::github::GitHubClient;
-use crate::output::{AuditFinding, AuditMatch, AuditReport, sanitize_for_terminal};
+use crate::output::{
+    AcceptedFinding, AuditFinding, AuditMatch, AuditReport, sanitize_for_terminal,
+};
 use crate::workflow;
 use colored::Colorize;
 use regex::Regex;
@@ -187,6 +190,7 @@ pub async fn run(
     let mut ignored = 0usize;
     let mut external_skipped: HashSet<String> = HashSet::new();
     let mut coverage_failures = Vec::new();
+    let mut workflow_digests = HashMap::new();
 
     for file in &files {
         let display_name = workflow::display_path(file.path(), repo_root);
@@ -211,6 +215,10 @@ pub async fn run(
             }
         };
 
+        workflow_digests.insert(
+            display_name.clone(),
+            format!("{:x}", Sha256::digest(content.as_bytes())),
+        );
         match extract_job_run_blocks(file.path(), &content) {
             Ok(jobs) => {
                 for run_blocks in jobs {
@@ -510,6 +518,7 @@ pub async fn run(
         eprintln!();
     }
 
+    let accepted = accept_workflow_findings(&mut collector.findings, &workflow_digests, config);
     let before_filters = collector.findings.len();
     collector.findings.retain(|f| {
         config.meets_severity(&f.severity) && !config.is_pattern_ignored(&f.description)
@@ -521,6 +530,9 @@ pub async fn run(
     if config.is_repo_local() {
         let trusted_host_allowed = collector.trusted_host_allowed;
         let mut parts = Vec::new();
+        if !accepted.is_empty() {
+            parts.push(format!("workflow findings accepted: {}", accepted.len()));
+        }
         if suppressed > 0 {
             parts.push(format!("findings suppressed: {suppressed}"));
         }
@@ -559,6 +571,7 @@ pub async fn run(
     let report = AuditReport {
         actions_scanned: completed_actions.len(),
         findings: collector.findings,
+        accepted,
         allowed: collector.allowed,
         had_token,
         rules_version: AUDIT_RULES_VERSION,
@@ -589,6 +602,44 @@ pub async fn run(
     } else {
         Ok(ExitCode::SUCCESS)
     }
+}
+
+fn accept_workflow_findings(
+    findings: &mut Vec<AuditFinding>,
+    workflow_digests: &HashMap<String, String>,
+    config: &Config,
+) -> Vec<AcceptedFinding> {
+    // Only the bytes read through workflow discovery can authorize an acceptance.
+    // Action findings, unreadable files, and global configuration never qualify.
+    if !config.is_repo_local() || config.accept_workflow_findings.is_empty() {
+        return Vec::new();
+    }
+    let mut accepted = Vec::new();
+    let mut remaining = Vec::new();
+    for finding in findings.drain(..) {
+        let acceptance = config.accept_workflow_findings.iter().find(|entry| {
+            finding.action.is_empty()
+                && finding.workflow_file.is_none()
+                && entry.workflow == finding.source_file
+                && workflow_digests.get(&entry.workflow) == Some(&entry.workflow_sha256)
+                && entry.category == finding.category
+                && entry.severity == finding.severity
+                && entry.description == finding.description
+                && entry.command == finding.pattern_matched
+                && !entry.reason.trim().is_empty()
+        });
+        if let Some(entry) = acceptance {
+            accepted.push(AcceptedFinding {
+                finding,
+                reason: entry.reason.clone(),
+                workflow_sha256: entry.workflow_sha256.clone(),
+            });
+        } else {
+            remaining.push(finding);
+        }
+    }
+    *findings = remaining;
+    accepted
 }
 
 /// Surface `uses: docker://…` container refs. A digest-pinned image is the

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,10 @@ pub struct Config {
     #[serde(default)]
     pub trusted_hosts: Vec<String>,
 
+    /// Exact, reviewed local workflow findings accepted by repository policy.
+    #[serde(default)]
+    pub accept_workflow_findings: Vec<WorkflowAcceptance>,
+
     /// Where this configuration was loaded from. Not part of the file format —
     /// used to attribute suppressions to the scanned repo's own config, which
     /// matters when auditing a repository you don't control.
@@ -74,6 +78,18 @@ pub struct IgnoreConfig {
     /// Suppress findings whose description contains these strings
     #[serde(default)]
     pub patterns: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct WorkflowAcceptance {
+    pub workflow: String,
+    pub workflow_sha256: String,
+    pub category: String,
+    pub severity: String,
+    pub description: String,
+    pub command: String,
+    pub reason: String,
 }
 
 impl Config {

--- a/src/output.rs
+++ b/src/output.rs
@@ -423,8 +423,18 @@ impl AuditMatch {
 }
 
 #[derive(Serialize)]
+pub struct AcceptedFinding {
+    #[serde(flatten)]
+    pub finding: AuditFinding,
+    pub reason: String,
+    pub workflow_sha256: String,
+}
+
+#[derive(Serialize)]
 pub struct AuditReport {
     pub findings: Vec<AuditFinding>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub accepted: Vec<AcceptedFinding>,
     pub allowed: Vec<AuditMatch>,
     pub actions_scanned: usize,
     pub had_token: bool,
@@ -472,6 +482,19 @@ pub struct AuditReport {
 
 impl AuditReport {
     pub fn print_human(&self, verbose: bool) {
+        for accepted in &self.accepted {
+            let f = &accepted.finding;
+            println!(
+                "ACCEPTED  {}:{}",
+                sanitize_for_terminal(&f.source_file),
+                f.line.unwrap_or(1)
+            );
+            println!("      {}", sanitize_for_terminal(&f.description));
+            println!("      {}", sanitize_for_terminal(&f.pattern_matched));
+            println!("      reason: {}", sanitize_for_terminal(&accepted.reason));
+            println!("      workflow SHA-256: {}", accepted.workflow_sha256);
+            println!();
+        }
         for f in &self.findings {
             let sev = match f.severity.as_str() {
                 "high" => "HIGH".red().bold(),
@@ -518,7 +541,12 @@ impl AuditReport {
             }
         }
 
-        if self.findings.is_empty() && self.coverage_complete {
+        if self.findings.is_empty() && !self.accepted.is_empty() {
+            println!(
+                "No unaccepted runtime fetch risks found; {} explicitly accepted.",
+                self.accepted.len()
+            );
+        } else if self.findings.is_empty() && self.coverage_complete {
             println!("No runtime fetch risks found.");
         } else if self.findings.is_empty() {
             println!("No runtime fetch risks found in the completed portion of the scan.");
@@ -696,7 +724,13 @@ impl AuditReport {
         let results = self
             .findings
             .iter()
-            .map(|f| {
+            .map(|finding| (finding, None))
+            .chain(
+                self.accepted
+                    .iter()
+                    .map(|entry| (&entry.finding, Some(&entry.reason))),
+            )
+            .map(|(f, reason)| {
                 let (uri, start_line) =
                     if let (Some(wf), Some(wl)) = (f.workflow_file.as_ref(), f.workflow_line) {
                         (wf.clone(), wl)
@@ -710,6 +744,15 @@ impl AuditReport {
                 }
 
                 SarifResult {
+                    suppressions: reason
+                        .map(|reason| {
+                            vec![SarifSuppression {
+                                kind: "external",
+                                status: "accepted",
+                                justification: reason.clone(),
+                            }]
+                        })
+                        .unwrap_or_default(),
                     rule_id: format!("pinprick/{}", f.category),
                     level: sarif_level(&f.severity).to_string(),
                     message: SarifText { text },
@@ -887,11 +930,20 @@ struct SarifConfig {
 
 #[derive(Serialize)]
 struct SarifResult {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    suppressions: Vec<SarifSuppression>,
     #[serde(rename = "ruleId")]
     rule_id: String,
     level: String,
     message: SarifText,
     locations: Vec<SarifLocation>,
+}
+
+#[derive(Serialize)]
+struct SarifSuppression {
+    kind: &'static str,
+    status: &'static str,
+    justification: String,
 }
 
 #[derive(Serialize)]
@@ -946,6 +998,7 @@ mod sarif_tests {
     fn report(findings: Vec<AuditFinding>) -> AuditReport {
         AuditReport {
             findings,
+            accepted: Vec::new(),
             allowed: vec![],
             actions_scanned: 0,
             had_token: false,
@@ -1138,6 +1191,7 @@ mod audit_summary_tests {
 
     fn empty_report() -> AuditReport {
         AuditReport {
+            accepted: Vec::new(),
             findings: vec![],
             allowed: vec![],
             actions_scanned: 0,

--- a/tests/workflow_acceptances.rs
+++ b/tests/workflow_acceptances.rs
@@ -1,0 +1,186 @@
+mod common;
+
+use predicates::prelude::*;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const COMMAND: &str = r#"curl --output "$OUTPUT" "$URL""#;
+const DESCRIPTION: &str =
+    "curl/wget downloads executable from non-literal source — cannot verify URL version";
+
+fn workflow(extra: &str) -> String {
+    format!(
+        "name: scan\non: push\njobs:\n  scan:\n    runs-on: ubuntu-latest\n    steps:\n      - run: {COMMAND}\n{extra}"
+    )
+}
+
+fn acceptance(source: &str) -> String {
+    format!(
+        r#"[[accept-workflow-findings]]
+workflow = ".github/workflows/scan.yml"
+workflow-sha256 = "{:x}"
+category = "shell_fetch"
+severity = "low"
+description = {DESCRIPTION:?}
+command = {COMMAND:?}
+reason = "Maintainer accepts this reviewed archive input; never execute its contents."
+"#,
+        Sha256::digest(source.as_bytes())
+    )
+}
+
+fn audit(path: &std::path::Path, options: &[&str]) -> (i32, Value) {
+    let output = common::pinprick_cmd()
+        .arg("audit")
+        .arg(path)
+        .args(options)
+        .output()
+        .unwrap();
+    (
+        output.status.code().unwrap(),
+        serde_json::from_slice(&output.stdout).unwrap(),
+    )
+}
+
+#[test]
+fn reviewed_workflow_finding_remains_visible_in_every_format() {
+    let source = workflow("");
+    let dir = common::repo_with_config("scan.yml", &source, &acceptance(&source));
+    let (status, report) = audit(dir.path(), &["--json"]);
+    assert_eq!(status, 0);
+    assert_eq!(report["coverage_complete"], true);
+    assert!(report["findings"].as_array().unwrap().is_empty());
+    assert_eq!(report["accepted"].as_array().unwrap().len(), 1);
+    assert_eq!(report["accepted"][0]["pattern_matched"], COMMAND);
+    assert_eq!(report["accepted"][0]["description"], DESCRIPTION);
+    assert!(
+        report["accepted"][0]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("Maintainer")
+    );
+
+    common::pinprick_cmd()
+        .arg("audit")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ACCEPTED  .github/workflows/scan.yml",
+        ))
+        .stdout(predicate::str::contains(
+            "No unaccepted runtime fetch risks found; 1 explicitly accepted.",
+        ))
+        .stderr(predicate::str::contains("workflow findings accepted: 1"));
+    let (status, sarif) = audit(dir.path(), &["--sarif"]);
+    assert_eq!(status, 0);
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["suppressions"][0]["kind"],
+        "external"
+    );
+    assert_eq!(
+        sarif["runs"][0]["results"][0]["suppressions"][0]["status"],
+        "accepted"
+    );
+    assert_eq!(
+        sarif["runs"][0]["properties"]["pinprickCoverageComplete"],
+        true
+    );
+
+    let (status, report) = audit(dir.path(), &["--json", "--no-repo-config"]);
+    assert_eq!(status, 1);
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    assert!(report.get("accepted").is_none());
+}
+
+#[test]
+fn every_identity_field_and_nonempty_reason_are_required() {
+    let source = workflow("");
+    let config = acceptance(&source);
+    for (from, to) in [
+        ("scan.yml", "other.yml"),
+        ("shell_fetch", "python_fetch"),
+        ("severity = \"low\"", "severity = \"medium\""),
+        ("cannot verify URL version", "different description"),
+        ("curl --output", "curl --silent --output"),
+        (
+            "Maintainer accepts this reviewed archive input; never execute its contents.",
+            "  ",
+        ),
+    ] {
+        let dir = common::repo_with_config("scan.yml", &source, &config.replace(from, to));
+        let (status, report) = audit(dir.path(), &["--json"]);
+        assert_eq!(status, 1, "changed {from}");
+        assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    }
+}
+
+#[test]
+fn any_workflow_change_invalidates_acceptance_without_hiding_the_finding() {
+    let source = workflow("");
+    let dir = common::repo_with_config(
+        "scan.yml",
+        &format!("{source}# changed context\n"),
+        &acceptance(&source),
+    );
+    let (status, report) = audit(dir.path(), &["--json"]);
+    assert_eq!(status, 1);
+    assert_eq!(report["coverage_complete"], true);
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn acceptance_never_makes_missing_source_coverage_successful() {
+    let source = workflow("      - uses: ./missing-action\n");
+    let dir = common::repo_with_config("scan.yml", &source, &acceptance(&source));
+    for format in ["--json", "--sarif"] {
+        let (status, report) = audit(dir.path(), &[format]);
+        assert_eq!(status, 2);
+        if format == "--json" {
+            assert_eq!(report["coverage_complete"], false);
+            assert_eq!(report["accepted"].as_array().unwrap().len(), 1);
+            assert!(!report["coverage_failures"].as_array().unwrap().is_empty());
+        } else {
+            assert_eq!(
+                report["runs"][0]["properties"]["pinprickCoverageComplete"],
+                false
+            );
+        }
+    }
+}
+
+#[test]
+fn sibling_workflow_findings_are_not_accepted() {
+    let source = workflow("");
+    let dir = common::repo_with_config("scan.yml", &source, &acceptance(&source));
+    std::fs::write(dir.path().join(".github/workflows/other.yml"), &source).unwrap();
+    let (status, report) = audit(dir.path(), &["--json"]);
+    assert_eq!(status, 1);
+    assert_eq!(report["accepted"].as_array().unwrap().len(), 1);
+    assert_eq!(report["findings"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        report["findings"][0]["source_file"],
+        ".github/workflows/other.yml"
+    );
+}
+
+#[test]
+fn global_configuration_cannot_accept_repository_workflow_findings() {
+    let source = workflow("");
+    let dir = common::repo_with_workflow("scan.yml", &source);
+    let global = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir(global.path().join("pinprick")).unwrap();
+    std::fs::write(
+        global.path().join("pinprick/config.toml"),
+        acceptance(&source),
+    )
+    .unwrap();
+    common::pinprick_cmd()
+        .env("XDG_CONFIG_HOME", global.path())
+        .arg("audit")
+        .arg(dir.path())
+        .arg("--json")
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(DESCRIPTION));
+}


### PR DESCRIPTION
Add explicit acceptance of reviewed local workflow findings, bound to the workflow's SHA-256 and the exact source path, category, severity, description, and command. Accepted findings remain visible in human, JSON, and SARIF output; changing the workflow invalidates the acceptance, and incomplete source coverage still exits 2. Action findings, global policy, and `--no-repo-config` cannot use these acceptances. Prepare engine 0.25.0 for the separate release and bot-authored action bump.

This supports two reviewed macOSdb archive-input risks without changing resumable publication downloads or broadly suppressing the shell-fetch rule. Fleet will own the consumer policy and preserve the trusted merge guard. The detector's existing fail-closed result is retained; this is a narrow policy capability, not a reclassification of those downloads as safe.

All Rust tests, formatting, Clippy, release-tool tests, dependency policy, site checks, and workflow audits passed through `just check` and the normal pre-push gate. Six focused integration tests cover exact identity, changed context, output visibility, sibling findings, global config, and incomplete coverage. Independently reviewed the candidate patch and its cache/config boundaries.

AI disclosure: GPT-6 with independent source review, focused regression tests, and the complete repository gate.
