### PR TITLE
refactor(audit): encode workflow digests without LowerHex

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -3,6 +3,7 @@ use serde_norway::Value;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::path::Path;
 use std::process::ExitCode;
 use std::sync::LazyLock;
@@ -215,10 +216,11 @@ pub async fn run(
             }
         };
 
-        workflow_digests.insert(
-            display_name.clone(),
-            format!("{:x}", Sha256::digest(content.as_bytes())),
-        );
+        let mut workflow_digest = String::with_capacity(64);
+        for byte in Sha256::digest(content.as_bytes()) {
+            write!(workflow_digest, "{byte:02x}")?;
+        }
+        workflow_digests.insert(display_name.clone(), workflow_digest);
         match extract_job_run_blocks(file.path(), &content) {
             Ok(jobs) => {
                 for run_blocks in jobs {

--- a/tests/workflow_acceptances.rs
+++ b/tests/workflow_acceptances.rs
@@ -3,6 +3,7 @@ mod common;
 use predicates::prelude::*;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 
 const COMMAND: &str = r#"curl --output "$OUTPUT" "$URL""#;
 const DESCRIPTION: &str =
@@ -15,17 +16,20 @@ fn workflow(extra: &str) -> String {
 }
 
 fn acceptance(source: &str) -> String {
+    let mut digest = String::with_capacity(64);
+    for byte in Sha256::digest(source.as_bytes()) {
+        write!(digest, "{byte:02x}").unwrap();
+    }
     format!(
         r#"[[accept-workflow-findings]]
 workflow = ".github/workflows/scan.yml"
-workflow-sha256 = "{:x}"
+workflow-sha256 = "{digest}"
 category = "shell_fetch"
 severity = "low"
 description = {DESCRIPTION:?}
 command = {COMMAND:?}
 reason = "Maintainer accepts this reviewed archive input; never execute its contents."
-"#,
-        Sha256::digest(source.as_bytes())
+"#
     )
 }
 
@@ -44,7 +48,7 @@ fn audit(path: &std::path::Path, options: &[&str]) -> (i32, Value) {
 
 #[test]
 fn reviewed_workflow_finding_remains_visible_in_every_format() {
-    let source = workflow("");
+    let source = workflow("# reviewed\n");
     let dir = common::repo_with_config("scan.yml", &source, &acceptance(&source));
     let (status, report) = audit(dir.path(), &["--json"]);
     assert_eq!(status, 0);
@@ -53,6 +57,10 @@ fn reviewed_workflow_finding_remains_visible_in_every_format() {
     assert_eq!(report["accepted"].as_array().unwrap().len(), 1);
     assert_eq!(report["accepted"][0]["pattern_matched"], COMMAND);
     assert_eq!(report["accepted"][0]["description"], DESCRIPTION);
+    assert_eq!(
+        report["accepted"][0]["workflow_sha256"],
+        "0da65ac968ce73f7bd73a7adc681581a93e07c8fd8eb11b856e1e4ef9a0ae58c"
+    );
     assert!(
         report["accepted"][0]["reason"]
             .as_str()


### PR DESCRIPTION
sha2 0.11 (digest 0.11 / hybrid-array) drops the `LowerHex` impl on digest output, which breaks the `{:x}` formatting in `src/audit.rs` and `tests/workflow_acceptances.rs` and blocks #592. This encodes each digest byte as two lowercase hex digits explicitly, producing the same 64-character string as before and compiling against both sha2 0.10 and 0.11. Cargo.toml and Cargo.lock are unchanged; #592 can rebase once this lands.

The acceptance test now pins a known digest for the fixture workflow. The fixture was chosen so its digest contains zero-leading bytes, so a dropped `02` width fails the assertion even when the production encoder and the test helper share the mistake.

AI disclosure: Claude Opus 5 with the digest recomputed by shasum and openssl, the acceptance tests run against both sha2 versions, and just check.
